### PR TITLE
Add links to primary meta issues + descriptive triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,14 @@
 blank_issues_enabled: false
 contact_links:
   - name: Copilot Chat Issues
-    url: https://github.com/microsoft/vscode/issues/new?labels=chat
+    url: https://github.com/microsoft/vscode/issues/new?labels=chat-oss-issue
     about: Please file issues related to Copilot Chat in the VS Code repository.
+  - name: Responsible AI Service response blocking
+    url: https://github.com/microsoft/vscode/issues/253130
+    about: See meta-issue for information on RAI response blocking.
+  - name: Request Rate Limiting
+    url: https://github.com/microsoft/vscode/issues/253124
+    about: See meta-issue for scenarios where chat requests are blocked due to rate limiting.
+  - name: Public Code Matching
+    url: https://github.com/microsoft/vscode/issues/253129
+    about: Learn how to enable/disable public code matching in responses via your organizational settings.


### PR DESCRIPTION
points issue links all at vscode, adds a label that will make sure issues from here land in the copilot classifier bucket.