### PR TITLE
Add math formatting hints to common prompts

### DIFF
--- a/src/extension/prompts/node/agent/agentInstructions.tsx
+++ b/src/extension/prompts/node/agent/agentInstructions.tsx
@@ -11,6 +11,7 @@ import { InstructionMessage } from '../base/instructionMessage';
 import { ResponseTranslationRules } from '../base/responseTranslationRules';
 import { Tag } from '../base/tag';
 import { CodeBlockFormattingRules, EXISTING_CODE_MARKER } from '../panel/codeBlockFormattingRules';
+import { MathIntegrationRules } from '../panel/editorIntegrationRules';
 import { getKeepGoingReminder } from './agentPrompt';
 
 interface DefaultAgentPromptProps extends BasePromptElementProps {
@@ -115,6 +116,7 @@ export class DefaultAgentPrompt extends PromptElement<DefaultAgentPromptProps> {
 				<Tag name='example'>
 					The class `Person` is in `src/models/person.ts`.
 				</Tag>
+				<MathIntegrationRules />
 			</Tag>
 			<ResponseTranslationRules />
 		</InstructionMessage>;

--- a/src/extension/prompts/node/panel/editorIntegrationRules.tsx
+++ b/src/extension/prompts/node/panel/editorIntegrationRules.tsx
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PromptElement } from '@vscode/prompt-tsx';
+import { BasePromptElementProps, PromptElement } from '@vscode/prompt-tsx';
+import { IConfigurationService } from '../../../../platform/configuration/common/configurationService';
 
 export class EditorIntegrationRules extends PromptElement {
 	render() {
@@ -12,10 +13,34 @@ export class EditorIntegrationRules extends PromptElement {
 				Use Markdown formatting in your answers.<br />
 				Make sure to include the programming language name at the start of the Markdown code blocks.<br />
 				Avoid wrapping the whole response in triple backticks.<br />
+				<MathIntegrationRules />
 				The user works in an IDE called Visual Studio Code which has a concept for editors with open files, integrated unit test support, an output pane that shows the output of running the code as well as an integrated terminal.<br />
 				The active document is the source code the user is looking at right now.<br />
 				You can only give one reply for each conversation turn.<br />
 			</>
 		);
+	}
+}
+
+export class MathIntegrationRules extends PromptElement {
+
+	constructor(
+		props: BasePromptElementProps,
+		@IConfigurationService private readonly configService: IConfigurationService
+	) {
+		super(props);
+	}
+
+	render() {
+		const mathEnabled = this.configService.getNonExtensionConfig<boolean>('chat.math.enabled');
+		if (mathEnabled) {
+			return (
+				<>
+					Use KaTeX for math equations in your answers.<br />
+					Wrap inline math equations in $.<br />
+					Wrap more complex blocks of math equations in $$.<br />
+				</>
+			);
+		}
 	}
 }


### PR DESCRIPTION
Includes hints if KaTeX should be used in responses and how to format these equations. This is needed as there are multiple ways that math equations can be expressed in markdown 