### PR TITLE
Fix BYOK Quota exceeded caused by Intent Detection with Copilot model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ coverage/
 test/simulation/cache/_base.sqlite
 
 test/aml/out
+
+# From the Booksmarks vscode extension
+.vscode/bookmarks.json

--- a/package.json
+++ b/package.json
@@ -2121,6 +2121,13 @@
 				"enablement": "github.copilot.byokEnabled"
 			},
 			{
+				"command": "github.copilot.chat.manageIntentDetectionModel",
+				"title": "Choose Intent Detection Model...",
+				"icon": "$(settings-gear)",
+				"category": "GitHub Copilot",
+				"enablement": "github.copilot.byokEnabled"
+			},
+			{
 				"command": "github.copilot.chat.debug.showElements",
 				"title": "Show Rendered Elements"
 			},

--- a/src/extension/byok/common/byokProvider.ts
+++ b/src/extension/byok/common/byokProvider.ts
@@ -110,6 +110,7 @@ export function resolveModelInfo(modelId: string, providerName: string, knownMod
 	return {
 		id: modelId,
 		name: modelName,
+		vendor: 'copilot-byok',
 		version: '1.0.0',
 		capabilities: {
 			type: 'chat',

--- a/src/extension/byok/common/byokProvider.ts
+++ b/src/extension/byok/common/byokProvider.ts
@@ -6,6 +6,7 @@ import type { ChatResponseProviderMetadata, Disposable } from 'vscode';
 import { CopilotToken } from '../../../platform/authentication/common/copilotToken';
 import { ICAPIClientService } from '../../../platform/endpoint/common/capiClient';
 import { IChatModelInformation } from '../../../platform/endpoint/common/endpointProvider';
+import { IChatEndpoint } from '../../../platform/networking/common/networking';
 import { TokenizerType } from '../../../util/common/tokenizer';
 import { localize } from '../../../util/vs/nls';
 
@@ -58,6 +59,7 @@ export interface BYOKModelRegistry {
 	updateKnownModelsList(knownModels: BYOKKnownModels | undefined): void;
 	getAllModels(apiKey?: string): Promise<{ id: string; name: string }[]>;
 	registerModel(config: BYOKModelConfig): Promise<Disposable>;
+	createEndpoint(config: BYOKModelConfig): Promise<IChatEndpoint | undefined>;
 }
 
 // Many model providers don't have robust model lists. This allows us to map id -> information about models, and then if we don't know the model just let the user enter a custom id

--- a/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -6,6 +6,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { CancellationToken, ChatResponseFragment2, ChatResponseProviderMetadata, Disposable, LanguageModelChatMessage, LanguageModelChatProvider, LanguageModelChatRequestOptions, LanguageModelTextPart, LanguageModelToolCallPart, lm, Progress } from 'vscode';
 import { ChatFetchResponseType, ChatLocation } from '../../../platform/chat/common/commonTypes';
+import { ChatEndpoint } from '../../../platform/endpoint/node/chatEndpoint';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IResponseDelta, OpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { APIUsage, rawMessageToCAPI } from '../../../platform/networking/common/openai';
@@ -26,6 +27,11 @@ export class AnthropicBYOKModelRegistry implements BYOKModelRegistry {
 		@ILogService private readonly _logService: ILogService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) { }
+
+	async createEndpoint(config: BYOKModelConfig): Promise<ChatEndpoint | undefined> {
+		// Doesn't define an implementation of Endpoint
+		return undefined;
+	}
 
 	async getAllModels(apiKey: string): Promise<{ id: string; name: string }[]> {
 		try {

--- a/src/extension/byok/vscode-node/byokUIService.ts
+++ b/src/extension/byok/vscode-node/byokUIService.ts
@@ -778,4 +778,28 @@ export class BYOKUIService {
 
 		return result;
 	}
+
+	public async pickIntentDetectionModel(models: { intentModelName: string }[]): Promise<string | undefined> {
+
+		const items: QuickPickItem[] = models.map(model => ({
+			label: model.intentModelName,
+		}));
+
+		const result = await createQuickPickWithBackButton(
+			items,
+			{
+				title: 'Select Intent Detection Model',
+				placeholder: 'Select a model to use for intent detection. The default for the copilot models is gpt-4o-mini.',
+				includeBackButton: false,
+				ignoreFocusOut: true,
+				canPickMany: false,
+			}
+		);
+
+		if (!result || isBackButtonClick(result)) {
+			return undefined;
+		}
+
+		return result[0].label;
+	}
 }

--- a/src/extension/byok/vscode-node/openRouterProvider.ts
+++ b/src/extension/byok/vscode-node/openRouterProvider.ts
@@ -80,6 +80,7 @@ export class OpenRouterBYOKModelRegistry extends BaseOpenAICompatibleBYOKRegistr
 		const modelInfo: IChatModelInformation = {
 			id: model.id,
 			name: model.name.includes(':') ? model.name : `${this.name}: ${model.name}`,
+			vendor: 'openrouter',
 			version: '1.0.0',
 			capabilities: {
 				type: 'chat',

--- a/src/extension/conversation/vscode-node/remoteAgents.ts
+++ b/src/extension/conversation/vscode-node/remoteAgents.ts
@@ -361,6 +361,7 @@ export class RemoteAgentContribution implements IDisposable {
 					},
 					id: selectedEndpoint.model,
 					name: selectedEndpoint.name,
+					vendor: 'copilot',
 					version: selectedEndpoint.version,
 				}, agentData ? { type: RequestType.RemoteAgentChat, slug: agentData.slug } : { type: RequestType.RemoteAgentChat });
 

--- a/src/extension/extension/vscode-node/services.ts
+++ b/src/extension/extension/vscode-node/services.ts
@@ -77,7 +77,6 @@ import { collectFetcherTelemetry } from '../../log/vscode-node/loggingActions';
 import { DebugCommandToConfigConverter, IDebugCommandToConfigConverter } from '../../onboardDebug/node/commandToConfigConverter';
 import { DebuggableCommandIdentifier, IDebuggableCommandIdentifier } from '../../onboardDebug/node/debuggableCommandIdentifier';
 import { ILanguageToolsProvider, LanguageToolsProvider } from '../../onboardDebug/node/languageToolsProvider';
-import { IIntentDetectionModelManagementService } from '../../prompt/common/intentDetectionModelManagementService';
 import { ChatMLFetcherImpl } from '../../prompt/node/chatMLFetcher';
 import { IFeedbackReporter } from '../../prompt/node/feedbackReporter';
 import { IPromptVariablesService } from '../../prompt/node/promptVariablesService';
@@ -85,7 +84,6 @@ import { DevContainerConfigurationServiceImpl } from '../../prompt/vscode-node/d
 import { ProductionEndpointProvider } from '../../prompt/vscode-node/endpointProviderImpl';
 import { GitCommitMessageServiceImpl } from '../../prompt/vscode-node/gitCommitMessageServiceImpl';
 import { GitDiffService } from '../../prompt/vscode-node/gitDiffService';
-import { IntentDetectionModelManagementService } from '../../prompt/vscode-node/intentDetectionModelManagementService';
 import { PromptVariablesServiceImpl } from '../../prompt/vscode-node/promptVariablesService';
 import { RequestLogger } from '../../prompt/vscode-node/requestLoggerImpl';
 import { SettingsEditorSearchServiceImpl } from '../../prompt/vscode-node/settingsEditorSearchServiceImpl';
@@ -182,7 +180,6 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 	builder.define(IWorkspaceListenerService, new SyncDescriptor(WorkspacListenerService));
 	builder.define(ICodeSearchAuthenticationService, new SyncDescriptor(VsCodeCodeSearchAuthenticationService));
 	builder.define(IThinkingDataService, new SyncDescriptor(ThinkingDataImpl));
-	builder.define(IIntentDetectionModelManagementService, new SyncDescriptor(IntentDetectionModelManagementService));
 }
 
 function setupMSFTExperimentationService(builder: IInstantiationServiceBuilder, extensionContext: ExtensionContext) {

--- a/src/extension/extension/vscode-node/services.ts
+++ b/src/extension/extension/vscode-node/services.ts
@@ -77,6 +77,7 @@ import { collectFetcherTelemetry } from '../../log/vscode-node/loggingActions';
 import { DebugCommandToConfigConverter, IDebugCommandToConfigConverter } from '../../onboardDebug/node/commandToConfigConverter';
 import { DebuggableCommandIdentifier, IDebuggableCommandIdentifier } from '../../onboardDebug/node/debuggableCommandIdentifier';
 import { ILanguageToolsProvider, LanguageToolsProvider } from '../../onboardDebug/node/languageToolsProvider';
+import { IIntentDetectionModelManagementService } from '../../prompt/common/intentDetectionModelManagementService';
 import { ChatMLFetcherImpl } from '../../prompt/node/chatMLFetcher';
 import { IFeedbackReporter } from '../../prompt/node/feedbackReporter';
 import { IPromptVariablesService } from '../../prompt/node/promptVariablesService';
@@ -84,6 +85,7 @@ import { DevContainerConfigurationServiceImpl } from '../../prompt/vscode-node/d
 import { ProductionEndpointProvider } from '../../prompt/vscode-node/endpointProviderImpl';
 import { GitCommitMessageServiceImpl } from '../../prompt/vscode-node/gitCommitMessageServiceImpl';
 import { GitDiffService } from '../../prompt/vscode-node/gitDiffService';
+import { IntentDetectionModelManagementService } from '../../prompt/vscode-node/intentDetectionModelManagementService';
 import { PromptVariablesServiceImpl } from '../../prompt/vscode-node/promptVariablesService';
 import { RequestLogger } from '../../prompt/vscode-node/requestLoggerImpl';
 import { SettingsEditorSearchServiceImpl } from '../../prompt/vscode-node/settingsEditorSearchServiceImpl';
@@ -180,6 +182,7 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 	builder.define(IWorkspaceListenerService, new SyncDescriptor(WorkspacListenerService));
 	builder.define(ICodeSearchAuthenticationService, new SyncDescriptor(VsCodeCodeSearchAuthenticationService));
 	builder.define(IThinkingDataService, new SyncDescriptor(ThinkingDataImpl));
+	builder.define(IIntentDetectionModelManagementService, new SyncDescriptor(IntentDetectionModelManagementService));
 }
 
 function setupMSFTExperimentationService(builder: IInstantiationServiceBuilder, extensionContext: ExtensionContext) {

--- a/src/extension/extension/vscode/services.ts
+++ b/src/extension/extension/vscode/services.ts
@@ -91,6 +91,8 @@ import { IInstantiationServiceBuilder } from '../../../util/common/services';
 import { SyncDescriptor } from '../../../util/vs/platform/instantiation/common/descriptors';
 import { ILaunchConfigService } from '../../onboardDebug/common/launchConfigService';
 import { LaunchConfigService } from '../../onboardDebug/vscode/launchConfigService';
+import { IIntentDetectionModelManagementService } from '../../prompt/common/intentDetectionModelManagementService';
+import { IntentDetectionModelManagementService } from '../../prompt/common/intentDetectionModelManagementServiceImpl';
 
 // ##########################################################################
 // ###                                                                    ###
@@ -160,4 +162,5 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 	builder.define(IInteractiveSessionService, new InteractiveSessionServiceImpl());
 	builder.define(IAuthenticationChatUpgradeService, new SyncDescriptor(AuthenticationChatUpgradeService));
 	builder.define(IEmbeddingsComputer, new SyncDescriptor(RemoteEmbeddingsComputer));
+	builder.define(IIntentDetectionModelManagementService, new SyncDescriptor(IntentDetectionModelManagementService));
 }

--- a/src/extension/prompt/common/intentDetectionModelManagementService.ts
+++ b/src/extension/prompt/common/intentDetectionModelManagementService.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IChatEndpoint } from '../../../platform/networking/common/networking';
+import { createDecorator } from '../../../util/vs/platform/instantiation/common/instantiation';
+
+export const IIntentDetectionModelManagementService = createDecorator<IIntentDetectionModelManagementService>('intentDetectionModelManagementService');
+
+export interface IIntentDetectionModelManagementService {
+	readonly _serviceBrand: undefined;
+	getIntentDetectionModel(modelName: string, modelVendor: string): Promise<IChatEndpoint | undefined>;
+	setIntentDetectionModel(modelName: string, modelVendor: string, intentModelName: string): Promise<IChatEndpoint>;
+	registerIntentDetectionModel(intentModelName: string, intentModelVendor: string, intentModelEndpoint: IChatEndpoint): void;
+	getRegisteredIntentDetectionModels(): { intentModelName: string; intentModelVendor: string; intentModelEndpoint: IChatEndpoint }[];
+
+}

--- a/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -80,7 +80,8 @@ export class ProductionEndpointProvider implements IEndpointProvider {
 		const modelId = modelMetadata.id;
 		let chatEndpoint = this._chatEndpoints.get(modelId);
 		if (!chatEndpoint) {
-			chatEndpoint = this._instantiationService.createInstance(ChatEndpoint, modelMetadata);
+			// Overwrite the vendor information from the API endpoint, e.g Azure OpenAI
+			chatEndpoint = this._instantiationService.createInstance(ChatEndpoint, { ...modelMetadata, vendor: 'copilot' });
 			this._chatEndpoints.set(modelId, chatEndpoint);
 		}
 		return chatEndpoint;
@@ -105,6 +106,7 @@ export class ProductionEndpointProvider implements IEndpointProvider {
 			return this.getOrCreateChatEndpointInstance({
 				id: this._overridenChatModel,
 				name: 'Custom Overriden Chat Model',
+				vendor: 'custom',
 				version: '1.0.0',
 				model_picker_enabled: true,
 				is_chat_default: false,

--- a/src/extension/prompt/vscode-node/intentDetectionModelManagementService.ts
+++ b/src/extension/prompt/vscode-node/intentDetectionModelManagementService.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { commands, window } from 'vscode';
+import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
+import { IChatEndpoint } from '../../../platform/networking/common/networking';
+import { IIntentDetectionModelManagementService } from '../common/intentDetectionModelManagementService';
+
+const INTENT_MODEL_KEY = 'copilot.intentDetectionModel';
+
+export class IntentDetectionModelManagementService implements IIntentDetectionModelManagementService {
+	declare readonly _serviceBrand: undefined;
+	private registeredIntentModels: { [intentModelName: string]: { intentModelEndpoint: IChatEndpoint; intentModelVendor: string } } = {};
+
+	constructor(
+		@IVSCodeExtensionContext private readonly _extensionContext: IVSCodeExtensionContext,
+		@IEndpointProvider private readonly endpointProvider: IEndpointProvider,
+	) { }
+
+	getRegisteredIntentDetectionModels(): { intentModelName: string; intentModelVendor: string; intentModelEndpoint: IChatEndpoint }[] {
+		return Object.entries(this.registeredIntentModels).map(([intentModelName, intentModel]) => ({
+			...intentModel,
+			intentModelName
+		}));
+	}
+
+	registerIntentDetectionModel(intentModelName: string, intentModelVendor: string, intentModelEndpoint: IChatEndpoint): void {
+		this.registeredIntentModels[intentModelName] = { intentModelEndpoint, intentModelVendor };
+	}
+
+	async getIntentDetectionModel(modelName: string, modelVendor: string): Promise<IChatEndpoint | undefined> {
+		if (modelVendor === 'copilot') {
+			return this.endpointProvider.getChatEndpoint('gpt-4o-mini');
+		}
+
+		const intentModel = this._extensionContext.globalState.get<string>(INTENT_MODEL_KEY);
+		if (intentModel === undefined) {
+			// If no intent model is defined for the current chat model, show an error and prompt the user to set one.
+			return await window.showErrorMessage(
+				`An intent detection model must be configured for the current chat model (${modelName}).`,
+				{
+					modal: true,
+					detail: 'Please select a BYOK model to use for intent detection. This helps Copilot understand your requests better.'
+				},
+				'Manage Intent Detection Model'
+			).then(async (selection) => {
+				if (selection === 'Manage Intent Detection Model') {
+					return await commands.executeCommand<Promise<IChatEndpoint | undefined>>('github.copilot.chat.manageIntentDetectionModel');
+				}
+			});
+		}
+
+		return this.registeredIntentModels[intentModel].intentModelEndpoint;
+	}
+
+	async setIntentDetectionModel(modelName: string, modelVendor: string, intentModelName: string): Promise<IChatEndpoint> {
+		await this._extensionContext.globalState.update(INTENT_MODEL_KEY, intentModelName);
+		return this.registeredIntentModels[intentModelName].intentModelEndpoint;
+	}
+}

--- a/src/extension/test/node/notebookPromptRendering.spec.ts
+++ b/src/extension/test/node/notebookPromptRendering.spec.ts
@@ -270,6 +270,7 @@ describe('Notebook Prompt Rendering', function () {
 			tokenizer: TokenizerType.O200K,
 			name: 'Test',
 			family: 'Test',
+			vendor: 'Test',
 			version: 'Test',
 			policy: 'enabled',
 			showInModelPicker: false,

--- a/src/extension/test/node/services.ts
+++ b/src/extension/test/node/services.ts
@@ -28,6 +28,8 @@ import { IWorkspaceChunkSearchService, NullWorkspaceChunkSearchService } from '.
 import { SyncDescriptor } from '../../../util/vs/platform/instantiation/common/descriptors';
 import { CommandServiceImpl, ICommandService } from '../../commands/node/commandService';
 import { ILinkifyService, LinkifyService } from '../../linkify/common/linkifyService';
+import { IIntentDetectionModelManagementService } from '../../prompt/common/intentDetectionModelManagementService';
+import { IntentDetectionModelManagementService } from '../../prompt/common/intentDetectionModelManagementServiceImpl';
 import { IFeedbackReporter, NullFeedbackReporterImpl } from '../../prompt/node/feedbackReporter';
 import { IPromptVariablesService, NullPromptVariablesService } from '../../prompt/node/promptVariablesService';
 import { CodeMapperService, ICodeMapperService } from '../../prompts/node/codeMapper/codeMapperService';
@@ -76,5 +78,6 @@ export function createExtensionUnitTestingServices(modelConfig?: ISimulationMode
 	testingServiceCollection.define(INotebookService, new SyncDescriptor(SimulationNotebookService));
 	testingServiceCollection.define(INotebookSummaryTracker, new SyncDescriptor(SimulationNotebookSummaryTracker));
 	testingServiceCollection.define(ITerminalService, new SyncDescriptor(NullTerminalService));
+	testingServiceCollection.define(IIntentDetectionModelManagementService, new SyncDescriptor(IntentDetectionModelManagementService));
 	return testingServiceCollection;
 }

--- a/src/extension/test/vscode-node/endpoints.test.ts
+++ b/src/extension/test/vscode-node/endpoints.test.ts
@@ -28,6 +28,7 @@ class FakeModelMetadataFetcher implements IModelMetadataFetcher {
 		return {
 			id: modelId,
 			name: 'fake-name',
+			vendor: 'fake',
 			version: 'fake-version',
 			model_picker_enabled: false,
 			is_chat_default: false,

--- a/src/extension/xtab/node/xtabEndpoint.ts
+++ b/src/extension/xtab/node/xtabEndpoint.ts
@@ -24,6 +24,7 @@ export class XtabEndpoint extends ChatEndpoint {
 	private static chatModelInfo: IChatModelInformation = {
 		id: CHAT_MODEL.XTAB_4O_MINI_FINETUNED,
 		name: 'xtab-4o-mini-finetuned',
+		vendor: 'xtab',
 		model_picker_enabled: false,
 		is_chat_default: false,
 		is_chat_fallback: false,

--- a/src/platform/endpoint/common/endpointProvider.ts
+++ b/src/platform/endpoint/common/endpointProvider.ts
@@ -60,7 +60,7 @@ export interface IModelAPIResponse {
 	capabilities: IChatModelCapabilities | IEmbeddingModelCapabilities | ICompletionsModelCapabilities;
 }
 
-export type IChatModelInformation = IModelAPIResponse & { capabilities: IChatModelCapabilities };
+export type IChatModelInformation = IModelAPIResponse & { capabilities: IChatModelCapabilities } & { vendor: string };
 export type IEmbeddingModelInformation = IModelAPIResponse & { capabilities: IEmbeddingModelCapabilities };
 
 export function isChatModelInformation(model: IModelAPIResponse): model is IChatModelInformation {

--- a/src/platform/endpoint/node/autoChatEndpoint.ts
+++ b/src/platform/endpoint/node/autoChatEndpoint.ts
@@ -44,6 +44,7 @@ export class AutoChatEndpoint implements IChatEndpoint {
 	name: string = 'Auto';
 	version: string = 'auto';
 	family: string = 'auto';
+	vendor: string = 'auto';
 	tokenizer: TokenizerType = TokenizerType.O200K;
 
 	constructor(

--- a/src/platform/endpoint/node/chatEndpoint.ts
+++ b/src/platform/endpoint/node/chatEndpoint.ts
@@ -144,6 +144,7 @@ export class ChatEndpoint implements IChatEndpoint {
 	private readonly _maxOutputTokens: number;
 	public readonly model: string;
 	public readonly name: string;
+	public readonly vendor: string;
 	public readonly version: string;
 	public readonly family: string;
 	public readonly tokenizer: TokenizerType;
@@ -178,6 +179,7 @@ export class ChatEndpoint implements IChatEndpoint {
 		this._maxOutputTokens = _modelMetadata.capabilities.limits?.max_output_tokens ?? 4096;
 		this.model = _modelMetadata.id;
 		this.name = _modelMetadata.name;
+		this.vendor = _modelMetadata.vendor;
 		this.version = _modelMetadata.version;
 		this.family = _modelMetadata.capabilities.family;
 		this.tokenizer = _modelMetadata.capabilities.tokenizer;

--- a/src/platform/endpoint/node/proxy4oEndpoint.ts
+++ b/src/platform/endpoint/node/proxy4oEndpoint.ts
@@ -42,6 +42,7 @@ export class Proxy4oEndpoint extends ChatEndpoint {
 		const modelInfo: IChatModelInformation = {
 			id: model,
 			name: model,
+			vendor: 'proxy',
 			version: 'unknown',
 			model_picker_enabled: false,
 			is_chat_default: false,

--- a/src/platform/endpoint/node/proxyXtabEndpoint.ts
+++ b/src/platform/endpoint/node/proxyXtabEndpoint.ts
@@ -25,6 +25,7 @@ export class ProxyXtabEndpoint extends ChatEndpoint {
 	private static chatModelInfo: IChatModelInformation = {
 		id: CHAT_MODEL.NES_XTAB,
 		name: 'xtab-proxy',
+		vendor: 'xtab',
 		model_picker_enabled: false,
 		is_chat_default: false,
 		is_chat_fallback: false,

--- a/src/platform/endpoint/test/node/azureEndpoint.ts
+++ b/src/platform/endpoint/test/node/azureEndpoint.ts
@@ -36,6 +36,7 @@ export class AzureTestEndpoint extends ChatEndpoint {
 		const modelInfo: IChatModelInformation = {
 			id: _azureModel,
 			name: 'Azure Test',
+			vendor: 'Azure',
 			version: '1.0',
 			model_picker_enabled: false,
 			is_chat_default: false,

--- a/src/platform/endpoint/test/node/customNesEndpoint.ts
+++ b/src/platform/endpoint/test/node/customNesEndpoint.ts
@@ -35,6 +35,7 @@ export class CustomNesEndpoint extends ChatEndpoint {
 		const modelInfo: IChatModelInformation = {
 			id: CHAT_MODEL.CUSTOM_NES,
 			name: 'custom-nes',
+			vendor: 'custom-nes',
 			model_picker_enabled: false,
 			is_chat_default: false,
 			is_chat_fallback: false,

--- a/src/platform/endpoint/test/node/mockEndpoint.ts
+++ b/src/platform/endpoint/test/node/mockEndpoint.ts
@@ -42,6 +42,7 @@ export class MockEndpoint implements IChatEndpoint {
 	name: string = 'test';
 	version: string = '1.0';
 	family: string = 'test';
+	vendor: string = 'copilot';
 	tokenizer: TokenizerType = TokenizerType.O200K;
 
 	processResponseFromChatEndpoint(telemetryService: ITelemetryService, logService: ILogService, response: Response, expectedNumChoices: number, finishCallback: FinishedCallback, telemetryData: TelemetryData, cancellationToken?: CancellationToken): Promise<AsyncIterableObject<ChatCompletion>> {

--- a/src/platform/endpoint/test/node/openaiEndpoint.ts
+++ b/src/platform/endpoint/test/node/openaiEndpoint.ts
@@ -38,6 +38,7 @@ export class OpenAITestEndpoint extends ChatEndpoint {
 		const modelInfo: IChatModelInformation = {
 			id: _openaiModel,
 			name: 'Open AI Test Model',
+			vendor: 'copilot',
 			version: '20250108',
 			model_picker_enabled: false,
 			is_chat_default: false,

--- a/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -29,12 +29,14 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 	public readonly isFallback: boolean = false;
 	public readonly isPremium: boolean = false;
 	public readonly multiplier: number = 0;
+	public readonly vendor: string;
 
 	constructor(
 		private readonly languageModel: vscode.LanguageModelChat,
 		@ITokenizerProvider private readonly _tokenizerProvider: ITokenizerProvider,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService
 	) {
+		this.vendor = languageModel.vendor;
 		// Initialize with the model's max tokens
 		this._maxTokens = languageModel.maxInputTokens;
 	}

--- a/src/platform/networking/common/networking.ts
+++ b/src/platform/networking/common/networking.ts
@@ -121,6 +121,7 @@ export interface IChatEndpoint extends IEndpoint {
 	readonly maxOutputTokens: number;
 	/** The model ID- this may change and will be `copilot-base` for the base model. Use `family` to switch behavior based on model type. */
 	readonly model: string;
+	readonly vendor: string;
 	readonly supportsToolCalls: boolean;
 	readonly supportsVision: boolean;
 	readonly supportsPrediction: boolean;

--- a/src/platform/openai/node/fetch.ts
+++ b/src/platform/openai/node/fetch.ts
@@ -179,7 +179,9 @@ export async function fetchAndStreamChat(
 		return { type: FetchResponseKind.Canceled, reason: 'after fetch request' };
 	}
 
-	if (response.status === 200 && authenticationService.copilotToken?.isFreeUser && authenticationService.copilotToken?.isChatQuotaExceeded) {
+	const isCopilotModel = !chatEndpointInfo.model.startsWith('models/');
+
+	if (response.status === 200 && isCopilotModel && authenticationService.copilotToken?.isFreeUser && authenticationService.copilotToken?.isChatQuotaExceeded) {
 		authenticationService.resetCopilotToken();
 	}
 

--- a/src/platform/openai/node/fetch.ts
+++ b/src/platform/openai/node/fetch.ts
@@ -179,7 +179,7 @@ export async function fetchAndStreamChat(
 		return { type: FetchResponseKind.Canceled, reason: 'after fetch request' };
 	}
 
-	const isCopilotModel = !chatEndpointInfo.model.startsWith('models/');
+	const isCopilotModel = chatEndpointInfo.vendor === 'copilot';
 
 	if (response.status === 200 && isCopilotModel && authenticationService.copilotToken?.isFreeUser && authenticationService.copilotToken?.isChatQuotaExceeded) {
 		authenticationService.resetCopilotToken();

--- a/test/intent/intentTest.ts
+++ b/test/intent/intentTest.ts
@@ -18,6 +18,7 @@ import { TestingServiceCollection } from '../../src/platform/test/node/services'
 import { TestingTabsAndEditorsService } from '../../src/platform/test/node/simulationWorkspaceServices';
 import { CancellationToken } from '../../src/util/vs/base/common/cancellation';
 import { IInstantiationService } from '../../src/util/vs/platform/instantiation/common/instantiation';
+import { ChatRequest } from '../../src/vscodeTypes';
 import { stest } from '../base/stest';
 
 export interface IIntentScenario {
@@ -45,7 +46,7 @@ export async function executeIntentTest(testingServiceCollection: TestingService
 	const intentDetector = instaService.createInstance(IntentDetector);
 	const query = scenario.query;
 	const builtinIntents = readBuiltinIntents(scenario.location);
-	const detectedIntent = await intentDetector.detectIntent(scenario.location, undefined, query, CancellationToken.None, createTelemetryWithId(), new ChatVariablesCollection([]), builtinIntents);
+	const detectedIntent = await intentDetector.detectIntent(scenario.location, undefined, { prompt: query, model: { vendor: 'copilot' } } as ChatRequest, CancellationToken.None, createTelemetryWithId(), new ChatVariablesCollection([]), builtinIntents);
 	const intent = detectedIntent ?? intentService.unknownIntent;
 
 	const expectedIntents = Array.isArray(scenario.expectedIntent) ? scenario.expectedIntent : [scenario.expectedIntent];

--- a/test/simulation/inlineChatSimulator.ts
+++ b/test/simulation/inlineChatSimulator.ts
@@ -379,7 +379,7 @@ export async function simulateEditingScenario(
 			if (!request.command) {
 				const intentDetector = instaService.createInstance(IntentDetector);
 				const participants = readBuiltinIntents(location);
-				const detectedParticipant = await intentDetector.provideParticipantDetection(request, { history }, { participants, location: ChatLocation.Editor }, CancellationToken.None);
+				const detectedParticipant = await intentDetector.provideParticipantDetection({ ...request, model: { name: 'gpt-4o-mini', vendor: 'copilot' } as vscode.LanguageModelChat }, { history }, { participants, location: ChatLocation.Editor }, CancellationToken.None);
 				if (detectedParticipant?.command) {
 					request = { ...request, command: detectedParticipant.command };
 				}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/251944

### Issue

Currently, the intent detection is hard-coded to use the copilot gpt-4o-mini model. This is an issue when you have exceeded your chat quota.

This will result in either one of the two errors

<img width="871" height="149" alt="image" src="https://github.com/user-attachments/assets/e7413a1f-abfd-4602-a1c0-772aea81c4d8" />

```
Sorry, your request failed. Reason: Canceled
```

This is caused after the BYOK Chat Request returns with a 200. The code will reset the copilot token, because it doesn't check that it originated from the Copilot API

```
if (response.status === 200 && authenticationService.copilotToken?.isFreeUser && authenticationService.copilotToken?.isChatQuotaExceeded) {
		authenticationService.resetCopilotToken();
}
```
This also causes unnecessary network requests

The second error I have seen (on possibly older versions of the plugin) is the Quota exceeded error

<img width="1026" height="178" alt="image" src="https://github.com/user-attachments/assets/b9491ae7-e071-4d4b-88c8-7a69041a6532" />

### Solution

I have tried to fix it in a way that is extensible later on
- Decouple the intent models from the regular models (although they are currently the same, this leaves the option to change it later)
- Design the API of the new service in a way so that the intent detection model can be set per language model (currently it is only one intent detection model for all models)
- The simplest fix would have been to use the current model of the Chat Request for intent detection, but that is potentially wasteful with expensive models and this isn't transparent to the user that another API request is sent behind the scenes
- Not mix the BYOK Code with the other code, so I made the BYOK code register its models on startup at the new service
- For all copilot models gpt-4o-mini is still used. I incorporated this into the message of the quick pick for users who want to have the same behaviour as before
- I didn't want to mix intent detection with a copilot model with a chat request with a BYOK model, because this is makes it more complicate and hard to reason about the different states of the system

With this MR there is an error message the first time a BYOK model is used
<img width="594" height="198" alt="image" src="https://github.com/user-attachments/assets/21767508-4869-45ff-b547-542ead78bd0b" />

The button opens a quick pick 
<img width="607" height="97" alt="image" src="https://github.com/user-attachments/assets/fdbe978a-07e5-49c1-a2bf-377aaecc6981" />


