### PR TITLE
Fix issue reporter destinations

### DIFF
--- a/src/extension/conversation/vscode-node/feedbackContribution.ts
+++ b/src/extension/conversation/vscode-node/feedbackContribution.ts
@@ -17,12 +17,15 @@ export class FeedbackCommandContribution extends Disposable {
 		this._register(vscode.commands.registerCommand('github.copilot.report', async (title: string = '') => {
 			const token = this.authenticationService.copilotToken;
 			const isTeamMember = token?.isVscodeTeamMember;
+			const isInternal = token?.isInternal;
 			const output: string[] = isTeamMember ? [`<details><summary>Prompt Details</summary>`] : [`<details><summary>Logs</summary>`];
 			appendPromptDetailsSection(output, LogMemory.getLogs().join('\n'), LogMemory.getRequestIds().join('\n'));
 			await vscode.commands.executeCommand('workbench.action.openIssueReporter', {
 				issueTitle: title,
 				extensionId: EXTENSION_ID,
-				uri: isTeamMember ? vscode.Uri.parse('https://github.com/microsoft/vscode-copilot-issues') : vscode.Uri.parse('https://github.com/microsoft/vscode'),
+				uri: isTeamMember ? vscode.Uri.parse('https://github.com/microsoft/vscode-internalbacklog') :
+					(isInternal ? vscode.Uri.parse('https://github.com/microsoft/vscode-copilot-issues') :
+						vscode.Uri.parse('https://github.com/microsoft/vscode')),
 				data: output.join('\n'),
 			});
 		}));


### PR DESCRIPTION
Avoids all team members going to `copilot-issues` repo which is meant for internal org ppl