### PR TITLE
add run task telemetry, fix bug

### DIFF
--- a/src/platform/tasks/vscode/tasksService.ts
+++ b/src/platform/tasks/vscode/tasksService.ts
@@ -271,7 +271,7 @@ export class TasksService extends DisposableStore implements ITasksService {
 								if (!resolved) {
 									resolve({ status: TaskStatus.Started });
 								}
-							}, 10000);
+							}, task?.isBackground && task.problemMatchers.length ? 10000 : 0);
 						} else {
 							resolve({ status: TaskStatus.Started });
 						}


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/254980)

We were waiting a full ten seconds for the task `executeResult` before. We should only do this when the task `isBackground` and has `problemMatchers` that might report errors.

cc @Tyriar 
cc @connor4312 