### PR TITLE
Draft: Tool filtering experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -2433,6 +2433,14 @@
 						],
 						"markdownDescription": "%github.copilot.config.agent.thinkingTool%"
 					},
+					"github.copilot.chat.tools.semanticSearch.enabled": {
+						"type": "boolean",
+						"default": false,
+						"tags": [
+							"experimental"
+						],
+						"markdownDescription": "%github.copilot.config.tools.semanticSearch.enabled%"
+					},
 					"github.copilot.chat.edits.suggestRelatedFilesFromGitHistory": {
 						"type": "boolean",
 						"default": true,

--- a/package.nls.json
+++ b/package.nls.json
@@ -129,6 +129,7 @@
 	"github.copilot.config.startDebugging.enabled": "Enables the `/startDebugging` intent in panel chat. Generates or finds launch config to match the query (if any), project structure, and more.",
 	"github.copilot.config.agent.runTasks": "Configures whether Copilot Edits can run workspace tasks in agent mode.",
 	"github.copilot.config.agent.thinkingTool": "Enables the thinking tool that allows Copilot to think deeply about your request before generating a response in agent mode.",
+	"github.copilot.config.tools.semanticSearch.enabled": "Enables semantic tool filtering. When enabled, Copilot will use embeddings to filter tools by relevance to your request when there are too many available tools.",
 	"github.copilot.config.setupTests.enabled": "Enables the `/setupTests` intent and prompting in `/tests` generation.",
 	"github.copilot.config.byok.ollamaEndpoint": "The endpoint to use for the Ollama when accessed via bring your own key. Defaults to localhost.",
 	"github.copilot.command.fixTestFailure": "Fix Test Failure",

--- a/src/extension/tools/common/toolEmbeddingsCache.ts
+++ b/src/extension/tools/common/toolEmbeddingsCache.ts
@@ -1,0 +1,129 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { CancellationToken } from 'vscode';
+import { Embedding, EmbeddingType, IEmbeddingsComputer } from '../../../platform/embeddings/common/embeddingsComputer';
+import { LRUCache } from '../../../util/common/cache';
+import { hash } from '../../../util/vs/base/common/hash';
+
+export interface ToolEmbeddingData {
+	readonly name: string;
+	readonly description: string;
+	readonly schema?: unknown;
+}
+
+export class ToolEmbeddingsCache {
+	private readonly _cache: LRUCache<Embedding>;
+	private readonly _embeddingType = EmbeddingType.text3small_512;
+
+	constructor(
+		private readonly _embeddingsComputer: IEmbeddingsComputer,
+		cacheSize: number = 256
+	) {
+		this._cache = new LRUCache<Embedding>(cacheSize);
+	}
+
+	/**
+	 * Get the cache key for a tool based on its data
+	 */
+	private _getCacheKey(tool: ToolEmbeddingData): string {
+		const contentHash = hash(`${tool.name}|${tool.description}|${JSON.stringify(tool.schema ?? {})}`);
+		return `${tool.name}_${contentHash}`;
+	}
+
+	/**
+	 * Get the text representation of a tool for embedding
+	 */
+	private _getToolText(tool: ToolEmbeddingData): string {
+		let text = `Tool: ${tool.name}\nDescription: ${tool.description}`;
+
+		if (tool.schema) {
+			try {
+				const schemaStr = JSON.stringify(tool.schema, null, 2);
+				text += `\nSchema: ${schemaStr}`;
+			} catch {
+				// Ignore schema serialization errors
+			}
+		}
+
+		return text;
+	}
+
+	/**
+	 * Get embeddings for multiple tools, using cache when possible
+	 */
+	async getToolEmbeddings(
+		tools: ReadonlyArray<ToolEmbeddingData>,
+		cancellationToken?: CancellationToken
+	): Promise<Map<string, Embedding>> {
+		const result = new Map<string, Embedding>();
+		const uncachedTools: { tool: ToolEmbeddingData; text: string }[] = [];
+
+		// Check cache first
+		for (const tool of tools) {
+			const cacheKey = this._getCacheKey(tool);
+			const cached = this._cache.get(cacheKey);
+
+			if (cached) {
+				result.set(tool.name, cached);
+			} else {
+				uncachedTools.push({
+					tool,
+					text: this._getToolText(tool)
+				});
+			}
+		}
+
+		// Compute embeddings for uncached tools
+		if (uncachedTools.length > 0) {
+			const texts = uncachedTools.map(item => item.text);
+			const embeddings = await this._embeddingsComputer.computeEmbeddings(
+				this._embeddingType,
+				texts,
+				{ inputType: 'document' },
+				cancellationToken
+			);
+
+			if (embeddings) {
+				for (let i = 0; i < uncachedTools.length; i++) {
+					const { tool } = uncachedTools[i];
+					const embedding = embeddings.values[i];
+
+					if (embedding) {
+						const cacheKey = this._getCacheKey(tool);
+						this._cache.put(cacheKey, embedding);
+						result.set(tool.name, embedding);
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Get embedding for a query string
+	 */
+	async getQueryEmbedding(
+		query: string,
+		cancellationToken?: CancellationToken
+	): Promise<Embedding | undefined> {
+		const embeddings = await this._embeddingsComputer.computeEmbeddings(
+			this._embeddingType,
+			[query],
+			{ inputType: 'query' },
+			cancellationToken
+		);
+
+		return embeddings?.values[0];
+	}
+
+	/**
+	 * Clear the cache
+	 */
+	clear(): void {
+		this._cache.clear();
+	}
+}

--- a/src/extension/tools/node/test/testToolsService.ts
+++ b/src/extension/tools/node/test/testToolsService.ts
@@ -50,7 +50,7 @@ export class TestToolsService extends BaseToolsService implements IToolsService 
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILogService logService: ILogService,
 	) {
-		super(logService);
+		super(logService, undefined);
 
 		const filteredTools = this.getFilteredTools(disabledTools);
 		this._copilotTools = new Map(filteredTools

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -709,6 +709,9 @@ export namespace ConfigKey {
 
 	export const AgentThinkingTool = defineSetting<boolean>('chat.agent.thinkingTool', false);
 
+	/** Enable semantic tool filtering based on query similarity */
+	export const ToolsSemanticSearchEnabled = defineSetting<boolean>('chat.tools.semanticSearch.enabled', false);
+
 	/** Add context from recently used files */
 	export const TemporalContextInlineChatEnabled = defineExpSetting<boolean>('chat.editor.temporalContext.enabled', false);
 	export const TemporalContextEditsEnabled = defineExpSetting<boolean>('chat.edits.temporalContext.enabled', false);

--- a/test/base/extHostContext/simulationExtHostToolsService.ts
+++ b/test/base/extHostContext/simulationExtHostToolsService.ts
@@ -9,16 +9,17 @@ import type { CancellationToken, ChatRequest, LanguageModelTool, LanguageModelTo
 import { getToolName, ToolName } from '../../../src/extension/tools/common/toolNames';
 import { ICopilotTool } from '../../../src/extension/tools/common/toolsRegistry';
 import { BaseToolsService, IToolsService } from '../../../src/extension/tools/common/toolsService';
+import { getPackagejsonToolsForTest } from '../../../src/extension/tools/node/test/testToolsService';
 import { ToolsContribution } from '../../../src/extension/tools/vscode-node/tools';
 import { ToolsService } from '../../../src/extension/tools/vscode-node/toolsService';
+import { IConfigurationService } from '../../../src/platform/configuration/common/configurationService';
 import { packageJson } from '../../../src/platform/env/common/packagejson';
 import { ILogService } from '../../../src/platform/log/common/logService';
+import { raceTimeout } from '../../../src/util/vs/base/common/async';
 import { CancellationError } from '../../../src/util/vs/base/common/errors';
 import { Iterable } from '../../../src/util/vs/base/common/iterator';
 import { IInstantiationService } from '../../../src/util/vs/platform/instantiation/common/instantiation';
 import { logger } from '../../simulationLogger';
-import { raceTimeout } from '../../../src/util/vs/base/common/async';
-import { getPackagejsonToolsForTest } from '../../../src/extension/tools/node/test/testToolsService';
 
 export class SimulationExtHostToolsService extends BaseToolsService implements IToolsService {
 	declare readonly _serviceBrand: undefined;
@@ -54,9 +55,10 @@ export class SimulationExtHostToolsService extends BaseToolsService implements I
 		private readonly _disabledTools: Set<string>,
 		@ILogService logService: ILogService,
 		@IInstantiationService instantiationService: IInstantiationService,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
-		super(logService);
-		this._inner = instantiationService.createInstance(ToolsService);
+		super(logService, undefined); // No embeddings computer in simulation environment
+		this._inner = new ToolsService(instantiationService, logService, undefined, configurationService);
 
 		// register the contribution so that our tools are on vscode.lm.tools
 		setImmediate(() => this.ensureToolsRegistered());


### PR DESCRIPTION
For discussion.

This PR introduces experimental semantic filtering for language model tools, specifically targeting MCP (Model Context Protocol) servers when the number of available tools exceeds 128.

**Scope**
- Reduces tool set size when too many MCP tools are available
- Improves relevance of available tools based on user query
- Preserves all non-MCP tools to avoid breaking existing functionality

**How it works**
1. **Tool Embeddings Cache** (src/extension/tools/common/toolEmbeddingsCache.ts) caches embeddings for tools to improve performance
    - Uses `text3small_512` embedding type
    - Caches tool embeddings based on name, description, and schema
    - LRU cache with default size of 256 entries
    - Supports both tool and query embeddings
2. **Semantic Tool Filtering** src/extension/tools/vscode-node/toolsService.ts)
    1. Triggers when tools > 128 and feature is enabled
    2. Separates MCP tools from others (only MCP tools get filtered)
    3. Uses semantic similarity (min score 0.3) to rank MCP tools
    4. Keeps top relevant MCP tools + all non-MCP tools (max 128 total)
3. **Configuration** `github.copilot.chat.tools.semanticSearch.enabled`, Boolean (default: false)

**TODO**
- [ ] Gets called way too often, and each filtering (cached) takes about 300ms on my M4 Pro
- [ ] Misses context from custom instructions and attached files