### PR TITLE
defer output fetching for task/terminal to tools, add `GetTaskOutputTool`, add terminal last command context to prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -420,7 +420,7 @@
 				"name": "copilot_getTerminalOutput",
 				"toolReferenceName": "getTerminalOutput",
 				"displayName": "%copilot.tools.getTerminalOutput.name%",
-				"modelDescription": "Get the output of a terminal command previous started with copilot_runInTerminal",
+				"modelDescription": "Get the output of a terminal command previously started with runInTerminal",
 				"tags": [],
 				"inputSchema": {
 					"type": "object",
@@ -432,6 +432,30 @@
 					},
 					"required": [
 						"id"
+					]
+				}
+			},
+			{
+				"name": "copilot_getTaskOutput",
+				"toolReferenceName": "getTaskOutput",
+				"displayName": "%copilot.tools.getTaskOutput.name%",
+				"modelDescription": "Get the output of a task to evaluate it for errors, idle status, and more",
+				"tags": [],
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"description": "The name of the task to check."
+						},
+						"maxLinesToRetrieve": {
+							"type": "number",
+							"description": "The maximum number of lines to retrieve from the terminal output."
+						}
+					},
+					"required": [
+						"maxLinesToRetrieve",
+						"name"
 					]
 				}
 			},
@@ -1220,7 +1244,8 @@
 				"icon": "$(terminal)",
 				"tools": [
 					"runInTerminal",
-					"getTerminalOutput"
+					"getTerminalOutput",
+					"getTaskOutput"
 				]
 			},
 			{

--- a/package.nls.json
+++ b/package.nls.json
@@ -258,6 +258,7 @@
 	"copilot.tools.listDirectory.name": "List Dir",
 	"copilot.tools.runInTerminal.name": "Run In Terminal",
 	"copilot.tools.getTerminalOutput.name": "Get Terminal Output",
+	"copilot.tools.getTaskOutput.name": "Get Task Output",
 	"copilot.tools.getErrors.name": "Get Problems",
 	"copilot.tools.readProjectStructure.name": "Project Structure",
 	"copilot.tools.getChangedFiles.name": "Git Changes",

--- a/src/extension/prompts/node/base/terminalAndTaskState.tsx
+++ b/src/extension/prompts/node/base/terminalAndTaskState.tsx
@@ -6,6 +6,7 @@
 import { BasePromptElementProps, PromptElement } from '@vscode/prompt-tsx';
 import { ITasksService } from '../../../../platform/tasks/common/tasksService';
 import { ITerminalService } from '../../../../platform/terminal/common/terminalService';
+import { ToolName } from '../../../tools/common/toolNames';
 
 export interface TerminalAndTaskStateProps extends BasePromptElementProps {
 	sessionId?: string;
@@ -23,24 +24,11 @@ export class TerminalAndTaskStatePromptElement extends PromptElement<TerminalAnd
 		super(props);
 	}
 	async render() {
-		if (Boolean('true')) {
-			// https://github.com/microsoft/vscode/issues/252690
-			return;
-		}
-
-		const runningTasks: { name: string; isBackground: boolean; type?: string; command?: string; problemMatcher?: string; group?: string; script?: string; dependsOn?: string; buffer: string }[] = [];
-		let terminals: { name: string; buffer: string }[] = [];
-
+		const runningTasks: { name: string; isBackground: boolean; type?: string; command?: string; problemMatcher?: string; group?: string; script?: string; dependsOn?: string }[] = [];
 		const running = this.tasksService.getTasks();
-		const tasks = Array.isArray(running?.[0]?.[1]) ? running[0][1] : [];
+		const tasks = Array.isArray(running?.[0]?.[1]) ? running[0][1].filter(t => this.tasksService.isTaskActive(t)) : [];
 		for (const exec of tasks) {
-			if (!this.tasksService.isTaskActive(exec)) {
-				continue;
-			}
-			// TODO:@meganrogge when there's API to determine if a terminal is a task, improve this vscode#234440
-			const terminal = this.terminalService.terminals.find(t => t.name === exec.label);
-			if (exec.label && terminal) {
-				const buffer = this.terminalService.getBufferForTerminal(terminal);
+			if (exec.label) {
 				runningTasks.push({
 					name: exec.label,
 					isBackground: exec.isBackground,
@@ -50,32 +38,29 @@ export class TerminalAndTaskStatePromptElement extends PromptElement<TerminalAnd
 					problemMatcher: Array.isArray(exec.problemMatcher) && exec.problemMatcher.length > 0 ? exec.problemMatcher.join(', ') : '',
 					group: exec.group,
 					dependsOn: exec.dependsOn,
-					buffer
 				});
 			}
 		}
 
 		if (this.terminalService && Array.isArray(this.terminalService.terminals)) {
 			const copilotTerminals = await this.terminalService.getCopilotTerminals(this.props.sessionId, true);
-			terminals = copilotTerminals.map((term) => {
-				const buffer = this.terminalService.getBufferForTerminal(term);
+			const terminals = copilotTerminals.map((term) => {
+				const lastCommand = this.terminalService.getLastCommandForTerminal(term);
 				return {
 					name: term.name,
-					buffer
+					lastCommand,
+					id: term.id,
 				};
 			});
-		}
-		if (terminals.length === 0 && tasks.length === 0) {
-			return;
-		}
 
-		return (
-			<>
-				Active Tasks:<br />
-				{runningTasks.length === 0 ? (
-					<>(none)<br /></>
-				) : (
+			if (terminals.length === 0 && tasks.length === 0) {
+				return;
+			}
+
+			const renderTasks = () =>
+				runningTasks.length > 0 && (
 					<>
+						Active Tasks:<br />
 						{runningTasks.map((t) => (
 							<>
 								Task: {t.name} ( background: {String(t.isBackground)}
@@ -85,26 +70,39 @@ export class TerminalAndTaskStatePromptElement extends PromptElement<TerminalAnd
 								{t.problemMatcher ? `Problem Matchers: ${t.problemMatcher}` : ''}<br />
 								{t.group ? `Group: ${t.group}` : ''}<br />
 								{t.dependsOn ? `Depends On: ${t.dependsOn}` : ''}<br />
-								Output: {t.buffer ?? '(no output)'}<br />
+								Output: {'{'}Query {ToolName.GetTaskOutput} for task terminal with name: {t.name} with the number of lines from the bottom to retrieve. {'}'}<br />
 								<br />
 							</>
 						))}
 					</>
-				)}
-				<br />
-				Active Terminals:<br />
-				{terminals.length === 0 ? (
-					<>(No active Copilot terminals)<br /></>
-				) : (
+				);
+
+			const renderTerminals = () =>
+				terminals.length > 0 && (
 					<>
-						{terminals.map((term, i) => (
+						Active Terminals:<br />
+						{terminals.map((term) => (
 							<>
-								Terminal: {term.name} with output: {term.buffer ?? '(no output)'}<br />
+								Terminal: {term.name}<br />
+								{term.lastCommand ? (
+									<>
+										Last Command: {term.lastCommand.commandLine ?? '(no last command)'}<br />
+										Cwd: {term.lastCommand.cwd ?? '(unknown)'}<br />
+										Exit Code: {term.lastCommand.exitCode ?? '(unknown)'}<br />
+									</>
+								) : null}
+								Output: {'{'}Query {ToolName.GetTerminalOutput} for terminal with ID: {term.id}. {'}'}<br />
 							</>
 						))}
 					</>
-				)}
-			</>
-		);
+				);
+
+			return (
+				<>
+					{renderTasks()}
+					{renderTerminals()}
+				</>
+			);
+		}
 	}
 }

--- a/src/extension/tools/common/toolNames.ts
+++ b/src/extension/tools/common/toolNames.ts
@@ -47,6 +47,7 @@ export const enum ToolName {
 	SimpleBrowser = 'open_simple_browser',
 	CreateDirectory = 'create_directory',
 	RunVscodeCmd = 'run_vscode_command',
+	GetTaskOutput = 'get_task_output'
 }
 
 // When updating this, also update contributedToolNameToToolNames
@@ -92,6 +93,7 @@ export const enum ContributedToolName {
 	SimpleBrowser = 'copilot_openSimpleBrowser',
 	CreateDirectory = 'copilot_createDirectory',
 	RunVscodeCmd = 'copilot_runVscodeCommand',
+	GetTaskOutput = 'copilot_getTaskOutput'
 }
 
 const contributedToolNameToToolNames = new Map<ContributedToolName, ToolName>([
@@ -136,6 +138,7 @@ const contributedToolNameToToolNames = new Map<ContributedToolName, ToolName>([
 	[ContributedToolName.SimpleBrowser, ToolName.SimpleBrowser],
 	[ContributedToolName.CreateDirectory, ToolName.CreateDirectory],
 	[ContributedToolName.RunVscodeCmd, ToolName.RunVscodeCmd],
+	[ContributedToolName.GetTaskOutput, ToolName.GetTaskOutput]
 ]);
 
 const toolNameToContributedToolNames = new Map<ToolName, ContributedToolName>();

--- a/src/extension/tools/node/allTools.ts
+++ b/src/extension/tools/node/allTools.ts
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './applyPatchTool';
 import './codebaseTool';
+import './createDirectoryTool';
 import './createFileTool';
 import './docTool';
 import './editNotebookTool';
@@ -11,7 +13,9 @@ import './findFilesTool';
 import './findTestsFilesTool';
 import './findTextInFilesTool';
 import './getErrorsTool';
+import './getNotebookCellOutputTool';
 import './getSearchViewResultsTool';
+import './getTaskOutputTool';
 import './githubRepoTool';
 import './insertEditTool';
 import './installExtensionTool';
@@ -24,20 +28,17 @@ import './notebookSummaryTool';
 import './readFileTool';
 import './readProjectStructureTool';
 import './replaceStringTool';
-import './applyPatchTool';
 import './runInTerminalTool';
 import './runNotebookCellTool';
-import './getNotebookCellOutputTool';
 import './runTaskTool';
 import './runTestsTool';
 import './scmChangesTool';
 import './searchWorkspaceSymbolsTool';
+import './simpleBrowserTool';
 import './terminalStateTools';
 import './testFailureTool';
 import './thinkTool';
 import './usagesTool';
 import './userPreferencesTool';
 import './vscodeAPITool';
-import './simpleBrowserTool';
-import './createDirectoryTool';
 import './vscodeCmdTool';

--- a/src/extension/tools/node/getTaskOutputTool.tsx
+++ b/src/extension/tools/node/getTaskOutputTool.tsx
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as l10n from '@vscode/l10n';
+import type * as vscode from 'vscode';
+import { ITerminalService } from '../../../platform/terminal/common/terminalService';
+import { LanguageModelTextPart, LanguageModelToolResult } from '../../../vscodeTypes';
+import { ToolName } from '../common/toolNames';
+import { ToolRegistry } from '../common/toolsRegistry';
+
+export interface ITaskOptions {
+	name: string;
+	maxLinesToRetrieve: number;
+}
+
+/**
+ * Tool to provide output for a given task terminal.
+ */
+export class GetTaskOutputTool implements vscode.LanguageModelTool<ITaskOptions> {
+	public static readonly toolName = ToolName.GetTaskOutput;
+
+	constructor(@ITerminalService private readonly terminalService: ITerminalService) {
+
+	}
+	async invoke(options: vscode.LanguageModelToolInvocationOptions<ITaskOptions>, token: vscode.CancellationToken) {
+		// TODO:@meganrogge when there's API to determine if a terminal is a task, improve this vscode#234440
+		const terminal = this.terminalService.terminals.find(t => t.name === options.input.name);
+		if (!terminal) {
+			return;
+		}
+		// 40 chars per line and 60k chars is about 1500 lines
+		const buffer = this.terminalService.getBufferForTerminal(terminal, Math.min(options.input.maxLinesToRetrieve, 1500));
+		return new LanguageModelToolResult([
+			new LanguageModelTextPart(`Output for task terminal ${terminal.name}: ${buffer}`)
+		]);
+	}
+
+	prepareInvocation(options: vscode.LanguageModelToolInvocationPrepareOptions<ITaskOptions>, token: vscode.CancellationToken): vscode.ProviderResult<vscode.PreparedToolInvocation> {
+		return {
+			invocationMessage: l10n.t("Checking output for task terminal {0}", options.input.name),
+			pastTenseMessage: l10n.t("Checked output for task terminal {0}", options.input.name)
+		};
+	}
+}
+
+ToolRegistry.registerTool(GetTaskOutputTool);

--- a/src/extension/tools/node/runInTerminalTool.tsx
+++ b/src/extension/tools/node/runInTerminalTool.tsx
@@ -86,10 +86,11 @@ export class RunInTerminalTool extends Disposable implements ICopilotTool<IRunIn
 		let error: string | undefined;
 
 		const timingStart = Date.now();
+		const termId = generateUuid();
 
 		if (options.input.isBackground) {
-			this.logService.logger.debug(`RunInTerminalTool: Creating background terminal`);
-			const toolTerminal = await this.instantiationService.createInstance(ToolTerminalCreator).createTerminal(sessionId, token, true);
+			this.logService.logger.debug(`RunInTerminalTool: Creating background terminal with ID=${termId}`);
+			const toolTerminal = await this.instantiationService.createInstance(ToolTerminalCreator).createTerminal(sessionId, termId, token, true);
 			if (token.isCancellationRequested) {
 				toolTerminal.terminal.dispose();
 				throw new CancellationError();
@@ -98,11 +99,9 @@ export class RunInTerminalTool extends Disposable implements ICopilotTool<IRunIn
 			toolTerminal.terminal.show(true);
 			const timingConnectMs = Date.now() - timingStart;
 
-			let termId: string | undefined;
 			try {
 				this.logService.logger.debug(`RunInTerminalTool: Starting background execution \`${command}\``);
 				const execution = new BackgroundTerminalExecution(toolTerminal.terminal, command);
-				const termId = generateUuid();
 				RunInTerminalTool.executions.set(termId, execution);
 				const resultText = (
 					didUserEditCommand
@@ -140,7 +139,7 @@ export class RunInTerminalTool extends Disposable implements ICopilotTool<IRunIn
 				this.logService.logger.debug(`RunInTerminalTool: Using existing terminal with session ID \`${sessionId}\``);
 			} else {
 				this.logService.logger.debug(`RunInTerminalTool: Creating terminal with session ID \`${sessionId}\``);
-				toolTerminal = await this.instantiationService.createInstance(ToolTerminalCreator).createTerminal(sessionId, token);
+				toolTerminal = await this.instantiationService.createInstance(ToolTerminalCreator).createTerminal(sessionId, termId, token);
 				if (token.isCancellationRequested) {
 					toolTerminal.terminal.dispose();
 					throw new CancellationError();

--- a/src/extension/tools/node/toolUtils.terminal.ts
+++ b/src/extension/tools/node/toolUtils.terminal.ts
@@ -42,7 +42,7 @@ export class ToolTerminalCreator {
 	) {
 	}
 
-	async createTerminal(sessionId: string, token: vscode.CancellationToken, isBackground?: boolean): Promise<IToolTerminal> {
+	async createTerminal(sessionId: string, id: string, token: vscode.CancellationToken, isBackground?: boolean): Promise<IToolTerminal> {
 		const terminal = this._createCopilotTerminal();
 		const toolTerminal: IToolTerminal = {
 			terminal,
@@ -60,11 +60,11 @@ export class ToolTerminalCreator {
 			if (shellIntegrationQuality !== ShellIntegrationQuality.None) {
 				ToolTerminalCreator._lastSuccessfulShell = ShellLaunchType.Default;
 				toolTerminal.shellIntegrationQuality = shellIntegrationQuality;
-				this.terminalService.associateTerminalWithSession(terminal, sessionId, shellIntegrationQuality, isBackground);
+				this.terminalService.associateTerminalWithSession(terminal, sessionId, id, shellIntegrationQuality, isBackground);
 				return toolTerminal;
 			}
 		}
-		this.terminalService.associateTerminalWithSession(terminal, sessionId, ShellIntegrationQuality.None, isBackground);
+		this.terminalService.associateTerminalWithSession(terminal, sessionId, id, ShellIntegrationQuality.None, isBackground);
 		// Fallback case: No shell integration in default profile
 		ToolTerminalCreator._lastSuccessfulShell = ShellLaunchType.Fallback;
 		return toolTerminal;

--- a/src/platform/terminal/common/terminalService.ts
+++ b/src/platform/terminal/common/terminalService.ts
@@ -54,11 +54,12 @@ export interface ITerminalService {
 	 *
 	 * @param terminal The terminal to associate with the session
 	 * @param sessionId The session ID to associate the terminal with
+	 * @param id The ID of the terminal
 	 * @param shellIntegrationQuality The shell integration quality of the terminal
 	 * @param isBackground Whether the terminal is a background terminal
 	 * @returns Promise resolving when the terminal is associated with the session
 	 */
-	associateTerminalWithSession(terminal: vscode.Terminal, sessionId: string, shellIntegrationQuality: ShellIntegrationQuality, isBackground?: boolean): Promise<void>;
+	associateTerminalWithSession(terminal: vscode.Terminal, sessionId: string, id: string, shellIntegrationQuality: ShellIntegrationQuality, isBackground?: boolean): Promise<void>;
 
 	/**
 	 * Gets non-background terminals associated with a specific session ID
@@ -67,13 +68,19 @@ export interface ITerminalService {
 	 * @param includeBackground Whether to include background terminals in the result
 	 * @returns Promise resolving to an array of terminals associated with the session
 	 */
-	getCopilotTerminals(sessionId?: string, includeBackground?: boolean): Promise<vscode.Terminal[]>;
+	getCopilotTerminals(sessionId?: string, includeBackground?: boolean): Promise<IKnownTerminal[]>;
 
 	/**
 	 * Gets the buffer for a terminal.
 	 * @param maxLines The maximum number of lines to return from the buffer, defaults to 1000
 	 */
 	getBufferForTerminal(terminal: vscode.Terminal, maxLines?: number): string;
+
+	/**
+	 * Gets the last command executed in a terminal.
+	 * @param terminal The terminal to get the last command for
+	 */
+	getLastCommandForTerminal(terminal: vscode.Terminal): vscode.TerminalExecutedCommand | undefined;
 
 	readonly terminals: readonly vscode.Terminal[];
 }
@@ -119,15 +126,15 @@ export class NullTerminalService extends Disposable implements ITerminalService 
 		return Promise.resolve(undefined);
 	}
 
-	async getCopilotTerminals(sessionId: string): Promise<vscode.Terminal[]> {
+	async getCopilotTerminals(sessionId: string): Promise<IKnownTerminal[]> {
 		return Promise.resolve([]);
 	}
 
-	getTerminalsWithSessionInfo(): Promise<{ terminal: vscode.Terminal; sessionId: string; shellIntegrationQuality: ShellIntegrationQuality }[]> {
+	getTerminalsWithSessionInfo(): Promise<{ terminal: IKnownTerminal; sessionId: string; shellIntegrationQuality: ShellIntegrationQuality }[]> {
 		throw new Error('Method not implemented.');
 	}
 
-	getToolTerminalForSession(sessionId: string): Promise<{ terminal: vscode.Terminal; shellIntegrationQuality: ShellIntegrationQuality } | undefined> {
+	getToolTerminalForSession(sessionId: string): Promise<{ terminal: IKnownTerminal; shellIntegrationQuality: ShellIntegrationQuality } | undefined> {
 		throw new Error('Method not implemented.');
 	}
 
@@ -149,10 +156,18 @@ export class NullTerminalService extends Disposable implements ITerminalService 
 	getBufferForTerminal(terminal: vscode.Terminal, maxLines?: number): string {
 		return '';
 	}
+
+	getLastCommandForTerminal(terminal: vscode.Terminal): vscode.TerminalExecutedCommand | undefined {
+		return undefined;
+	}
 }
 export function isTerminalService(thing: any): thing is ITerminalService {
 	return thing && typeof thing.createTerminal === 'function';
 }
 export function isNullTerminalService(thing: any): thing is NullTerminalService {
 	return thing && typeof thing.createTerminal === 'function' && thing.createTerminal() === undefined;
+}
+
+export interface IKnownTerminal extends vscode.Terminal {
+	id: string;
 }

--- a/src/platform/terminal/vscode/terminalBufferListener.ts
+++ b/src/platform/terminal/vscode/terminalBufferListener.ts
@@ -32,6 +32,9 @@ export function getBufferForTerminal(terminal?: Terminal, maxLines: number = 100
 	return buffer.slice(start).join('\n');
 }
 
+export function getLastCommandForTerminal(terminal: Terminal): TerminalExecutedCommand | undefined {
+	return terminalCommands.get(terminal)?.at(-1);
+}
 
 export function getActiveTerminalLastCommand(): TerminalExecutedCommand | undefined {
 	const activeTerminal = window.activeTerminal;
@@ -97,8 +100,8 @@ export function getActiveTerminalShellType(): string {
 
 function appendLimitedWindow<T>(target: T[], data: T) {
 	target.push(data);
-	if (target.length > 20000) {
-		// 20000 data events should capture a minimum of about twice the typical visible area
+	if (target.length > 40) {
+		// 40 data events should capture a minimum of about twice the typical visible area
 		target.shift();
 	}
 }

--- a/src/platform/terminal/vscode/terminalServiceImpl.ts
+++ b/src/platform/terminal/vscode/terminalServiceImpl.ts
@@ -8,8 +8,8 @@ import { timeout } from '../../../util/vs/base/common/async';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { IChatSessionService } from '../../chat/common/chatSessionService';
 import { IVSCodeExtensionContext } from '../../extContext/common/extensionContext';
-import { ITerminalService, ShellIntegrationQuality } from '../common/terminalService';
-import { getActiveTerminalBuffer, getActiveTerminalLastCommand, getActiveTerminalSelection, getActiveTerminalShellType, getBufferForTerminal, installTerminalBufferListeners } from './terminalBufferListener';
+import { IKnownTerminal, ITerminalService, ShellIntegrationQuality } from '../common/terminalService';
+import { getActiveTerminalBuffer, getActiveTerminalLastCommand, getActiveTerminalSelection, getActiveTerminalShellType, getBufferForTerminal, getLastCommandForTerminal, installTerminalBufferListeners } from './terminalBufferListener';
 
 export const TerminalSessionStorageKey = 'runInTerminalTool.sessionTerminals';
 export class TerminalServiceImpl extends Disposable implements ITerminalService {
@@ -84,16 +84,17 @@ export class TerminalServiceImpl extends Disposable implements ITerminalService 
 		return terminal;
 	}
 
-	async associateTerminalWithSession(terminal: Terminal, sessionId: string, shellIntegrationQuality: ShellIntegrationQuality, isBackground?: boolean): Promise<void> {
+	async associateTerminalWithSession(terminal: Terminal, sessionId: string, id: string, shellIntegrationQuality: ShellIntegrationQuality, isBackground?: boolean): Promise<void> {
 		try {
 			const pid = await Promise.race([terminal.processId, timeout(5000)]);
 			if (typeof pid === 'number') {
-				const associations: Record<number, { shellIntegrationQuality: ShellIntegrationQuality; sessionId: string; isBackground?: boolean }> = this.extensionContext.workspaceState.get(TerminalSessionStorageKey, {});
+				const associations: Record<number, { shellIntegrationQuality: ShellIntegrationQuality; sessionId: string; id: string; isBackground?: boolean }> = this.extensionContext.workspaceState.get(TerminalSessionStorageKey, {});
 				const existingAssociation = associations[pid] || {};
 				associations[pid] = {
 					...existingAssociation,
 					sessionId,
 					shellIntegrationQuality,
+					id,
 					isBackground
 				};
 
@@ -102,9 +103,9 @@ export class TerminalServiceImpl extends Disposable implements ITerminalService 
 		} catch { }
 	}
 
-	async getCopilotTerminals(sessionId: string, includeBackground?: boolean): Promise<Terminal[]> {
+	async getCopilotTerminals(sessionId: string, includeBackground?: boolean): Promise<IKnownTerminal[]> {
 
-		const terminals: Terminal[] = [];
+		const terminals: IKnownTerminal[] = [];
 		const storedTerminalAssociations: Record<number, any> = this.extensionContext.workspaceState.get(TerminalSessionStorageKey, {});
 
 		for (const terminal of this.terminals) {
@@ -113,7 +114,7 @@ export class TerminalServiceImpl extends Disposable implements ITerminalService 
 				if (typeof pid === 'number') {
 					const association = storedTerminalAssociations[pid];
 					if (association && typeof association === 'object' && (includeBackground || !association.isBackground) && association.sessionId === sessionId) {
-						terminals.push(terminal);
+						terminals.push({ ...terminal, id: association.id });
 					}
 				}
 			} catch { }
@@ -149,6 +150,10 @@ export class TerminalServiceImpl extends Disposable implements ITerminalService 
 
 	getBufferForTerminal(terminal: Terminal, maxLines?: number): string {
 		return getBufferForTerminal(terminal, maxLines);
+	}
+
+	getLastCommandForTerminal(terminal: Terminal): TerminalExecutedCommand | undefined {
+		return getLastCommandForTerminal(terminal);
 	}
 
 	get terminalBuffer(): string {

--- a/src/platform/test/node/simulationWorkspaceServices.ts
+++ b/src/platform/test/node/simulationWorkspaceServices.ts
@@ -38,7 +38,7 @@ import { INotebookSummaryTracker } from '../../notebook/common/notebookSummaryTr
 import { IReviewService, ReviewComment, ReviewDiagnosticCollection } from '../../review/common/reviewService';
 import { AbstractSearchService } from '../../search/common/searchService';
 import { ITabsAndEditorsService, TabInfo } from '../../tabs/common/tabsAndEditorsService';
-import { ITerminalService, ShellIntegrationQuality } from '../../terminal/common/terminalService';
+import { IKnownTerminal, ITerminalService, ShellIntegrationQuality } from '../../terminal/common/terminalService';
 import { AbstractWorkspaceService, IWorkspaceService } from '../../workspace/common/workspaceService';
 import { isNotebook, SimulationWorkspace } from './simulationWorkspace';
 
@@ -764,7 +764,7 @@ export class TestingTerminalService extends Disposable implements ITerminalServi
 	onDidCloseTerminal: vscode.Event<vscode.Terminal> = Event.None;
 	onDidWriteTerminalData: vscode.Event<vscode.TerminalDataWriteEvent> = Event.None;
 
-	private readonly sessionTerminals = new Map<string, { terminal: vscode.Terminal; shellIntegrationQuality: ShellIntegrationQuality }[]>();
+	private readonly sessionTerminals = new Map<string, { terminal: vscode.Terminal; shellIntegrationQuality: ShellIntegrationQuality; id: string }[]>();
 
 	createTerminal(name?: string, shellPath?: string, shellArgs?: readonly string[] | string): vscode.Terminal;
 	createTerminal(options: vscode.TerminalOptions): vscode.Terminal;
@@ -788,22 +788,26 @@ export class TestingTerminalService extends Disposable implements ITerminalServi
 		return Promise.resolve(undefined);
 	}
 
-	associateTerminalWithSession(terminal: vscode.Terminal, sessionId: string, shellIntegrationQuality: ShellIntegrationQuality): Promise<void> {
+	associateTerminalWithSession(terminal: vscode.Terminal, sessionId: string, id: string, shellIntegrationQuality: ShellIntegrationQuality): Promise<void> {
 		const terms = this.sessionTerminals.get(sessionId);
 		if (terms) {
-			terms.push({ terminal, shellIntegrationQuality });
+			terms.push({ terminal, shellIntegrationQuality, id });
 		} else {
-			this.sessionTerminals.set(sessionId, [{ terminal, shellIntegrationQuality }]);
+			this.sessionTerminals.set(sessionId, [{ terminal, shellIntegrationQuality, id }]);
 		}
 		return Promise.resolve();
 	}
 
-	getCopilotTerminals(sessionId: string): Promise<vscode.Terminal[]> {
-		return Promise.resolve(this.sessionTerminals.get(sessionId)?.map(t => t.terminal) || []);
+	getCopilotTerminals(sessionId: string): Promise<IKnownTerminal[]> {
+		return Promise.resolve(this.sessionTerminals.get(sessionId)?.map(t => { return { ...t.terminal, id: t.id }; }) || []);
 	}
 
 	getToolTerminalForSession(sessionId: string): Promise<{ terminal: vscode.Terminal; shellIntegrationQuality: ShellIntegrationQuality } | undefined> {
 		return Promise.resolve(this.sessionTerminals.get(sessionId)?.at(0));
+	}
+
+	getLastCommandForTerminal(terminal: vscode.Terminal): vscode.TerminalExecutedCommand | undefined {
+		return undefined;
 	}
 
 	get terminalBuffer(): string {


### PR DESCRIPTION
Before:

Output was being provided in the prompt agent context.

Now, we reference tools in the prompt agent context that can be invoked if needed. We also now provide the last command context to the agent.

For tasks:
- added a new `GetTaskOutput` tool 
- because they don't have an associated terminal, for now, we're finding the terminal with the name of the task until we have better API vscode#234440 and passing that in to the tool

For terminals:
- associated the `id` that's assigned to a terminal in the `RunInTerminal` tool with the Copilot terminal, as `IKnownTerminal`
- returned `IKnownTerminal[]` from `getCopilotTerminals` so that the `id` can be passed to `GetTerminalOutput` tool



<img width="464" alt="Screenshot 2025-06-27 at 12 53 54 PM" src="https://github.com/user-attachments/assets/b46079f2-6006-4ff3-a696-e85589eb4304" />

<img width="1366" alt="Screenshot 2025-06-27 at 12 55 50 PM" src="https://github.com/user-attachments/assets/854dae07-cdb3-4ef9-bbe5-f78a69cc9564" />

Fixes #252690