### PR TITLE
Show prompt for remote index on auth failures

### DIFF
--- a/src/extension/extension/vscode-node/services.ts
+++ b/src/extension/extension/vscode-node/services.ts
@@ -37,6 +37,8 @@ import { IParserService } from '../../../platform/parser/node/parserService';
 import { ParserServiceImpl } from '../../../platform/parser/node/parserServiceImpl';
 import { AdoCodeSearchService, IAdoCodeSearchService } from '../../../platform/remoteCodeSearch/common/adoCodeSearchService';
 import { GithubCodeSearchService, IGithubCodeSearchService } from '../../../platform/remoteCodeSearch/common/githubCodeSearchService';
+import { ICodeSearchAuthenticationService } from '../../../platform/remoteCodeSearch/node/codeSearchRepoAuth';
+import { VsCodeCodeSearchAuthenticationService } from '../../../platform/remoteCodeSearch/vscode-node/codeSearchRepoAuth';
 import { IDocsSearchClient } from '../../../platform/remoteSearch/common/codeOrDocsSearchClient';
 import { DocsSearchClient } from '../../../platform/remoteSearch/node/codeOrDocsSearchClientImpl';
 import { IRequestLogger } from '../../../platform/requestLogger/node/requestLogger';
@@ -175,6 +177,7 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 	builder.define(IFixCookbookService, new SyncDescriptor(FixCookbookService));
 	builder.define(ILanguageContextService, new SyncDescriptor(LanguageContextServiceImpl));
 	builder.define(IWorkspaceListenerService, new SyncDescriptor(WorkspacListenerService));
+	builder.define(ICodeSearchAuthenticationService, new SyncDescriptor(VsCodeCodeSearchAuthenticationService));
 }
 
 function setupMSFTExperimentationService(builder: IInstantiationServiceBuilder, extensionContext: ExtensionContext) {

--- a/src/platform/remoteCodeSearch/node/codeSearchRepoAuth.ts
+++ b/src/platform/remoteCodeSearch/node/codeSearchRepoAuth.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator as createServiceIdentifier } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { IAuthenticationService } from '../../authentication/common/authentication';
+import { ResolvedRepoEntry } from './codeSearchRepoTracker';
+
+export const ICodeSearchAuthenticationService = createServiceIdentifier<ICodeSearchAuthenticationService>('ICodeSearchAuthentication');
+
+export interface ICodeSearchAuthenticationService {
+	readonly _serviceBrand: undefined;
+
+	tryAuthenticating(repo: ResolvedRepoEntry | undefined): Promise<void>;
+	tryReauthenticating(repo: ResolvedRepoEntry | undefined): Promise<void>;
+}
+
+export class BasicCodeSearchAuthenticationService implements ICodeSearchAuthenticationService {
+
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
+	) { }
+
+	async tryAuthenticating(repo: ResolvedRepoEntry | undefined): Promise<void> {
+		if (repo?.remoteInfo.repoId.type === 'ado') {
+			await this._authenticationService.getAdoAccessTokenBase64({ createIfNone: true });
+			return;
+		}
+
+		await this._authenticationService.getAnyGitHubSession({ createIfNone: true });
+	}
+
+	async tryReauthenticating(repo: ResolvedRepoEntry | undefined): Promise<void> {
+		if (repo?.remoteInfo.repoId.type === 'ado') {
+			await this._authenticationService.getAdoAccessTokenBase64({ createIfNone: true });
+			return;
+		}
+
+		await this._authenticationService.getPermissiveGitHubSession({ createIfNone: true });
+	}
+}

--- a/src/platform/remoteCodeSearch/vscode-node/codeSearchRepoAuth.ts
+++ b/src/platform/remoteCodeSearch/vscode-node/codeSearchRepoAuth.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { t } from '@vscode/l10n';
+import * as vscode from 'vscode';
+import { IAuthenticationService } from '../../authentication/common/authentication';
+import { IAuthenticationChatUpgradeService } from '../../authentication/common/authenticationUpgrade';
+import { ICodeSearchAuthenticationService } from '../node/codeSearchRepoAuth';
+import { ResolvedRepoEntry } from '../node/codeSearchRepoTracker';
+
+
+export class VsCodeCodeSearchAuthenticationService implements ICodeSearchAuthenticationService {
+
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IAuthenticationService private readonly _authService: IAuthenticationService,
+		@IAuthenticationChatUpgradeService private readonly _authUpgradeService: IAuthenticationChatUpgradeService,
+	) { }
+
+	async tryAuthenticating(repo: ResolvedRepoEntry | undefined): Promise<void> {
+		const fetchUrl = repo?.remoteInfo.fetchUrl;
+
+		const signInButton: vscode.MessageItem = {
+			title: t`Sign In`,
+		};
+		const cancelButton: vscode.MessageItem = {
+			title: t`Cancel`,
+			isCloseAffordance: true
+		};
+
+		if (repo?.remoteInfo.repoId.type === 'ado') {
+			const result = await vscode.window.showWarningMessage(t`Sign in to use remote index`, {
+				modal: true,
+				detail: fetchUrl
+					? t`Sign in to Azure DevOps to use remote workspace index for: ${fetchUrl.toString()}`
+					: t`Sign in to Azure DevOps to use remote workspace index for a repo in this workspace`
+			}, signInButton, cancelButton);
+
+			if (result === signInButton) {
+				await this._authService.getAdoAccessTokenBase64({ createIfNone: true });
+				return;
+			}
+		} else {
+			const result = await vscode.window.showWarningMessage(t`Sign in to use remote index`, {
+				modal: true,
+				detail: fetchUrl
+					? t`Sign in to GitHub to use remote workspace index for: ${fetchUrl.toString()}`
+					: t`Sign in to GitHub to use remote workspace index for a repo in this workspace`
+			}, signInButton, cancelButton);
+
+			if (result === signInButton) {
+				await this._authService.getAnyGitHubSession({ createIfNone: true });
+				return;
+			}
+		}
+	}
+
+	async tryReauthenticating(repo: ResolvedRepoEntry | undefined): Promise<void> {
+		const fetchUrl = repo?.remoteInfo.fetchUrl;
+
+		const signInButton: vscode.MessageItem = {
+			title: t`Sign In`,
+		};
+		const cancelButton: vscode.MessageItem = {
+			title: t`Cancel`,
+			isCloseAffordance: true
+		};
+
+		if (repo?.remoteInfo.repoId.type === 'ado') {
+			const result = await vscode.window.showWarningMessage(t`Reauthenticate to use remote workspace index`, {
+				modal: true,
+				detail: fetchUrl
+					? t`Sign in to Azure DevOps again to use remote workspace index for: ${fetchUrl}`
+					: t`Sign in to Azure DevOps again to use remote workspace index for a repo in this workspace`
+			}, signInButton, cancelButton);
+
+			if (result === signInButton) {
+				await this._authService.getAdoAccessTokenBase64({ createIfNone: true });
+				return;
+			}
+		} else {
+			const result = await vscode.window.showWarningMessage(t`Reauthenticate to use remote workspace index`, {
+				modal: true,
+				detail: fetchUrl
+					? t`Sign in to GitHub again to use remote workspace index for: ${fetchUrl}`
+					: t`Sign in to GitHub again to use remote workspace index for a repo in this workspace`
+			}, signInButton, cancelButton);
+
+			if (result === signInButton) {
+				await this._authUpgradeService.showPermissiveSessionModal();
+				return;
+			}
+		}
+	}
+}

--- a/src/platform/test/node/services.ts
+++ b/src/platform/test/node/services.ts
@@ -66,6 +66,7 @@ import { IUrlOpener, NullUrlOpener } from '../../open/common/opener';
 import { IParserService } from '../../parser/node/parserService';
 import { ParserServiceImpl } from '../../parser/node/parserServiceImpl';
 import { IPromptPathRepresentationService, TestPromptPathRepresentationService } from '../../prompts/common/promptPathRepresentationService';
+import { BasicCodeSearchAuthenticationService, ICodeSearchAuthenticationService } from '../../remoteCodeSearch/node/codeSearchRepoAuth';
 import { NullRequestLogger } from '../../requestLogger/node/nullRequestLogger';
 import { IRequestLogger } from '../../requestLogger/node/requestLogger';
 import { IScopeSelector } from '../../scopeSelection/common/scopeSelection';
@@ -212,6 +213,7 @@ export function _createBaselineServices(): TestingServiceCollection {
 	testingServiceCollection.define(ISurveyService, new SyncDescriptor(NullSurveyService));
 	testingServiceCollection.define(IEditSurvivalTrackerService, new SyncDescriptor(NullEditSurvivalTrackerService));
 	testingServiceCollection.define(IWorkspaceChunkSearchService, new SyncDescriptor(NullWorkspaceChunkSearchService));
+	testingServiceCollection.define(ICodeSearchAuthenticationService, new SyncDescriptor(BasicCodeSearchAuthenticationService));
 	return testingServiceCollection;
 }
 

--- a/src/platform/workspaceChunkSearch/common/workspaceChunkSearch.ts
+++ b/src/platform/workspaceChunkSearch/common/workspaceChunkSearch.ts
@@ -86,6 +86,18 @@ export interface IWorkspaceChunkSearchStrategy {
 	readonly id: WorkspaceChunkSearchStrategyId;
 
 	/**
+	 * Invoked before the search is performed.
+	 *
+	 * This can be used to prompt the user or perform other actions.
+	 *
+	 * Unlike time spent in `searchWorkspace`, this method will not count towards timeouts
+	 */
+	prepareSearchWorkspace?(
+		telemetryInfo: TelemetryCorrelationId,
+		token: CancellationToken,
+	): Promise<void>;
+
+	/**
 	 * Takes search queries and returns the chunks of text that are most semantically similar to any of the queries.
 	 *
 	 * @return Either the result (which may have zero chunks) or undefined if the search could not be performed.


### PR DESCRIPTION
Shows a once per session sign in prompt if we know for sure that we could not use the remote index due to being unauthorized (typically no/expired token). This is shown when codebase search is first requested 