### PR TITLE
fix run task / get task output labels

### DIFF
--- a/src/extension/tools/node/getTaskOutputTool.tsx
+++ b/src/extension/tools/node/getTaskOutputTool.tsx
@@ -67,7 +67,7 @@ export class GetTaskOutputTool implements vscode.LanguageModelTool<ITaskOptions>
 	private getTaskDefinition(input: ITaskOptions) {
 		const idx = input.id.indexOf(': ');
 		const taskType = input.id.substring(0, idx);
-		const taskLabel = input.id.substring(idx + 2);
+		let taskLabel = input.id.substring(idx + 2);
 
 		const workspaceFolderRaw = this.promptPathRepresentationService.resolveFilePath(input.workspaceFolder);
 		const workspaceFolder = (workspaceFolderRaw && this.workspaceService.getWorkspaceFolder(workspaceFolderRaw)) || this.workspaceService.getWorkspaceFolders()[0];
@@ -75,7 +75,11 @@ export class GetTaskOutputTool implements vscode.LanguageModelTool<ITaskOptions>
 		if (!task) {
 			return undefined;
 		}
-
+		try {
+			if (typeof parseInt(taskLabel) === 'number') {
+				taskLabel = input.id;
+			}
+		} catch { }
 		return { workspaceFolder, task, taskLabel };
 	}
 }

--- a/src/extension/tools/node/runTaskTool.tsx
+++ b/src/extension/tools/node/runTaskTool.tsx
@@ -78,9 +78,20 @@ class RunTaskTool implements vscode.LanguageModelTool<IRunTaskToolInput> {
 			invocationMessage: trustedMark(l10n.t`Running ${taskLabel ?? link(options.input.id)}`),
 			pastTenseMessage: trustedMark(task?.isBackground ? l10n.t`Started ${link(taskLabel ?? options.input.id)}` : l10n.t`Ran ${link(taskLabel ?? options.input.id)}`),
 			confirmationMessages: task && task.group !== 'build'
-				? { title: l10n.t`Allow task run?`, message: trustedMark(l10n.t`Allow Copilot to run the \`${task.type}\` task ${link(`\`${task.label ?? task.script}\``)}?`) }
+				? { title: l10n.t`Allow task run?`, message: trustedMark(l10n.t`Allow Copilot to run the \`${task.type}\` task ${link(`\`${this.getTaskRepresentation(task)}\``)}?`) }
 				: undefined
 		};
+	}
+
+	private getTaskRepresentation(task: vscode.TaskDefinition): string {
+		if ('label' in task) {
+			return task.label;
+		} else if ('script' in task) {
+			return task.script;
+		} else if ('command' in task) {
+			return task.command;
+		}
+		return '';
 	}
 
 	private getTaskDefinition(input: IRunTaskToolInput) {

--- a/src/extension/tools/node/runTaskTool.tsx
+++ b/src/extension/tools/node/runTaskTool.tsx
@@ -78,7 +78,7 @@ class RunTaskTool implements vscode.LanguageModelTool<IRunTaskToolInput> {
 			invocationMessage: trustedMark(l10n.t`Running ${taskLabel ?? link(options.input.id)}`),
 			pastTenseMessage: trustedMark(task?.isBackground ? l10n.t`Started ${link(taskLabel ?? options.input.id)}` : l10n.t`Ran ${link(taskLabel ?? options.input.id)}`),
 			confirmationMessages: task && task.group !== 'build'
-				? { title: l10n.t`Allow task run?`, message: trustedMark(l10n.t`Allow Copilot to run the \`${task.type}\` task ${link(`\`${task.label}\``)}?`) }
+				? { title: l10n.t`Allow task run?`, message: trustedMark(l10n.t`Allow Copilot to run the \`${task.type}\` task ${link(`\`${task.label ?? task.script}\``)}?`) }
 				: undefined
 		};
 	}
@@ -86,7 +86,7 @@ class RunTaskTool implements vscode.LanguageModelTool<IRunTaskToolInput> {
 	private getTaskDefinition(input: IRunTaskToolInput) {
 		const idx = input.id.indexOf(': ');
 		const taskType = input.id.substring(0, idx);
-		const taskLabel = input.id.substring(idx + 2);
+		let taskLabel = input.id.substring(idx + 2);
 
 		const workspaceFolderRaw = this.promptPathRepresentationService.resolveFilePath(input.workspaceFolder);
 		const workspaceFolder = (workspaceFolderRaw && this.workspaceService.getWorkspaceFolder(workspaceFolderRaw)) || this.workspaceService.getWorkspaceFolders()[0];
@@ -94,7 +94,11 @@ class RunTaskTool implements vscode.LanguageModelTool<IRunTaskToolInput> {
 		if (!task) {
 			return undefined;
 		}
-
+		try {
+			if (typeof parseInt(taskLabel) === 'number') {
+				taskLabel = input.id;
+			}
+		} catch { }
 		return { workspaceFolder, task, taskLabel };
 	}
 }


### PR DESCRIPTION
fix #19112

Follow-up to https://github.com/microsoft/vscode-copilot-chat/pull/85 to fix cases when `task.label` is not defined

![Screenshot 2025-07-03 at 8 14 13 AM](https://github.com/user-attachments/assets/3a5fff2a-3b07-452c-a050-5aa4383b2b18)
![Screenshot 2025-07-03 at 8 14 23 AM](https://github.com/user-attachments/assets/89b2774d-4f96-4ac6-bd4d-bfc1397d5375)
![Screenshot 2025-07-03 at 8 17 41 AM](https://github.com/user-attachments/assets/804aef80-b042-4a40-9412-05b891226dc3)
![Screenshot 2025-07-03 at 8 17 52 AM](https://github.com/user-attachments/assets/b0cd36bf-68ca-4702-89fc-5e171c534bc4)
