### PR TITLE
tools: add trajectory telemetry for read_file

### DIFF
--- a/src/extension/intents/node/toolCallingLoop.ts
+++ b/src/extension/intents/node/toolCallingLoop.ts
@@ -33,6 +33,7 @@ import { SummarizedConversationHistoryMetadata } from '../../prompts/node/agent/
 import { ToolFailureEncountered, ToolResultMetadata } from '../../prompts/node/panel/toolCalling';
 import { ToolName } from '../../tools/common/toolNames';
 import { ToolCallCancelledError } from '../../tools/common/toolsService';
+import { ReadFileParams } from '../../tools/node/readFileTool';
 import { PauseController } from './pauseController';
 
 
@@ -194,7 +195,94 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 			}
 		}
 
+		this.emitReadFileTrajectories().catch(err => {
+			this._logService.logger.error('Error emitting read file trajectories', err);
+		});
+
 		return { ...lastResult, toolCallRounds: this.toolCallRounds, toolCallResults: this.toolCallResults };
+	}
+
+	private async emitReadFileTrajectories() {
+		// We are tuning our `read_file` tool to read files more effectively and efficiently.
+		// This is a likely-temporary function that emits trajectory telemetry read_files
+		// at the end of each agentic loop so that we can do so, in addition to the
+		// per-call telemetry in ReadFileTool
+
+		function tryGetRFArgs(call: IToolCall): ReadFileParams | undefined {
+			if (call.name !== ToolName.ReadFile) {
+				return undefined;
+			}
+			try {
+				return JSON.parse(call.arguments);
+			} catch {
+				return undefined;
+			}
+		}
+
+		const consumed = new Set<string>();
+		const tcrs = this.toolCallRounds;
+		for (let i = 0; i < tcrs.length; i++) {
+			const { toolCalls } = tcrs[i];
+			for (const call of toolCalls) {
+				if (consumed.has(call.id)) {
+					continue;
+				}
+				const args = tryGetRFArgs(call);
+				if (!args) {
+					continue;
+				}
+
+				const seqArgs = [args];
+				consumed.add(call.id);
+
+				for (let k = i + 1; k < tcrs.length; k++) {
+					for (const call2 of tcrs[k].toolCalls) {
+						if (consumed.has(call2.id)) {
+							continue;
+						}
+
+						const args2 = tryGetRFArgs(call2);
+						if (!args2 || args2.filePath !== args.filePath) {
+							continue;
+						}
+
+						consumed.add(call2.id);
+						seqArgs.push(args2);
+					}
+				}
+
+				let chunkSizeTotal = 0;
+				let chunkSizeNo = 0;
+				for (const arg of seqArgs) {
+					if ('startLine' in arg) {
+						chunkSizeNo++;
+						chunkSizeTotal += arg.endLine - arg.startLine + 1;
+					} else if (arg.limit) {
+						chunkSizeNo++;
+						chunkSizeTotal += arg.limit;
+					}
+				}
+
+				/* __GDPR__
+					"readFileTrajectory" : {
+						"owner": "connor4312",
+						"comment": "read_file tool invokation trajectory",
+						"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model that invoked the tool" },
+						"rounds": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "The number of times the file was read sequentially" },
+						"avgChunkSize": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "The number of lines read at a time" }
+					}
+				*/
+				this._telemetryService.sendMSFTTelemetryEvent('readFileTrajectory',
+					{
+						model: this.options.request.model.id,
+					},
+					{
+						rounds: seqArgs.length,
+						avgChunkSize: chunkSizeNo > 0 ? Math.round(chunkSizeTotal / chunkSizeNo) : -1,
+					}
+				);
+			}
+		}
 	}
 
 	private hitToolCallLimit(stream: ChatResponseStream | undefined, lastResult: IToolCallSingleResult) {

--- a/src/extension/tools/node/readFileTool.tsx
+++ b/src/extension/tools/node/readFileTool.tsx
@@ -65,7 +65,7 @@ export interface IReadFileParamsV2 {
 
 const MAX_LINES_PER_READ = 2000;
 
-type ReadFileParams = IReadFileParamsV1 | IReadFileParamsV2;
+export type ReadFileParams = IReadFileParamsV1 | IReadFileParamsV2;
 
 const isParamsV2 = (params: ReadFileParams): params is IReadFileParamsV2 =>
 	(params as IReadFileParamsV1).startLine === undefined;
@@ -202,7 +202,8 @@ class ReadFileTool implements ICopilotTool<ReadFileParams> {
 				"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model that invoked the tool" },
 				"linesRead": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "The number of lines that were read" },
 				"truncated": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "The file length was truncated" },
-				"isV2": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the tool is a v2 version" }
+				"isV2": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the tool is a v2 version" },
+				"isEntireFile": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the entire file was read with v2 params" }
 			}
 		*/
 		this.telemetryService.sendMSFTTelemetryEvent('readFileToolInvoked',
@@ -211,6 +212,7 @@ class ReadFileTool implements ICopilotTool<ReadFileParams> {
 				interactionId: options.chatRequestId,
 				toolOutcome: outcome, // Props named "outcome" often get stuck in the kusto pipeline
 				isV2: isParamsV2(options.input) ? 'true' : 'false',
+				isEntireFile: isParamsV2(options.input) && options.input.offset === undefined && options.input.limit === undefined ? 'true' : 'false',
 				model
 			},
 			{


### PR DESCRIPTION
We want this to support experiments during the next stable release.