### PR TITLE
Improve error handling for read_file

### DIFF
--- a/src/extension/tools/node/readFileTool.tsx
+++ b/src/extension/tools/node/readFileTool.tsx
@@ -140,6 +140,7 @@ class ReadFileTool implements ICopilotTool<ReadFileParams> {
 			]);
 		} catch (err) {
 			void this.sendReadFileTelemetry('error', options, ranges || { start: 0, end: 0, truncated: false });
+			throw err;
 		}
 	}
 

--- a/src/extension/tools/node/toolUtils.ts
+++ b/src/extension/tools/node/toolUtils.ts
@@ -84,15 +84,16 @@ export async function assertFileOkForTool(accessor: ServicesAccessor, uri: URI):
 	const workspaceService = accessor.get(IWorkspaceService);
 	const tabsAndEditorsService = accessor.get(ITabsAndEditorsService);
 	const ignoreService = accessor.get(IIgnoreService);
+	const promptPathRepresentationService = accessor.get(IPromptPathRepresentationService);
 
 	if (workspaceService.getWorkspaceFolders.length > 0 && !workspaceService.getWorkspaceFolder(normalizePath(uri))) {
 		const fileOpenInSomeTab = tabsAndEditorsService.tabs.some(tab => isEqual(tab.uri, uri));
 		if (!fileOpenInSomeTab) {
-			throw new Error(`File is outside of the workspace and can't be read`);
+			throw new Error(`File ${promptPathRepresentationService.getFilePath(uri)} is outside of the workspace and can't be read`);
 		}
 	}
 
 	if (await ignoreService.isCopilotIgnored(uri)) {
-		throw new Error(`File is configured to be ignored by Copilot`);
+		throw new Error(`File ${promptPathRepresentationService.getFilePath(uri)} is configured to be ignored by Copilot`);
 	}
 }


### PR DESCRIPTION
Throw an error that was swallowed, add proper file path to error, send telemetry for invalid input