### PR TITLE
ignore: add an ignore reason and 'behavioral' ignores

### DIFF
--- a/src/extension/byok/vscode-node/ollamaProvider.ts
+++ b/src/extension/byok/vscode-node/ollamaProvider.ts
@@ -49,7 +49,7 @@ export class OllamaModelRegistry extends BaseOpenAICompatibleBYOKRegistry {
 		try {
 			// Check Ollama server version before proceeding with model operations
 			await this._checkOllamaVersion();
-			
+
 			const response = await this._fetcherService.fetch(`${this._ollamaBaseUrl}/api/tags`, { method: 'GET' });
 			const models = (await response.json()).models;
 			return models.map((model: { model: string; name: string }) => ({ id: model.model, name: model.name }));
@@ -97,7 +97,7 @@ export class OllamaModelRegistry extends BaseOpenAICompatibleBYOKRegistry {
 		try {
 			const response = await this._fetcherService.fetch(`${this._ollamaBaseUrl}/api/version`, { method: 'GET' });
 			const versionInfo = await response.json() as OllamaVersionResponse;
-			
+
 			if (!this._isVersionSupported(versionInfo.version)) {
 				throw new Error(
 					`Ollama server version ${versionInfo.version} is not supported. ` +
@@ -127,11 +127,11 @@ export class OllamaModelRegistry extends BaseOpenAICompatibleBYOKRegistry {
 		// Simple version comparison: split by dots and compare numerically
 		const currentParts = currentVersion.split('.').map(n => parseInt(n, 10));
 		const minimumParts = MINIMUM_OLLAMA_VERSION.split('.').map(n => parseInt(n, 10));
-		
+
 		for (let i = 0; i < Math.max(currentParts.length, minimumParts.length); i++) {
 			const current = currentParts[i] || 0;
 			const minimum = minimumParts[i] || 0;
-			
+
 			if (current > minimum) {
 				return true;
 			}
@@ -139,7 +139,7 @@ export class OllamaModelRegistry extends BaseOpenAICompatibleBYOKRegistry {
 				return false;
 			}
 		}
-		
+
 		return true; // versions are equal
 	}
 }

--- a/src/extension/ignore/vscode-node/ignoreProvider.ts
+++ b/src/extension/ignore/vscode-node/ignoreProvider.ts
@@ -15,7 +15,7 @@ class IgnoredFileProvider implements vscode.LanguageModelIgnoredFileProvider {
 	) { }
 
 	provideFileIgnored(uri: vscode.Uri, token: vscode.CancellationToken): vscode.ProviderResult<boolean> {
-		return this._ignoreService.isCopilotIgnored(uri);
+		return !!this._ignoreService.isCopilotIgnored(uri);
 	}
 }
 

--- a/src/extension/intents/node/testIntent/summarizedDocumentWithSelection.tsx
+++ b/src/extension/intents/node/testIntent/summarizedDocumentWithSelection.tsx
@@ -17,6 +17,7 @@ import { ServicesAccessor } from '../../../../util/vs/platform/instantiation/com
 import { getStructure } from '../../../context/node/resolvers/selectionContextHelpers';
 import { EarlyStopping, LeadingMarkdownStreaming, ReplyInterpreter, ReplyInterpreterMetaData } from '../../../prompt/node/intents';
 import { TextPieceClassifiers } from '../../../prompt/node/streamingEdits';
+import { IgnoredFiles } from '../../../prompts/node/base/ignoredFiles';
 import { Tag } from '../../../prompts/node/base/tag';
 import { getAdjustedSelection } from '../../../prompts/node/inline/adjustSelection';
 import { MarkdownBlock } from '../../../prompts/node/inline/inlineChatGenerateMarkdownPrompt';
@@ -156,7 +157,7 @@ export class SummarizedDocumentWithSelection extends PromptElement<SummarizedDoc
 		const isIgnored = await this.ignoreService.isCopilotIgnored(documentData.document.uri);
 
 		if (isIgnored) {
-			return <ignoredFiles value={[documentData.document.uri]} />;
+			return <IgnoredFiles uris={documentData.document.uri} reason={isIgnored} />;
 		}
 
 		let { tokenBudget } = this.props;

--- a/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -12,7 +12,7 @@ import { CanceledResult, ChatFetchResponseType, ChatLocation, ChatResponse, getE
 import { IConversationOptions } from '../../../platform/chat/common/conversationOptions';
 import { IEditSurvivalTrackerService, IEditSurvivalTrackingSession, NullEditSurvivalTrackingSession } from '../../../platform/editSurvivalTracking/common/editSurvivalTrackerService';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
-import { HAS_IGNORED_FILES_MESSAGE } from '../../../platform/ignore/common/ignoreService';
+import { HAS_IGNORED_FILES_MESSAGE, IgnoreReason } from '../../../platform/ignore/common/ignoreService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { FinishedCallback, OptionalChatRequestParams } from '../../../platform/networking/common/fetch';
 import { IRequestLogger } from '../../../platform/requestLogger/node/requestLogger';
@@ -132,7 +132,7 @@ export class DefaultIntentRequestHandler {
 				chatResult.errorDetails = intentInvocation.modifyErrorDetails(chatResult.errorDetails, resultDetails.response);
 			}
 
-			if (resultDetails.hadIgnoredFiles) {
+			if (resultDetails.hadIgnoredFiles === IgnoreReason.ContentExclusion) {
 				this.stream.markdown(HAS_IGNORED_FILES_MESSAGE);
 			}
 
@@ -468,7 +468,7 @@ interface IInternalRequestResult {
 	response: ChatResponse;
 	round: IToolCallRound;
 	chatResult?: ChatResult; // TODO should just be metadata
-	hadIgnoredFiles: boolean;
+	hadIgnoredFiles: IgnoreReason;
 	lastRequestMessages: Raw.ChatMessage[];
 	lastRequestTelemetry: ChatTelemetry;
 	availableToolCount: number;

--- a/src/extension/prompts/node/agent/agentPrompt.tsx
+++ b/src/extension/prompts/node/agent/agentPrompt.tsx
@@ -11,6 +11,7 @@ import { ConfigKey, IConfigurationService } from '../../../../platform/configura
 import { CacheType } from '../../../../platform/endpoint/common/endpointTypes';
 import { IEnvService, OperatingSystem } from '../../../../platform/env/common/envService';
 import { getGitHubRepoInfoFromContext, IGitService } from '../../../../platform/git/common/gitService';
+import { IIgnoreService } from '../../../../platform/ignore/common/ignoreService';
 import { ILogService } from '../../../../platform/log/common/logService';
 import { IChatEndpoint } from '../../../../platform/networking/common/networking';
 import { IAlternativeNotebookContentService } from '../../../../platform/notebook/common/alternativeContent';
@@ -410,6 +411,7 @@ class CurrentEditorContext extends PromptElement<CurrentEditorContextProps> {
 		@IPromptPathRepresentationService private readonly promptPathRepresentationService: IPromptPathRepresentationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IAlternativeNotebookContentService private readonly alternativeNotebookContent: IAlternativeNotebookContentService,
+		@IIgnoreService private readonly ignoreService: IIgnoreService,
 	) {
 		super(props);
 	}
@@ -421,12 +423,12 @@ class CurrentEditorContext extends PromptElement<CurrentEditorContextProps> {
 
 		let context: PromptElement | undefined;
 		const activeEditor = this.tabsAndEditorsService.activeTextEditor;
-		if (activeEditor) {
+		if (activeEditor && !(await this.ignoreService.isCopilotIgnored(this.tabsAndEditorsService.activeTextEditor.document.uri))) {
 			context = this.renderActiveTextEditor(activeEditor);
 		}
 
 		const activeNotebookEditor = this.tabsAndEditorsService.activeNotebookEditor;
-		if (activeNotebookEditor) {
+		if (activeNotebookEditor && !(await this.ignoreService.isCopilotIgnored(activeNotebookEditor.notebook.uri))) {
 			context = this.renderActiveNotebookEditor(activeNotebookEditor);
 		}
 

--- a/src/extension/prompts/node/base/ignoredFiles.tsx
+++ b/src/extension/prompts/node/base/ignoredFiles.tsx
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BasePromptElementProps, PromptElement } from '@vscode/prompt-tsx';
+import { URI } from '@vscode/prompt-tsx/dist/base/util/vs/common/uri';
+import { IgnoredMetadata, IgnoreReason } from '../../../../platform/ignore/common/ignoreService';
+
+export class IgnoredFiles extends PromptElement<BasePromptElementProps & { uris: URI | URI[]; reason: IgnoreReason }> {
+	override render() {
+		const uris = Array.isArray(this.props.uris) ? this.props.uris : [this.props.uris];
+		if (this.props.reason === IgnoreReason.NotIgnored || !uris.length) {
+			return;
+		}
+
+		return <>
+			<ignoredFiles value={Array.isArray(this.props.uris) ? this.props.uris : [this.props.uris]} />
+			<meta value={new IgnoredMetadata(this.props.reason, uris)} />
+		</>;
+	}
+}

--- a/src/extension/prompts/node/codeMapper/codeMapperPrompt.tsx
+++ b/src/extension/prompts/node/codeMapper/codeMapperPrompt.tsx
@@ -16,6 +16,7 @@ import { IInstantiationService } from '../../../../util/vs/platform/instantiatio
 import { Uri } from '../../../../vscodeTypes';
 import { getStructure } from '../../../context/node/resolvers/selectionContextHelpers';
 import { CompositeElement } from '../base/common';
+import { IgnoredFiles } from '../base/ignoredFiles';
 import { ResponseTranslationRules } from '../base/responseTranslationRules';
 import { LegacySafetyRules } from '../base/safetyRules';
 import { Tag } from '../base/tag';
@@ -54,7 +55,7 @@ export class CodeMapperPatchRewritePrompt extends PromptElement<CodeMapperPrompt
 
 		const isIgnored = await this.ignoreService.isCopilotIgnored(document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[document.uri]} />;
+			return <IgnoredFiles uris={document.uri} reason={isIgnored} />;
 		}
 
 		const inputDocCharLimit = (sizing.endpoint.modelMaxPromptTokens / 3) * 4; // consume one 3rd of the model window, estimating roughly 4 chars per token;
@@ -234,7 +235,7 @@ export class CodeMapperFullRewritePrompt extends PromptElement<CodeMapperPromptP
 		const document = this.props.request.existingDocument;
 		const isIgnored = await this.ignoreService.isCopilotIgnored(document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[document.uri]} />;
+			return <IgnoredFiles uris={document.uri} reason={isIgnored} />;
 		}
 
 		const summarized = document instanceof NotebookDocumentSnapshot ?

--- a/src/extension/prompts/node/inline/diagnosticsContext.tsx
+++ b/src/extension/prompts/node/inline/diagnosticsContext.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { BasePromptElementProps, PromptElement, PromptReference, PromptSizing } from '@vscode/prompt-tsx';
 import { TextDocumentSnapshot } from '../../../../platform/editing/common/textDocumentSnapshot';
-import { IIgnoreService } from '../../../../platform/ignore/common/ignoreService';
+import { IgnoreReason, IIgnoreService } from '../../../../platform/ignore/common/ignoreService';
 import { ILogService } from '../../../../platform/log/common/logService';
 import { IParserService, treeSitterOffsetRangeToVSCodeRange, treeSitterToVSCodeRange, vscodeToTreeSitterOffsetRange, vscodeToTreeSitterRange } from '../../../../platform/parser/node/parserService';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry';
@@ -12,6 +12,7 @@ import { IWorkspaceService } from '../../../../platform/workspace/common/workspa
 import { Diagnostic, Location, Range, Uri } from '../../../../vscodeTypes';
 import { asyncComputeWithTimeBudget } from '../../../context/node/resolvers/selectionContextHelpers';
 import { IDocumentContext } from '../../../prompt/node/documentContext';
+import { IgnoredFiles } from '../base/ignoredFiles';
 import { Tag } from '../base/tag';
 import { ReferencesAtPosition } from '../panel/referencesAtPosition';
 import { CodeBlock } from '../panel/safeElements';
@@ -44,7 +45,7 @@ export class Diagnostics extends PromptElement<DiagnosticsProps> {
 		const { diagnostics, documentContext } = this.props;
 		const isIgnored = await this.ignoreService.isCopilotIgnored(documentContext.document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[documentContext.document.uri]} />;
+			return <IgnoredFiles uris={documentContext.document.uri} reason={isIgnored} />;
 		}
 
 		return (
@@ -141,7 +142,7 @@ export class DiagnosticRelatedInfo extends PromptElement<DiagnosticRelatedInfoPr
 	async render(_state: void, sizing: PromptSizing) {
 		const { infos, ignoredFiles, definitionRanges } = await this.getRelatedInfos();
 		if (!infos.length && !definitionRanges.length) {
-			return <ignoredFiles value={ignoredFiles} />;
+			return <IgnoredFiles uris={ignoredFiles} reason={IgnoreReason.ContentExclusion} />;
 		}
 		return <>
 			This diagnostic has some related code:<br />
@@ -151,7 +152,7 @@ export class DiagnosticRelatedInfo extends PromptElement<DiagnosticRelatedInfoPr
 			{
 				definitionRanges.map(range => <ReferencesAtPosition document={this.props.document} position={range.start} />)
 			}
-			<ignoredFiles value={ignoredFiles} />
+			<IgnoredFiles uris={ignoredFiles} reason={IgnoreReason.ContentExclusion} />
 		</>;
 	}
 

--- a/src/extension/prompts/node/inline/inlineChatEditCodePrompt.tsx
+++ b/src/extension/prompts/node/inline/inlineChatEditCodePrompt.tsx
@@ -16,6 +16,7 @@ import { GenericInlinePromptProps } from '../../../context/node/resolvers/generi
 import { SelectionSplitKind, SummarizedDocumentData, SummarizedDocumentWithSelection } from '../../../intents/node/testIntent/summarizedDocumentWithSelection';
 import { EarlyStopping, LeadingMarkdownStreaming } from '../../../prompt/node/intents';
 import { TextPieceClassifiers } from '../../../prompt/node/streamingEdits';
+import { IgnoredFiles } from '../base/ignoredFiles';
 import { InstructionMessage } from '../base/instructionMessage';
 import { LegacySafetyRules } from '../base/safetyRules';
 import { Tag } from '../base/tag';
@@ -57,7 +58,7 @@ export class InlineChatEditCodePrompt extends PromptElement<InlineChatEditCodePr
 
 		const isIgnored = await this._ignoreService.isCopilotIgnored(document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[document.uri]} />;
+			return <IgnoredFiles uris={document.uri} reason={isIgnored} />;
 		}
 		const { query, history, chatVariables, } = this.props.promptContext;
 

--- a/src/extension/prompts/node/inline/inlineChatEditMarkdownPrompt.tsx
+++ b/src/extension/prompts/node/inline/inlineChatEditMarkdownPrompt.tsx
@@ -12,6 +12,7 @@ import { GenericInlinePromptProps } from '../../../context/node/resolvers/generi
 import { SelectionSplitKind, SummarizedDocumentData, SummarizedDocumentWithSelection } from '../../../intents/node/testIntent/summarizedDocumentWithSelection';
 import { EarlyStopping, LeadingMarkdownStreaming } from '../../../prompt/node/intents';
 import { TextPieceClassifiers } from '../../../prompt/node/streamingEdits';
+import { IgnoredFiles } from '../base/ignoredFiles';
 import { InstructionMessage } from '../base/instructionMessage';
 import { LegacySafetyRules } from '../base/safetyRules';
 import { Tag } from '../base/tag';
@@ -49,7 +50,7 @@ export class InlineChatEditMarkdownPrompt extends PromptElement<InlineChatEditMa
 
 		const isIgnored = await this._ignoreService.isCopilotIgnored(context.document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[this.props.documentContext.document.uri]} />;
+			return <IgnoredFiles uris={this.props.documentContext.document.uri} reason={isIgnored} />;
 		}
 
 		const data = await this._instantiationService.invokeFunction(SummarizedDocumentData.create,

--- a/src/extension/prompts/node/inline/inlineChatFix3Prompt.tsx
+++ b/src/extension/prompts/node/inline/inlineChatFix3Prompt.tsx
@@ -28,6 +28,7 @@ import { getStructure } from '../../../context/node/resolvers/selectionContextHe
 import { OutcomeAnnotation, OutcomeAnnotationLabel } from '../../../inlineChat/node/promptCraftingTypes';
 import { IResponseProcessorContext, ReplyInterpreter, ReplyInterpreterMetaData } from '../../../prompt/node/intents';
 import { CompositeElement } from '../base/common';
+import { IgnoredFiles } from '../base/ignoredFiles';
 import { InstructionMessage } from '../base/instructionMessage';
 import { LegacySafetyRules } from '../base/safetyRules';
 import { Tag } from '../base/tag';
@@ -61,7 +62,7 @@ export class InlineFix3Prompt extends PromptElement<InlineFixProps> {
 		const { document, wholeRange, fileIndentInfo, selection, language } = this.props.documentContext;
 		const isIgnored = await this.ignoreService.isCopilotIgnored(document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[document.uri]} />;
+			return <IgnoredFiles uris={document.uri} reason={isIgnored} />;
 		}
 		if (isNotebookCellOrNotebookChatInput(document.uri)) {
 			throw illegalArgument('InlineFix3PlusPrompt should not be used with a notebook!');

--- a/src/extension/prompts/node/inline/inlineChatGenerateCodePrompt.tsx
+++ b/src/extension/prompts/node/inline/inlineChatGenerateCodePrompt.tsx
@@ -16,6 +16,7 @@ import { GenericInlinePromptProps } from '../../../context/node/resolvers/generi
 import { SelectionSplitKind, SummarizedDocumentData, SummarizedDocumentWithSelection } from '../../../intents/node/testIntent/summarizedDocumentWithSelection';
 import { EarlyStopping, LeadingMarkdownStreaming } from '../../../prompt/node/intents';
 import { TextPieceClassifiers } from '../../../prompt/node/streamingEdits';
+import { IgnoredFiles } from '../base/ignoredFiles';
 import { InstructionMessage } from '../base/instructionMessage';
 import { LegacySafetyRules } from '../base/safetyRules';
 import { Tag } from '../base/tag';
@@ -57,7 +58,7 @@ export class InlineChatGenerateCodePrompt extends PromptElement<InlineChatGenera
 
 		const isIgnored = await this._ignoreService.isCopilotIgnored(document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[document.uri]} />;
+			return <IgnoredFiles uris={document.uri} reason={isIgnored} />;
 		}
 
 		const { query, history, chatVariables, } = this.props.promptContext;

--- a/src/extension/prompts/node/inline/inlineChatGenerateMarkdownPrompt.tsx
+++ b/src/extension/prompts/node/inline/inlineChatGenerateMarkdownPrompt.tsx
@@ -14,6 +14,7 @@ import { GenericInlinePromptProps } from '../../../context/node/resolvers/generi
 import { SelectionSplitKind, SummarizedDocumentData, SummarizedDocumentWithSelection } from '../../../intents/node/testIntent/summarizedDocumentWithSelection';
 import { EarlyStopping, LeadingMarkdownStreaming } from '../../../prompt/node/intents';
 import { TextPieceClassifiers } from '../../../prompt/node/streamingEdits';
+import { IgnoredFiles } from '../base/ignoredFiles';
 import { InstructionMessage } from '../base/instructionMessage';
 import { LegacySafetyRules } from '../base/safetyRules';
 import { Tag } from '../base/tag';
@@ -52,7 +53,7 @@ export class InlineChatGenerateMarkdownPrompt extends PromptElement<InlineChatGe
 
 		const isIgnored = await this._ignoreService.isCopilotIgnored(context.document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[this.props.documentContext.document.uri]} />;
+			return <IgnoredFiles uris={this.props.documentContext.document.uri} reason={isIgnored} />;
 		}
 
 		const { query, history, chatVariables, } = this.props.promptContext;

--- a/src/extension/prompts/node/inline/inlineChatNotebookCommonPromptElements.tsx
+++ b/src/extension/prompts/node/inline/inlineChatNotebookCommonPromptElements.tsx
@@ -6,6 +6,7 @@
 import { BasePromptElementProps, PromptElement, PromptElementProps, PromptSizing, TextChunk, TokenLimit, UserMessage } from '@vscode/prompt-tsx';
 import type * as vscode from 'vscode';
 import { TextDocumentSnapshot } from '../../../../platform/editing/common/textDocumentSnapshot';
+import { IgnoreReason } from '../../../../platform/ignore/common/ignoreService';
 import { INotebookService, PipPackage, VariablesResult } from '../../../../platform/notebook/common/notebookService';
 import { ITabsAndEditorsService } from '../../../../platform/tabs/common/tabsAndEditorsService';
 import { IWorkspaceService } from '../../../../platform/workspace/common/workspaceService';
@@ -24,7 +25,7 @@ import { ProjectedDocument } from './summarizedDocument/summarizeDocument';
 
 export interface InlineChatNotebookBasePromptState {
 	summarizedDocument: PromptingSummarizedDocument;
-	isIgnored: boolean;
+	isIgnored: IgnoreReason;
 	priorities: NotebookPromptPriority;
 	tagBasedDocumentSummary: boolean;
 }

--- a/src/extension/prompts/node/inline/inlineChatNotebookEditPrompt.tsx
+++ b/src/extension/prompts/node/inline/inlineChatNotebookEditPrompt.tsx
@@ -28,6 +28,7 @@ import { InlineChatEditCodePromptProps } from './inlineChatEditCodePrompt';
 import { promptPriorities } from './inlineChatNotebookCommon';
 import { generateSelectionContextInNotebook, InlineChatCustomNotebookCellsContextRenderer, InlineChatCustomNotebookInfoRenderer, InlineChatJupyterNotebookCellsContextRenderer, InlineChatNotebookBasePromptState, InlineChatNotebookSelectionCommonProps, InlineChatNotebookSelectionState, InlineChatNotebookVariables } from './inlineChatNotebookCommonPromptElements';
 import { createPromptingSummarizedDocument } from './promptingSummarizedDocument';
+import { IgnoredFiles } from '../base/ignoredFiles';
 
 interface InlineChatNotebookEditSelectionProps extends InlineChatNotebookSelectionCommonProps {
 	hasCodeWithoutSelection: boolean;
@@ -200,7 +201,7 @@ export class InlineChatNotebookEditPrompt extends PromptElement<InlineChatEditCo
 			throw illegalArgument('InlineChatNotebookEditPrompt should be used only with a notebook!');
 		}
 		if (state.isIgnored) {
-			return <ignoredFiles value={[context.document.uri]} />;
+			return <IgnoredFiles uris={context.document.uri} reason={state.isIgnored} />;
 		}
 
 		const tagBasedDocumentSummary = state.tagBasedDocumentSummary;

--- a/src/extension/prompts/node/inline/inlineChatNotebookFixPrompt.tsx
+++ b/src/extension/prompts/node/inline/inlineChatNotebookFixPrompt.tsx
@@ -6,7 +6,7 @@
 import { BasePromptElementProps, PromptElement, PromptSizing, SystemMessage, UserMessage } from '@vscode/prompt-tsx';
 import type * as vscode from 'vscode';
 import { TextDocumentSnapshot } from '../../../../platform/editing/common/textDocumentSnapshot';
-import { IIgnoreService } from '../../../../platform/ignore/common/ignoreService';
+import { IgnoreReason, IIgnoreService } from '../../../../platform/ignore/common/ignoreService';
 import { ILanguageDiagnosticsService, rangeSpanningDiagnostics } from '../../../../platform/languages/common/languageDiagnosticsService';
 import { IParserService } from '../../../../platform/parser/node/parserService';
 import { ITabsAndEditorsService } from '../../../../platform/tabs/common/tabsAndEditorsService';
@@ -26,6 +26,7 @@ import { CodeContextRegion } from '../../../inlineChat/node/codeContextRegion';
 import { IDocumentContext } from '../../../prompt/node/documentContext';
 import { ReplyInterpreterMetaData } from '../../../prompt/node/intents';
 import { CompositeElement } from '../base/common';
+import { IgnoredFiles } from '../base/ignoredFiles';
 import { InstructionMessage } from '../base/instructionMessage';
 import { IPromptEndpoint } from '../base/promptRenderer';
 import { LegacySafetyRules } from '../base/safetyRules';
@@ -44,7 +45,7 @@ import { summarizeDocumentSync } from './summarizedDocument/summarizeDocumentHel
 
 const FIX_SELECTION_LENGTH_THRESHOLD = 15;
 interface InlineChatNotebookFixPromptState {
-	isIgnored: boolean;
+	isIgnored: IgnoreReason;
 	priorities: NotebookPromptPriority;
 }
 
@@ -82,7 +83,7 @@ export class InlineFixNotebookPrompt extends PromptElement<InlineFixProps, Inlin
 		}
 
 		if (state.isIgnored) {
-			return <ignoredFiles value={[documentContext.document.uri]} />;
+			return <IgnoredFiles uris={documentContext.document.uri} reason={state.isIgnored} />;
 		}
 
 		const { query, history, chatVariables } = this.props.promptContext;

--- a/src/extension/prompts/node/panel/currentEditor.tsx
+++ b/src/extension/prompts/node/panel/currentEditor.tsx
@@ -15,6 +15,7 @@ import { Schemas } from '../../../../util/vs/base/common/network';
 import * as path from '../../../../util/vs/base/common/path';
 import { Position, Range } from '../../../../vscodeTypes';
 import { PromptReference } from '../../../prompt/common/conversation';
+import { IgnoredFiles } from '../base/ignoredFiles';
 import { IPromptEndpoint } from '../base/promptRenderer';
 import { CodeBlock } from './safeElements';
 
@@ -57,7 +58,7 @@ export class CurrentEditor extends PromptElement<CurrentEditorPromptProps> {
 
 		const isIgnored = await this._ignoreService.isCopilotIgnored(document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[document.uri]} />;
+			return <IgnoredFiles uris={document.uri} reason={isIgnored} />;
 		}
 
 		if (document.getText().trim().length === 0) {
@@ -101,7 +102,7 @@ export class CurrentEditor extends PromptElement<CurrentEditorPromptProps> {
 		const document = NotebookDocumentSnapshot.create(notebook, format);
 		const isIgnored = await this._ignoreService.isCopilotIgnored(document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[document.uri]} />;
+			return <IgnoredFiles uris={document.uri} reason={isIgnored} />;
 		}
 
 		if (document.getText().trim().length === 0) {
@@ -144,7 +145,7 @@ export class CurrentEditor extends PromptElement<CurrentEditorPromptProps> {
 		const document = NotebookDocumentSnapshot.create(editor.notebook, format);
 		const isIgnored = await this._ignoreService.isCopilotIgnored(document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[document.uri]} />;
+			return <IgnoredFiles uris={document.uri} reason={isIgnored} />;
 		}
 
 		if (document.getText().trim().length === 0) {

--- a/src/extension/prompts/node/panel/editCodePrompt.tsx
+++ b/src/extension/prompts/node/panel/editCodePrompt.tsx
@@ -28,6 +28,7 @@ import { Turn } from '../../../prompt/common/conversation';
 import { INotebookWorkingSetEntry, isTextDocumentWorkingSetEntry, ITextDocumentWorkingSetEntry, IWorkingSet, WorkingSetEntryState } from '../../../prompt/common/intents';
 import { CompositeElement } from '../base/common';
 import { CopilotIdentityRules } from '../base/copilotIdentity';
+import { IgnoredFiles } from '../base/ignoredFiles';
 import { InstructionMessage } from '../base/instructionMessage';
 import { ResponseTranslationRules } from '../base/responseTranslationRules';
 import { LegacySafetyRules } from '../base/safetyRules';
@@ -392,7 +393,7 @@ export class TextDocumentWorkingSetEntry extends PromptElement<TextDocumentWorki
 
 		const isIgnored = await this._ignoreService.isCopilotIgnored(document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[document.uri]} />;
+			return <IgnoredFiles uris={document.uri} reason={isIgnored} />;
 		}
 
 		const s = this.instantiationService.createInstance(DocumentSummarizer);
@@ -453,7 +454,7 @@ export class NotebookWorkingSetEntry extends PromptElement<NotebookWorkingSetEnt
 
 		const isIgnored = await this._ignoreService.isCopilotIgnored(document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[document.uri]} />;
+			return <IgnoredFiles uris={document.uri} reason={isIgnored} />;
 		}
 
 		// TODO@rebornix ensure notebook is open
@@ -522,7 +523,7 @@ class FileSelection extends PromptElement<CurrentFileSelectionPromptProps> {
 
 		const isIgnored = await this._ignoreService.isCopilotIgnored(document.uri);
 		if (isIgnored) {
-			return <ignoredFiles value={[document.uri]} />;
+			return <IgnoredFiles uris={document.uri} reason={isIgnored} />;
 		}
 
 		if (document.lineCount >= 4) {

--- a/src/extension/prompts/node/panel/fileVariable.tsx
+++ b/src/extension/prompts/node/panel/fileVariable.tsx
@@ -23,6 +23,7 @@ import { basename } from '../../../../util/vs/base/common/resources';
 import { splitLines } from '../../../../util/vs/base/common/strings';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { Location, Position, Range, Uri } from '../../../../vscodeTypes';
+import { IgnoredFiles } from '../base/ignoredFiles';
 import { IPromptEndpoint } from '../base/promptRenderer';
 import { Tag } from '../base/tag';
 import { SummarizedDocumentLineNumberStyle } from '../inline/summarizedDocument/implementation';
@@ -56,8 +57,9 @@ export class FileVariable extends PromptElement<FileVariableProps, unknown> {
 	override async render(_state: unknown, sizing: PromptSizing) {
 		const uri = 'uri' in this.props.variableValue ? this.props.variableValue.uri : this.props.variableValue;
 
-		if (await this.ignoreService.isCopilotIgnored(uri)) {
-			return <ignoredFiles value={[uri]} />;
+		const ignored = await this.ignoreService.isCopilotIgnored(uri);
+		if (ignored) {
+			return <IgnoredFiles uris={uri} reason={ignored} />;
 		}
 
 		if (uri.scheme === 'untitled' && !this.workspaceService.textDocuments.some(doc => doc.uri.toString() === uri.toString())) {

--- a/src/extension/prompts/node/panel/referencesAtPosition.tsx
+++ b/src/extension/prompts/node/panel/referencesAtPosition.tsx
@@ -19,6 +19,7 @@ import { ExtensionMode, Location, Selection, Uri } from '../../../../vscodeTypes
 import { asyncComputeWithTimeBudget } from '../../../context/node/resolvers/selectionContextHelpers';
 import { determineNodeToDocument } from '../../../prompt/node/definitionAroundCursor';
 import { CodeBlock } from './safeElements';
+import { IgnoredFiles } from '../base/ignoredFiles';
 
 type Props = PromptElementProps<{
 	document: TextDocumentSnapshot;
@@ -60,8 +61,9 @@ export class ReferencesAtPosition extends PromptElement<Props> {
 	}
 
 	async render(state: void, sizing: PromptSizing) {
-		if (await this.ignoreService.isCopilotIgnored(this.props.document.uri)) {
-			return <ignoredFiles value={[this.props.document.uri]} />;
+		const ignored = await this.ignoreService.isCopilotIgnored(this.props.document.uri);
+		if (ignored) {
+			return <IgnoredFiles uris={this.props.document.uri} reason={ignored} />;
 		}
 
 		const timeout = this.extensionContext.extensionMode === ExtensionMode.Test


### PR DESCRIPTION
This can be used to ignore files that aren't content-excluded, but otherwise should never end up in prompts, such as diff editors of previously-made edits.

Fixes https://github.com/microsoft/vscode/issues/254172