### PR TITLE
Fix remote type in unknown cases

### DIFF
--- a/src/platform/remoteCodeSearch/node/codeSearchRepoTracker.ts
+++ b/src/platform/remoteCodeSearch/node/codeSearchRepoTracker.ts
@@ -456,7 +456,7 @@ export class CodeSearchRepoTracker extends Disposable {
 			if (remoteInfos.length) {
 				const primaryRemote = remoteInfos[0];
 				const remoteHost = primaryRemote.fetchUrl ? parseRemoteUrl(primaryRemote.fetchUrl) : undefined;
-				remoteTelemetryType = remoteHost ? getRemoteTypeForTelemetry(remoteHost.host) : GitRemoteTypeForTelemetry.Github;
+				remoteTelemetryType = remoteHost ? getRemoteTypeForTelemetry(remoteHost.host) : GitRemoteTypeForTelemetry.Unknown;
 			} else {
 				const allRemotes = Array.from(getOrderedRemoteUrlsFromContext(repo));
 				if (allRemotes.length === 0) {


### PR DESCRIPTION
Shouldn't default to GitHub 