### PR TITLE
Some grep_search improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,15 +290,15 @@
 					"properties": {
 						"query": {
 							"type": "string",
-							"description": "The pattern to search for in files in the workspace. Use regex with alternation (e.g., 'word1|word2|word3') or character classes to find multiple potential words in a single search. The isRegexp property declares whether it's a regex or plain text pattern. Is case-insensitive."
+							"description": "The pattern to search for in files in the workspace. Use regex with alternation (e.g., 'word1|word2|word3') or character classes to find multiple potential words in a single search. Be sure to set the isRegexp property properly to declare whether it's a regex or plain text pattern. Is case-insensitive."
 						},
 						"isRegexp": {
 							"type": "boolean",
-							"description": "Whether the pattern is a regex. False by default."
+							"description": "Whether the pattern is a regex."
 						},
 						"includePattern": {
 							"type": "string",
-							"description": "Search files matching this glob pattern. Will be applied to the relative path of files within the workspace."
+							"description": "Search files matching this glob pattern. Will be applied to the relative path of files within the workspace. To search recursively inside a folder, use a proper glob pattern like \"src/folder/**\". Do not use | in includePattern."
 						},
 						"maxResults": {
 							"type": "number",

--- a/src/extension/tools/node/test/findFiles.spec.tsx
+++ b/src/extension/tools/node/test/findFiles.spec.tsx
@@ -35,7 +35,13 @@ suite('FindFiles', () => {
 	});
 
 	function setup(expected: vscode.GlobPattern) {
-		collection.define(ISearchService, new TestSearchService(expected));
+		const patterns: vscode.GlobPattern[] = [expected];
+		if (typeof expected === 'string' && !expected.endsWith('/**')) {
+			patterns.push(expected + '/**');
+		} else if (typeof expected !== 'string' && !expected.pattern.endsWith('/**')) {
+			patterns.push(new RelativePattern(expected.baseUri, expected.pattern + '/**'));
+		}
+		collection.define(ISearchService, new TestSearchService(patterns));
 		accessor = collection.createTestingAccessor();
 	}
 
@@ -94,7 +100,7 @@ suite('FindFiles', () => {
 });
 
 class TestSearchService extends AbstractSearchService {
-	constructor(private readonly expectedPattern: vscode.GlobPattern) {
+	constructor(private readonly expectedPattern: vscode.GlobPattern | vscode.GlobPattern[]) {
 		super();
 	}
 
@@ -106,7 +112,7 @@ class TestSearchService extends AbstractSearchService {
 		throw new Error('Method not implemented.');
 	}
 
-	override async findFiles(filePattern: vscode.GlobPattern, options?: vscode.FindFiles2Options | undefined, token?: vscode.CancellationToken | undefined): Promise<vscode.Uri[]> {
+	override async findFiles(filePattern: vscode.GlobPattern | vscode.GlobPattern[], options?: vscode.FindFiles2Options | undefined, token?: vscode.CancellationToken | undefined): Promise<vscode.Uri[]> {
 		expect(filePattern).toEqual(this.expectedPattern);
 		return [];
 	}

--- a/src/extension/tools/node/test/findTextInFilesResult.spec.tsx
+++ b/src/extension/tools/node/test/findTextInFilesResult.spec.tsx
@@ -30,7 +30,7 @@ suite('FindTextInFilesResult', () => {
 		const clz = class extends PromptElement {
 			render() {
 				return <UserMessage>
-					<FindTextInFilesResult textResults={results} />
+					<FindTextInFilesResult textResults={results} maxResults={20} />
 				</UserMessage>;
 			}
 		};

--- a/src/extension/tools/node/toolUtils.ts
+++ b/src/extension/tools/node/toolUtils.ts
@@ -46,7 +46,7 @@ export function formatUriForFileWidget(uriOrLocation: URI | Location): string {
 	// Empty link text -> rendered as file widget
 	return `[](${uri.toString()}${rangePart})`;
 }
-export function inputGlobToPattern(query: string, workspaceService: IWorkspaceService): vscode.GlobPattern {
+export function inputGlobToPattern(query: string, workspaceService: IWorkspaceService): vscode.GlobPattern[] {
 	let pattern: vscode.GlobPattern = query;
 	if (isAbsolute(query)) {
 		try {
@@ -62,7 +62,13 @@ export function inputGlobToPattern(query: string, workspaceService: IWorkspaceSe
 		}
 	}
 
-	return pattern;
+	const patterns = [pattern];
+	if (typeof pattern === 'string' && !pattern.endsWith('/**')) {
+		patterns.push(pattern + '/**');
+	} else if (typeof pattern !== 'string' && !pattern.pattern.endsWith('/**')) {
+		patterns.push(new RelativePattern(pattern.baseUri, pattern.pattern + '/**'));
+	}
+	return patterns;
 }
 
 export function resolveToolInputPath(path: string, promptPathRepresentationService: IPromptPathRepresentationService): URI {

--- a/test/outcome/edit-toolcalling-panel.json
+++ b/test/outcome/edit-toolcalling-panel.json
@@ -2,7 +2,7 @@
 	{
 		"name": "edit (toolCalling) [panel] - does not read",
 		"requests": [
-			"76361434c04a973e84596e025817efc52dc7f9acefe2071af168813fbab1441f"
+			"561bc5c1ea6572be977c51f817f1142501614e0e8fbe84dfecefee30d7683086"
 		]
 	}
 ]

--- a/test/outcome/findfilestool-toolcalling-panel.json
+++ b/test/outcome/findfilestool-toolcalling-panel.json
@@ -2,7 +2,7 @@
 	{
 		"name": "findFilesTool (toolCalling) [panel] - proper glob patterns",
 		"requests": [
-			"a1cfaa5f708b962bbf23445670f96f0ae344b7aa87d332f3cb704c61dab47e62"
+			"b8377faef4e1f04257476bb530fdb1b542decd016a00ae90c189795f37c996f2"
 		]
 	}
 ]

--- a/test/outcome/notebooks-toolcalling-panel.json
+++ b/test/outcome/notebooks-toolcalling-panel.json
@@ -2,25 +2,25 @@
 	{
 		"name": "notebooks (toolCalling) [panel] - Edit cell tool",
 		"requests": [
-			"7eb26ea6acae12c01746f923cfad48724ad3ae361fcc32ef37a0cd7aba876a6b"
+			"0b4721b2b7fff8790e9d06ba38f69623aebb6e627a42fa7de74be838767ba577"
 		]
 	},
 	{
 		"name": "notebooks (toolCalling) [panel] - Run cell at a specific index",
 		"requests": [
-			"04966ec21a141eb5868546e642eade2dc15e419218d47e865dae3dafc216f956"
+			"f0f79f9928e8411fcf5fe0d813a326128b72edc30b89251bf207229d2910c644"
 		]
 	},
 	{
 		"name": "notebooks (toolCalling) [panel] - Run cell tool",
 		"requests": [
-			"f65a1c439bd6fa98d333905647c94a6fa6c86b336a15150bfa973a6714385b37"
+			"bda4bc2b9f5dcfbe26c25d1ae9e99034b29820cbec8c54f592dd68ccaf94cc97"
 		]
 	},
 	{
 		"name": "notebooks (toolCalling) [panel] - Run cell tool should avoid running markdown cells",
 		"requests": [
-			"d630b894e4b35eb533535843962bb441c6d9e7fb086673c5e689253fe8e079b5"
+			"431b34365a70b3a3ef3202d97ac83ace5233637c62b517ad6360769659ccd258"
 		]
 	}
 ]

--- a/test/outcome/toolcalling-panel.json
+++ b/test/outcome/toolcalling-panel.json
@@ -2,13 +2,13 @@
 	{
 		"name": "toolCalling [panel] - find all phone numbers in markdown files in the codebase",
 		"requests": [
-			"61ff04cb540e7874eaf05160ef12807b041dc36e79c1478f426218534ed8e0fa"
+			"0a3e0682792fdb3543968daba8d3e31633a3498beda68f885d645203448bea81"
 		]
 	},
 	{
 		"name": "toolCalling [panel] - I'm using git, create a new branch called issue-9876",
 		"requests": [
-			"f4e87715f7b5cac1639e2a593a9275bbbc615d6aa904228b800433790bed9636"
+			"c2856ef312f58e9a83a2509548789f23f26adce3b5b44595ce34b88e8d579b26"
 		]
 	}
 ]

--- a/test/simulation/baseline.json
+++ b/test/simulation/baseline.json
@@ -940,9 +940,9 @@
   {
     "name": "edit (toolCalling) [panel] - does not read",
     "contentFilterCount": 0,
-    "passCount": 7,
-    "failCount": 3,
-    "score": 0.7
+    "passCount": 10,
+    "failCount": 0,
+    "score": 1
   },
   {
     "name": "edit [inline] [cpp] - edit for cpp",
@@ -9481,9 +9481,9 @@
   {
     "name": "notebooks (toolCalling) [panel] - Run cell tool should avoid running markdown cells",
     "contentFilterCount": 0,
-    "passCount": 10,
-    "failCount": 0,
-    "score": 1
+    "passCount": 5,
+    "failCount": 5,
+    "score": 0.5
   },
   {
     "name": "PR Title and Description [context] - Multiple commits without issue information",

--- a/test/simulation/cache/layers/53e98a53-b403-4038-b94d-8192c72ac082.sqlite
+++ b/test/simulation/cache/layers/53e98a53-b403-4038-b94d-8192c72ac082.sqlite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3a2d3d9d201e512e60379b3e6dba796a869254f34c4094953ad522a8a75011c
+size 266240


### PR DESCRIPTION
4.1 struggles to set isRegexp correctly, so fallback to the opposite case if no matches returned.
Fix maxResults label logic and cap maxResults.
Some instructions which I'm not sure whether they help much.
Encouraging the alternation helped reduce random blind read_files but it also adds noise and sometimes shows up in includePattern now.