### PR TITLE
Fix typo in function call to 'palindrome'

### DIFF
--- a/test/scenarios/test-scenario-fix-python/case8.py
+++ b/test/scenarios/test-scenario-fix-python/case8.py
@@ -11,9 +11,9 @@ def palindrome(s, inner = False):
             i += 1
             j += -1
         elif inner == False:
-            if s[i+1:j+1] == palindrom(s[i+1:j+1],inner = True):
+            if s[i+1:j+1] == palindrome(s[i+1:j+1],inner = True):
                 return s[0:i]+s[i+1:j+1]+s[j+1:]
-            elif s[i:j] == palindrom(s[i:j],inner = True):
+            elif s[i:j] == palindrome(s[i:j],inner = True):
                 return s[0:i]+s[i:j]+s[j+1:]
             else:
                 return None


### PR DESCRIPTION
### Summary

This PR fixes a minor typo in the main code where the function `palindrom` was called instead of the correct `palindrome`, which was already defined by the user.

### Changes Made
- Corrected the function call from `palindrom` to `palindrome`

### Why This Matters
This typo would result in a `NameError` at runtime, as `palindrom` is undefined. Fixing it ensures the intended palindrome check executes correctly.

Let me know if any additional changes are needed!