### PR TITLE
Enable all available models for Free users

### DIFF
--- a/src/platform/authentication/vscode-node/copilotTokenManager.ts
+++ b/src/platform/authentication/vscode-node/copilotTokenManager.ts
@@ -89,6 +89,7 @@ export class VSCodeCopilotTokenManager extends BaseCopilotTokenManager {
 				case TokenErrorNotificationId.ServerError:
 				case TokenErrorNotificationId.FeatureFlagBlocked:
 				case TokenErrorNotificationId.SpammyUser:
+				case TokenErrorNotificationId.SnippyNotConfigured:
 					throw new ContactSupportError(message);
 			}
 		}

--- a/src/platform/chat/common/chatQuotaServiceImpl.ts
+++ b/src/platform/chat/common/chatQuotaServiceImpl.ts
@@ -38,7 +38,7 @@ export class ChatQuotaService extends Disposable implements IChatQuotaService {
 	}
 
 	processQuotaHeaders(headers: IHeaders): void {
-		const quotaHeader = headers.get('x-quota-snapshot-premium_models') || headers.get('x-quota-snapshot-premium_interactions');
+		const quotaHeader = this._authService.copilotToken?.isFreeUser ? headers.get('x-quota-snapshot-chat') : headers.get('x-quota-snapshot-premium_models') || headers.get('x-quota-snapshot-premium_interactions');
 		if (!quotaHeader) {
 			return;
 		}


### PR DESCRIPTION
This PR fixes two issues:
1) We recently saw snippy misconfigurations but we didn't show a proper error message
2) Free users are broken when they want to use Sonnet 3.5 or any of the models available in Free other than GPT 4.1. This is because we are not looking at the right header for free users. Without the change users always get the notification that they ran out of premium requests and fall back to 4.1. With the change user can use their monthly quota with any of the available models.

@brannon