### PR TITLE
also track non-copilot terminals in agent context

### DIFF
--- a/package.json
+++ b/package.json
@@ -430,11 +430,12 @@
 						"id": {
 							"type": "string",
 							"description": "The ID of the terminal command output to check."
+						},
+						"pid": {
+							"type": "number",
+							"description": "The process ID of the terminal command to check. If provided, this will be used to find the terminal instead of the ID."
 						}
-					},
-					"required": [
-						"id"
-					]
+					}
 				}
 			},
 			{

--- a/src/extension/prompts/node/base/terminalAndTaskState.tsx
+++ b/src/extension/prompts/node/base/terminalAndTaskState.tsx
@@ -108,7 +108,7 @@ export class TerminalAndTaskStatePromptElement extends PromptElement<TerminalAnd
 					)}
 					{mappedOtherTerminals.length > 0 && (
 						<>
-							Other Terminals:<br />
+							User created Terminals:<br />
 							{mappedOtherTerminals.map((term) => (
 								<>
 									Terminal: {term.name}<br />

--- a/src/extension/tools/node/runInTerminalTool.tsx
+++ b/src/extension/tools/node/runInTerminalTool.tsx
@@ -400,9 +400,8 @@ export class GetTerminalOutputTool implements vscode.LanguageModelTool<IGetTermi
 			return new LanguageModelToolResult([
 				new LanguageModelTextPart(`Output of terminal ${options.input.id}:\n${RunInTerminalTool.getBackgroundOutput(options.input.id)}`)]);
 		} else if (options.input.pid) {
-			const buffer = this.terminalService.getBufferWithPid(options.input.pid);
 			return new LanguageModelToolResult([
-				new LanguageModelTextPart(`Output of terminal:\n${buffer}`)
+				new LanguageModelTextPart(`Output of terminal ${options.input.pid}:\n${await this.terminalService.getBufferWithPid(options.input.pid)}`)
 			]);
 		}
 	}

--- a/src/extension/tools/node/runInTerminalTool.tsx
+++ b/src/extension/tools/node/runInTerminalTool.tsx
@@ -388,15 +388,23 @@ export class RunInTerminalResult extends PromptElement<IRunInTerminalResultProps
 }
 
 interface IGetTerminalOutputParams {
-	id: string;
+	id?: string;
+	pid?: number;
 }
 
 export class GetTerminalOutputTool implements vscode.LanguageModelTool<IGetTerminalOutputParams> {
 	public static readonly toolName = ToolName.GetTerminalOutput;
-
+	constructor(@ITerminalService private readonly terminalService: ITerminalService) { }
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<IGetTerminalOutputParams>, token: CancellationToken) {
-		return new LanguageModelToolResult([
-			new LanguageModelTextPart(`Output of terminal ${options.input.id}:\n${RunInTerminalTool.getBackgroundOutput(options.input.id)}`)]);
+		if (options.input.id) {
+			return new LanguageModelToolResult([
+				new LanguageModelTextPart(`Output of terminal ${options.input.id}:\n${RunInTerminalTool.getBackgroundOutput(options.input.id)}`)]);
+		} else if (options.input.pid) {
+			const buffer = this.terminalService.getBufferWithPid(options.input.pid);
+			return new LanguageModelToolResult([
+				new LanguageModelTextPart(`Output of terminal:\n${buffer}`)
+			]);
+		}
 	}
 
 	prepareInvocation(options: vscode.LanguageModelToolInvocationPrepareOptions<IGetTerminalOutputParams>, token: vscode.CancellationToken): vscode.ProviderResult<vscode.PreparedToolInvocation> {

--- a/src/platform/terminal/common/terminalService.ts
+++ b/src/platform/terminal/common/terminalService.ts
@@ -77,6 +77,12 @@ export interface ITerminalService {
 	getBufferForTerminal(terminal: vscode.Terminal, maxChars?: number): string;
 
 	/**
+	 * Gets the buffer for a terminal with the given pid.
+	 * @param maxChars The maximum number of chars to return from the buffer, defaults to 16k
+	 */
+	getBufferWithPid(pid: number, maxChars?: number): string;
+
+	/**
 	 * Gets the last command executed in a terminal.
 	 * @param terminal The terminal to get the last command for
 	 */
@@ -154,6 +160,10 @@ export class NullTerminalService extends Disposable implements ITerminalService 
 	}
 
 	getBufferForTerminal(terminal: vscode.Terminal, maxLines?: number): string {
+		return '';
+	}
+
+	getBufferWithPid(pid: number, maxChars?: number): string {
 		return '';
 	}
 

--- a/src/platform/terminal/common/terminalService.ts
+++ b/src/platform/terminal/common/terminalService.ts
@@ -80,7 +80,7 @@ export interface ITerminalService {
 	 * Gets the buffer for a terminal with the given pid.
 	 * @param maxChars The maximum number of chars to return from the buffer, defaults to 16k
 	 */
-	getBufferWithPid(pid: number, maxChars?: number): string;
+	getBufferWithPid(pid: number, maxChars?: number): Promise<string>;
 
 	/**
 	 * Gets the last command executed in a terminal.
@@ -163,8 +163,8 @@ export class NullTerminalService extends Disposable implements ITerminalService 
 		return '';
 	}
 
-	getBufferWithPid(pid: number, maxChars?: number): string {
-		return '';
+	getBufferWithPid(pid: number, maxChars?: number): Promise<string> {
+		return Promise.resolve('');
 	}
 
 	getLastCommandForTerminal(terminal: vscode.Terminal): vscode.TerminalExecutedCommand | undefined {

--- a/src/platform/terminal/vscode/terminalServiceImpl.ts
+++ b/src/platform/terminal/vscode/terminalServiceImpl.ts
@@ -152,6 +152,14 @@ export class TerminalServiceImpl extends Disposable implements ITerminalService 
 		return getBufferForTerminal(terminal, maxChars);
 	}
 
+	getBufferWithPid(pid: number, maxChars?: number): string {
+		const terminal = this.terminals.find(async t => await t.processId === pid);
+		if (terminal) {
+			return this.getBufferForTerminal(terminal, maxChars);
+		}
+		return '';
+	}
+
 	getLastCommandForTerminal(terminal: Terminal): TerminalExecutedCommand | undefined {
 		return getLastCommandForTerminal(terminal);
 	}

--- a/src/platform/terminal/vscode/terminalServiceImpl.ts
+++ b/src/platform/terminal/vscode/terminalServiceImpl.ts
@@ -152,8 +152,15 @@ export class TerminalServiceImpl extends Disposable implements ITerminalService 
 		return getBufferForTerminal(terminal, maxChars);
 	}
 
-	getBufferWithPid(pid: number, maxChars?: number): string {
-		const terminal = this.terminals.find(async t => await t.processId === pid);
+	async getBufferWithPid(pid: number, maxChars?: number): Promise<string> {
+		let terminal: Terminal | undefined;
+		for (const t of this.terminals) {
+			const tPid = await t.processId;
+			if (tPid === pid) {
+				terminal = t;
+				break;
+			}
+		}
 		if (terminal) {
 			return this.getBufferForTerminal(terminal, maxChars);
 		}

--- a/src/platform/test/node/simulationWorkspaceServices.ts
+++ b/src/platform/test/node/simulationWorkspaceServices.ts
@@ -825,6 +825,9 @@ export class TestingTerminalService extends Disposable implements ITerminalServi
 	getBufferForTerminal(terminal: vscode.Terminal, maxChars?: number): string {
 		return '';
 	}
+	getBufferWithPid(pid: number, maxChars?: number): string {
+		throw new Error('Method not implemented.');
+	}
 }
 
 class SimulationTerminal extends Disposable implements vscode.Terminal {

--- a/src/platform/test/node/simulationWorkspaceServices.ts
+++ b/src/platform/test/node/simulationWorkspaceServices.ts
@@ -825,7 +825,7 @@ export class TestingTerminalService extends Disposable implements ITerminalServi
 	getBufferForTerminal(terminal: vscode.Terminal, maxChars?: number): string {
 		return '';
 	}
-	getBufferWithPid(pid: number, maxChars?: number): string {
+	getBufferWithPid(pid: number, maxChars?: number): Promise<string> {
 		throw new Error('Method not implemented.');
 	}
 }


### PR DESCRIPTION
<img width="436" height="470" alt="Screenshot 2025-07-11 at 3 56 00 PM" src="https://github.com/user-attachments/assets/54d105ff-2114-42a2-b316-4e47b94a6335" />
