### PR TITLE
Git LFS instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,7 @@ Please include the following with each issue:
 ## Requirements
 - Node 22.x
 - Python >= 3.10, <= 3.12
+- Git Large File Storage (LFS) - for running tests
 
 ### First-time setup
 - on Windows you need to run `Set-ExecutionPolicy Unrestricted` as admin in Powershell.
@@ -80,6 +81,7 @@ Please include the following with each issue:
 **Note:** Setup and running under Windows Subsystem for Linux (WSL) is supported.
 
 ### Testing
+If you hit errors while running tests, ensure that you are using the correct Node version and that git lfs is properly installed (run `git lfs pull` to validate).
 
 There are unit tests which run in Node.JS:
 


### PR DESCRIPTION
If git lfs is not installed, the tests will not pass. This includes the unit tests. In addition, if LFS is installed after clone or the node version is not correct it can lead to test failures.

Updating the instructions to try to steer people to installing LFS and correctly validating node versions and LFS functionality prior to filing issues about tests failing.