### PR TITLE
fix the ugly husky deprecation warning

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 set -e
 
 npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 set -e
 
 # git-lfs hook

--- a/package.json
+++ b/package.json
@@ -3683,7 +3683,6 @@
 	"scripts": {
 		"postinstall": "tsx ./script/postinstall.ts",
 		"prepare": "tsx ./script/prepare.ts",
-		"husky:install": "husky install",
 		"vscode-dts:dev": "node node_modules/@vscode/dts/index.js dev && mv vscode.proposed.*.ts src/extension",
 		"vscode-dts:main": "node node_modules/@vscode/dts/index.js main && mv vscode.d.ts src/extension",
 		"build": "tsx .esbuild.ts",

--- a/script/prepare.ts
+++ b/script/prepare.ts
@@ -5,7 +5,7 @@
 import { execSync } from 'child_process';
 
 function prepareHusky() {
-	execSync('npm run husky:install', { stdio: 'inherit' });
+	execSync('husky', { stdio: 'inherit' });
 }
 
 function main() {


### PR DESCRIPTION
When we run `npm install` in the cloned repo, I get the following warning:

```
> copilot-chat@0.30.0 prepare
> tsx ./script/prepare.ts


> copilot-chat@0.30.0 husky:install
> husky install

husky - install command is DEPRECATED
```

This PR fixes this warning by configuring husky in the right way according to the procedure described [here](https://remarkablemark.org/blog/2024/02/04/how-to-migrate-from-husky-8-to-9/).