### PR TITLE
Make sure we update the ado index state when setting changes

### DIFF
--- a/src/platform/remoteCodeSearch/node/codeSearchRepoTracker.ts
+++ b/src/platform/remoteCodeSearch/node/codeSearchRepoTracker.ts
@@ -309,6 +309,7 @@ export class CodeSearchRepoTracker extends Disposable {
 		this._register(Event.any(
 			this._authenticationService.onDidAuthenticationChange,
 			this._authenticationService.onDidAdoAuthenticationChange,
+			this._adoCodeSearchService.onDidChangeIndexState
 		)(() => {
 			this.updateAllRepoStatuses();
 		}));
@@ -788,6 +789,7 @@ export class CodeSearchRepoTracker extends Disposable {
 					return;
 
 				case RepoStatus.NotYetIndexed:
+				case RepoStatus.NotIndexable:
 				case RepoStatus.BuildingIndex:
 				case RepoStatus.Ready:
 				case RepoStatus.CouldNotCheckIndexStatus:


### PR DESCRIPTION
Fixes microsoft/vscode#254010

Worth fixing in June as this can cause users to believe they are not able to use the remote index 