### PR TITLE
Remove unused dev container Feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
 		"ghcr.io/devcontainers/features/azure-cli:1": {},
 		"ghcr.io/devcontainers/features/python:1": {},
 		"ghcr.io/devcontainers/features/dotnet:2": {},
-		"ghcr.io/devcontainers-contrib/features/pylint:2": {},
 		"ghcr.io/devcontainers/features/desktop-lite:1": {}
 	},
 	"containerEnv": {


### PR DESCRIPTION
Remove unnecessary dev container Feature. The python Feature [already installs pylint](https://github.com/devcontainers/features/tree/main/src/python#options) by default