### PR TITLE
fix default visibiliy of copilot chat debug view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1954,6 +1954,11 @@
 				"category": "Developer"
 			},
 			{
+				"command": "github.copilot.debug.showChatLogView",
+				"title": "%github.copilot.command.showChatLogView%",
+				"category": "Developer"
+			},
+			{
 				"command": "github.copilot.terminal.explainTerminalSelection",
 				"title": "%github.copilot.command.explainTerminalSelection%",
 				"category": "GitHub Copilot"
@@ -3432,7 +3437,7 @@
 					"id": "copilot-chat",
 					"name": "Copilot Chat Debug",
 					"icon": "assets/debug-icon.svg",
-					"visibility": "hidden"
+					"when": "github.copilot.chat.showLogView"
 				}
 			]
 		},

--- a/package.nls.json
+++ b/package.nls.json
@@ -76,6 +76,7 @@
 		]
 	},
 	"github.copilot.command.logWorkbenchState": "Log Workbench State",
+	"github.copilot.command.showChatLogView": "Show Chat Debug View",
 	"github.copilot.command.applySuggestionWithCopilot": "Apply Suggestion with Copilot",
 	"github.copilot.command.explainTerminalSelection": "Explain Terminal Selection",
 	"github.copilot.command.explainTerminalSelectionContextMenu": "Explain",


### PR DESCRIPTION
Default show the chat debug view for:
- Internal users
- When debugging the extension

Adds developer command to turn on the log view for the session