### PR TITLE
split up PR and CI builds (#126)

### DIFF
--- a/.github/workflows/ensure-node-modules-cache.yml
+++ b/.github/workflows/ensure-node-modules-cache.yml
@@ -1,0 +1,83 @@
+name: Ensure node modules cache
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    name: Linux
+    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-ubuntu-22.04-x64 ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.x'
+
+      - name: Restore build cache
+        uses: actions/cache@v4
+        id: build-cache
+        with:
+          key: build_cache-${{ hashFiles('build/.cachesalt', 'package-lock.json') }}
+          path: .build/build_cache
+
+      - name: Install dependencies
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Create build cache archive
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: |
+          set -e
+          mkdir -p .build
+          node build/listBuildCacheFiles.js .build/build_cache_list.txt
+          mkdir -p .build/build_cache
+          tar -czf .build/build_cache/cache.tgz --files-from .build/build_cache_list.txt
+
+  windows:
+    name: Windows
+    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-windows-2022-x64 ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.x'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          architecture: 'x64'
+
+      - name: Restore build cache
+        uses: actions/cache@v4
+        id: build-cache
+        with:
+          key: windows-build_cache-${{ hashFiles('build/.cachesalt', 'package-lock.json') }}
+          path: .build/build_cache
+
+      - name: Install dependencies
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Create build cache archive
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir .build
+          node build/listBuildCacheFiles.js .build/build_cache_list.txt
+          mkdir .build/build_cache
+          7z.exe a .build/build_cache/cache.7z -mx3 `@.build/build_cache_list.txt

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,6 @@ name: PR Checks
 on:
   push:
     branches:
-      - main
       - 'gh-readonly-queue/main/*'
   pull_request:
     branches:
@@ -13,9 +12,6 @@ on:
 permissions:
   contents: read
   pull-requests: read
-
-env:
-  IS_MAIN: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:
   check-test-cache:
@@ -60,7 +56,6 @@ jobs:
   check-telemetry:
     name: Check telemetry events
     runs-on: [ self-hosted, 1ES.Pool=1es-vscode-ubuntu-22.04-x64 ]
-    if: github.ref != 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -95,18 +90,17 @@ jobs:
           architecture: 'x64'
 
       - name: Install setuptools
-        if: env.IS_MAIN != 'true'
         run: pip install setuptools
 
       - name: Restore build cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         id: build-cache
         with:
           key: build_cache-${{ hashFiles('build/.cachesalt', 'package-lock.json') }}
           path: .build/build_cache
 
       - name: Extract build cache
-        if: env.IS_MAIN != 'true' && steps.build-cache.outputs.cache-hit == 'true'
+        if: steps.build-cache.outputs.cache-hit == 'true'
         run: tar -xzf .build/build_cache/cache.tgz
 
       - name: Install dependencies
@@ -123,42 +117,35 @@ jobs:
           tar -czf .build/build_cache/cache.tgz --files-from .build/build_cache_list.txt
 
       - name: Install dotnet cli
-        if: env.IS_MAIN != 'true'
         run: npm run setup:dotnet
 
       - name: TypeScript type checking
-        if: env.IS_MAIN != 'true'
         run: npm run typecheck
 
       - name: Lint
-        if: env.IS_MAIN != 'true'
         run: npm run lint
 
       - name: Compile
-        if: env.IS_MAIN != 'true'
         run: npm run compile
 
       - name: Run vitest unit tests
-        if: env.IS_MAIN != 'true'
         run: npm run test:unit
 
       - name: Run simulation tests with cache
-        if: env.IS_MAIN != 'true'
         run: npm run simulate-ci
 
       - name: Run extension tests using VS Code
-        if: env.IS_MAIN != 'true'
         run: xvfb-run -a npm run test:extension
 
       - name: Archive simulation output
-        if: always() && env.IS_MAIN != 'true'
+        if: always()
         run: |
           set -e
           mkdir -p .simulation-archive
           tar -czf .simulation-archive/simulation.tgz -C .simulation .
 
       - name: Upload simulation output
-        if: always() && env.IS_MAIN != 'true'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: simulation-output-linux-${{ github.run_attempt }}
@@ -185,18 +172,17 @@ jobs:
           architecture: 'x64'
 
       - name: Install setuptools
-        if: env.IS_MAIN != 'true'
         run: pip install setuptools
 
       - name: Restore build cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         id: build-cache
         with:
           key: windows-build_cache-${{ hashFiles('build/.cachesalt', 'package-lock.json') }}
           path: .build/build_cache
 
       - name: Extract build cache
-        if: env.IS_MAIN != 'true' && steps.build-cache.outputs.cache-hit == 'true'
+        if: steps.build-cache.outputs.cache-hit == 'true'
         run: 7z.exe x .build/build_cache/cache.7z -aoa
 
       - name: Install dependencies
@@ -206,31 +192,25 @@ jobs:
       - name: Create build cache archive
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir .build
+          mkdir -Force .build
           node build/listBuildCacheFiles.js .build/build_cache_list.txt
-          mkdir .build/build_cache
+          mkdir -Force .build/build_cache
           7z.exe a .build/build_cache/cache.7z -mx3 `@.build/build_cache_list.txt
 
       - name: TypeScript type checking
-        if: env.IS_MAIN != 'true'
         run: npm run typecheck
 
       - name: Lint
-        if: env.IS_MAIN != 'true'
         run: npm run lint
 
       - name: Compile
-        if: env.IS_MAIN != 'true'
         run: npm run compile
 
       - name: Run vitest unit tests
-        if: env.IS_MAIN != 'true'
         run: npm run test:unit
 
       - name: Run simulation tests with cache
-        if: env.IS_MAIN != 'true'
         run: npm run simulate-ci
 
       - name: Run extension tests using VS Code
-        if: env.IS_MAIN != 'true'
         run: npm run test:extension


### PR DESCRIPTION
* split up PR and CI builds:
- PR should only attempt to restore cache
- CI should only ensure node_modules

* also mkdir -Force

* pr workflow should still run on merge queue