### PR TITLE
Fix https://github.com/microsoft/vscode-copilot/issues/18392

### DIFF
--- a/src/extension/inlineEdits/vscode-node/inlineEditProviderFeature.ts
+++ b/src/extension/inlineEdits/vscode-node/inlineEditProviderFeature.ts
@@ -124,10 +124,7 @@ export class InlineEditProviderFeature extends Disposable implements IExtensionC
 			const recordingDirPath = join(this._vscodeExtensionContext.globalStorageUri.fsPath, 'logContextRecordings');
 			const logContextRecorder = this.inlineEditsLogFileEnabled ? reader.store.add(this._instantiationService.createInstance(LogContextRecorder, recordingDirPath, logger)) : undefined;
 
-			let inlineEditDebugComponent: InlineEditDebugComponent | undefined = undefined;
-			if (this._internalActionsEnabled.read(reader)) {
-				inlineEditDebugComponent = reader.store.add(new InlineEditDebugComponent(this._internalActionsEnabled, this.inlineEditsEnabled, model.debugRecorder, this._inlineEditsProviderId));
-			}
+			const inlineEditDebugComponent = reader.store.add(new InlineEditDebugComponent(this._internalActionsEnabled, this.inlineEditsEnabled, model.debugRecorder, this._inlineEditsProviderId));
 
 			const telemetrySender = this._register(this._instantiationService.createInstance(TelemetrySender));
 


### PR DESCRIPTION
```Copilot Generated Description:``` Simplify the initialization of the inline edit debug component by removing unnecessary conditional checks.

Fixes microsoft/vscode-copilot#18392