### PR TITLE
Show prompt before indexing large workspace locally using expanded indexing 

### DIFF
--- a/src/platform/remoteCodeSearch/node/codeSearchRepoAuth.ts
+++ b/src/platform/remoteCodeSearch/node/codeSearchRepoAuth.ts
@@ -14,6 +14,8 @@ export interface ICodeSearchAuthenticationService {
 
 	tryAuthenticating(repo: ResolvedRepoEntry | undefined): Promise<void>;
 	tryReauthenticating(repo: ResolvedRepoEntry | undefined): Promise<void>;
+
+	promptForExpandedLocalIndexing(fileCount: number): Promise<boolean>;
 }
 
 export class BasicCodeSearchAuthenticationService implements ICodeSearchAuthenticationService {
@@ -40,5 +42,10 @@ export class BasicCodeSearchAuthenticationService implements ICodeSearchAuthenti
 		}
 
 		await this._authenticationService.getPermissiveGitHubSession({ createIfNone: true });
+	}
+
+	async promptForExpandedLocalIndexing(fileCount: number): Promise<boolean> {
+		// Can't show prompt here
+		return false;
 	}
 }

--- a/src/platform/remoteCodeSearch/vscode-node/codeSearchRepoAuth.ts
+++ b/src/platform/remoteCodeSearch/vscode-node/codeSearchRepoAuth.ts
@@ -95,4 +95,26 @@ export class VsCodeCodeSearchAuthenticationService implements ICodeSearchAuthent
 			}
 		}
 	}
+
+	async promptForExpandedLocalIndexing(fileCount: number): Promise<boolean> {
+		const confirmButton: vscode.MessageItem = {
+			title: t`Enable`,
+		};
+		const cancelButton: vscode.MessageItem = {
+			title: t`Cancel`,
+			isCloseAffordance: true
+		};
+
+		const result = await vscode.window.showWarningMessage(
+			t`Build local index for this workspace?`,
+			{
+				modal: true,
+				detail: t`This workspace contains ${fileCount} files. Building a local index may take a while but will improve search performance.`,
+			},
+			confirmButton,
+			cancelButton
+		);
+
+		return result === confirmButton;
+	}
 }

--- a/src/platform/workspaceChunkSearch/node/workspaceChunkEmbeddingsIndex.ts
+++ b/src/platform/workspaceChunkSearch/node/workspaceChunkEmbeddingsIndex.ts
@@ -60,8 +60,9 @@ export class WorkspaceChunkEmbeddingsIndex extends Disposable {
 		this._cacheRoot = vsExtensionContext.storageUri;
 
 		this._cache = new Lazy(async () => {
-			const cache = await _instantiationService.invokeFunction(accessor => createWorkspaceChunkAndEmbeddingCache(accessor, this._embeddingType, this._cacheRoot, this._workspaceIndex));
-			return this._register(cache);
+			const cache = this._register(await _instantiationService.invokeFunction(accessor => createWorkspaceChunkAndEmbeddingCache(accessor, this._embeddingType, this._cacheRoot, this._workspaceIndex)));
+			this._onDidChangeWorkspaceIndexState.fire();
+			return cache;
 		});
 
 		this._register(Event.any(


### PR DESCRIPTION
Before indexing the entire workspace locally, we want to make sure the user is aware of what is happening. This informs them why search may be slow and also avoid extra load building the index if it was only requested by mistake 