### PR TITLE
HostServiceImpl tests: skip getAllCommands() test because of flakiness

### DIFF
--- a/src/platform/workbench/test/vscode-node/workbenchServiceImpl.test.ts
+++ b/src/platform/workbench/test/vscode-node/workbenchServiceImpl.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import { WorkbenchServiceImpl } from '../../vscode/workbenchServiceImpt';
 
 suite('HostServiceImpl', () => {
-	test('getAllCommands', async () => {
+	test.skip('getAllCommands', async () => { // TODO@TylerLeonhardt
 		const envService = new WorkbenchServiceImpl();
 		const commands = await envService.getAllCommands();
 		assert.ok(Array.isArray(commands));


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/253598