### PR TITLE
tools: improve string_replace and add healing (ft. Gemini)

### DIFF
--- a/package.json
+++ b/package.json
@@ -933,7 +933,7 @@
 				"name": "copilot_replaceString",
 				"toolReferenceName": "replaceString",
 				"displayName": "%copilot.tools.replaceString.name%",
-				"modelDescription": "This is a tool for making edits in an existing file in the workspace. For moving or renaming files, use run in terminal tool with the 'mv' command instead. For larger edits, split them into smaller edits and call the edit tool multiple times to ensure accuracy. Before editing, always ensure you have the context to understand the file's contents and context. To edit a file, provide: 1) filePath (absolute path), 2) oldString (must exactly match, including whitespace and indentation, uniquely identifying a single occurrence), and 3) newString (replacement text). Each use of this tool replaces exactly ONE occurrence of oldString. CRITICAL REQUIREMENTS: ensure oldString uniquely identifies the change by including at least 3-5 lines of context both before and after the target text, preserving whitespace and indentation exactly. Never use ...existing code... comments in the oldString or newString. Edits must result in valid, idiomatic code and not leave the file broken!",
+				"modelDescription": "This is a tool for making edits in an existing file in the workspace. For moving or renaming files, use run in terminal tool with the 'mv' command instead. For larger edits, split them into smaller edits and call the edit tool multiple times to ensure accuracy. Before editing, always ensure you have the context to understand the file's contents and context. To edit a file, provide: 1) filePath (absolute path), 2) oldString (MUST be the exact literal text to replace including all whitespace, indentation, newlines, and surrounding code etc), and 3) newString (MUST be the exact literal text to replace \\`oldString\\` with (also including all whitespace, indentation, newlines, and surrounding code etc.). Ensure the resulting code is correct and idiomatic.). Each use of this tool replaces exactly ONE occurrence of oldString.\n\nCRITICAL for \\`oldString\\`: Must uniquely identify the single instance to change. Include at least 3 lines of context BEFORE and AFTER the target text, matching whitespace and indentation precisely. If this string matches multiple locations, or does not match exactly, the tool will fail. Never use ...existing code... comments in the oldString or newString.",
 				"when": "!config.github.copilot.chat.disableReplaceTool",
 				"inputSchema": {
 					"type": "object",
@@ -944,11 +944,11 @@
 						},
 						"oldString": {
 							"type": "string",
-							"description": "The string to be replaced in the file. Never use ...existing code... comments in the oldString."
+							"description": "The exact literal text to replace, preferably unescaped. For single replacements (default), include at least 3 lines of context BEFORE and AFTER the target text, matching whitespace and indentation precisely. For multiple replacements, specify expected_replacements parameter. If this string is not the exact literal text (i.e. you escaped it) or does not match exactly, the tool will fail."
 						},
 						"newString": {
 							"type": "string",
-							"description": "The replacement string. Can be empty to delete oldString."
+							"description": "The exact literal text to replace `old_string` with, preferably unescaped. Provide the EXACT text. Ensure the resulting code is correct and idiomatic."
 						}
 					},
 					"required": [

--- a/src/extension/prompts/node/agent/agentInstructions.tsx
+++ b/src/extension/prompts/node/agent/agentInstructions.tsx
@@ -74,18 +74,18 @@ export class DefaultAgentPrompt extends PromptElement<DefaultAgentPromptProps> {
 				{hasReplaceStringTool ?
 					<>
 						Before you edit an existing file, make sure you either already have it in the provided context, or read it with the {ToolName.ReadFile} tool, so that you can make proper changes.<br />
-						Use the {ToolName.ReplaceString} tool to replace a string in a file, but only if you are sure that the string is unique enough to not cause any issues. You can use this tool multiple times per file.<br />
-						Use the {ToolName.EditFile} tool to insert code into a file.<br />
+						Use the {ToolName.ReplaceString} tool to edit files, paying attention to context to ensure your replacement is unique. You can use this tool multiple times per file.<br />
+						Use the {ToolName.EditFile} tool to insert code into a file ONLY if {ToolName.ReplaceString} has failed.<br />
 						When editing files, group your changes by file.<br />
 						NEVER show the changes to the user, just call the tool, and the edits will be applied and shown to the user.<br />
-						NEVER print a codeblock that represents a change to a file, use {ToolName.EditFile} or {ToolName.ReplaceString} instead.<br />
+						NEVER print a codeblock that represents a change to a file, use {ToolName.ReplaceString} or {ToolName.EditFile} instead.<br />
 						For each file, give a short description of what needs to be changed, then use the {ToolName.ReplaceString} or {ToolName.EditFile} tools. You can use any tool multiple times in a response, and you can keep writing text after using a tool.<br /></> :
 					<>
 						Don't try to edit an existing file without reading it first, so you can make changes properly.<br />
-						Use the {ToolName.EditFile} tool to edit files. When editing files, group your changes by file.<br />
+						Use the {ToolName.ReplaceString} tool to edit files. When editing files, group your changes by file.<br />
 						NEVER show the changes to the user, just call the tool, and the edits will be applied and shown to the user.<br />
-						NEVER print a codeblock that represents a change to a file, use {ToolName.EditFile} instead.<br />
-						For each file, give a short description of what needs to be changed, then use the {ToolName.EditFile} tool. You can use any tool multiple times in a response, and you can keep writing text after using a tool.<br />
+						NEVER print a codeblock that represents a change to a file, use {ToolName.ReplaceString} instead.<br />
+						For each file, give a short description of what needs to be changed, then use the {ToolName.ReplaceString} tool. You can use any tool multiple times in a response, and you can keep writing text after using a tool.<br />
 					</>}
 				<GenericEditingTips {...this.props} />
 				The {ToolName.EditFile} tool is very smart and can understand how to apply your edits to the user's files, you just need to provide minimal hints.<br />

--- a/src/extension/prompts/node/agent/agentPrompt.tsx
+++ b/src/extension/prompts/node/agent/agentPrompt.tsx
@@ -8,6 +8,7 @@ import { isDefined } from '@vscode/test-electron/out/util';
 import type { ChatRequestEditedFileEvent, LanguageModelToolInformation, NotebookEditor, TaskDefinition, TextEditor } from 'vscode';
 import { ChatLocation } from '../../../../platform/chat/common/commonTypes';
 import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
+import { modelNeedsStrongReplaceStringHint } from '../../../../platform/endpoint/common/chatModelCapabilities';
 import { CacheType } from '../../../../platform/endpoint/common/endpointTypes';
 import { IEnvService, OperatingSystem } from '../../../../platform/env/common/envService';
 import { getGitHubRepoInfoFromContext, IGitService } from '../../../../platform/git/common/gitService';
@@ -46,7 +47,6 @@ import { MultirootWorkspaceStructure } from '../panel/workspace/workspaceStructu
 import { AgentConversationHistory } from './agentConversationHistory';
 import { DefaultAgentPrompt, SweBenchAgentPrompt } from './agentInstructions';
 import { SummarizedConversationHistory } from './summarizedConversationHistory';
-import { modelNeedsStrongReplaceStringHint } from '../../../../platform/endpoint/common/chatModelCapabilities';
 
 export interface AgentPromptProps extends GenericBasePromptElementProps {
 	readonly endpoint: IChatEndpoint;
@@ -606,7 +606,7 @@ export function getEditingReminder(hasEditFileTool: boolean, hasReplaceStringToo
 	}
 	if (hasEditFileTool && hasReplaceStringTool) {
 		if (useStrongReplaceStringHint) {
-			lines.push(<>You must always try making file edits using {ToolName.ReplaceString} tool. You may only use {ToolName.EditFile} for an edit if {ToolName.ReplaceString} fails.</>);
+			lines.push(<>You must always try making file edits using {ToolName.ReplaceString} tool. NEVER use {ToolName.EditFile} unless told to by the user or by a tool.</>);
 		} else {
 			lines.push(<>It is much faster to edit using the {ToolName.ReplaceString} tool. Prefer {ToolName.ReplaceString} for making edits and only fall back to {ToolName.EditFile} if it fails.</>);
 		}

--- a/src/extension/prompts/node/agent/agentPrompt.tsx
+++ b/src/extension/prompts/node/agent/agentPrompt.tsx
@@ -599,10 +599,12 @@ export function getEditingReminder(hasEditFileTool: boolean, hasReplaceStringToo
 	const lines = [];
 	if (hasEditFileTool) {
 		lines.push(<>When using the {ToolName.EditFile} tool, avoid repeating existing code, instead use a line comment with \`{EXISTING_CODE_MARKER}\` to represent regions of unchanged code.<br /></>);
-
 	}
 	if (hasReplaceStringTool) {
 		lines.push(<>When using the {ToolName.ReplaceString} tool, include 3-5 lines of unchanged code before and after the string you want to replace, to make it unambiguous which part of the file should be edited.<br /></>);
+	}
+	if (hasEditFileTool && hasReplaceStringTool) {
+		lines.push(<>It is much faster to edit using the {ToolName.ReplaceString} tool. Prefer {ToolName.ReplaceString} for making edits and only fall back to {ToolName.EditFile} if it fails.</>);
 	}
 
 	return lines;

--- a/src/extension/prompts/node/agent/agentPrompt.tsx
+++ b/src/extension/prompts/node/agent/agentPrompt.tsx
@@ -46,6 +46,7 @@ import { MultirootWorkspaceStructure } from '../panel/workspace/workspaceStructu
 import { AgentConversationHistory } from './agentConversationHistory';
 import { DefaultAgentPrompt, SweBenchAgentPrompt } from './agentInstructions';
 import { SummarizedConversationHistory } from './summarizedConversationHistory';
+import { modelNeedsStrongReplaceStringHint } from '../../../../platform/endpoint/common/chatModelCapabilities';
 
 export interface AgentPromptProps extends GenericBasePromptElementProps {
 	readonly endpoint: IChatEndpoint;
@@ -285,7 +286,7 @@ export class AgentUserMessage extends PromptElement<AgentUserMessageProps> {
 					<Tag name='reminderInstructions'>
 						{/* Critical reminders that are effective when repeated right next to the user message */}
 						{getKeepGoingReminder(this.props.endpoint.family)}
-						{getEditingReminder(hasEditFileTool, hasReplaceStringTool)}
+						{getEditingReminder(hasEditFileTool, hasReplaceStringTool, modelNeedsStrongReplaceStringHint(this.props.endpoint))}
 						<NotebookReminderInstructions chatVariables={this.props.chatVariables} query={this.props.request} />
 					</Tag>
 					{query && <Tag name='userRequest' priority={900} flexGrow={7}>{query + attachmentHint}</Tag>}
@@ -595,7 +596,7 @@ class AgentTasksInstructions extends PromptElement {
 	}
 }
 
-export function getEditingReminder(hasEditFileTool: boolean, hasReplaceStringTool: boolean) {
+export function getEditingReminder(hasEditFileTool: boolean, hasReplaceStringTool: boolean, useStrongReplaceStringHint: boolean) {
 	const lines = [];
 	if (hasEditFileTool) {
 		lines.push(<>When using the {ToolName.EditFile} tool, avoid repeating existing code, instead use a line comment with \`{EXISTING_CODE_MARKER}\` to represent regions of unchanged code.<br /></>);
@@ -604,7 +605,11 @@ export function getEditingReminder(hasEditFileTool: boolean, hasReplaceStringToo
 		lines.push(<>When using the {ToolName.ReplaceString} tool, include 3-5 lines of unchanged code before and after the string you want to replace, to make it unambiguous which part of the file should be edited.<br /></>);
 	}
 	if (hasEditFileTool && hasReplaceStringTool) {
-		lines.push(<>It is much faster to edit using the {ToolName.ReplaceString} tool. Prefer {ToolName.ReplaceString} for making edits and only fall back to {ToolName.EditFile} if it fails.</>);
+		if (useStrongReplaceStringHint) {
+			lines.push(<>You must always try making file edits using {ToolName.ReplaceString} tool. You may only use {ToolName.EditFile} for an edit if {ToolName.ReplaceString} fails.</>);
+		} else {
+			lines.push(<>It is much faster to edit using the {ToolName.ReplaceString} tool. Prefer {ToolName.ReplaceString} for making edits and only fall back to {ToolName.EditFile} if it fails.</>);
+		}
 	}
 
 	return lines;

--- a/src/extension/prompts/node/agent/test/__snapshots__/agentPrompt.spec.tsx.snap
+++ b/src/extension/prompts/node/agent/test/__snapshots__/agentPrompt.spec.tsx.snap
@@ -175,11 +175,11 @@ Tools can be disabled by the user. You may see tools used previously in the conv
 </toolUseInstructions>
 <editFileInstructions>
 Before you edit an existing file, make sure you either already have it in the provided context, or read it with the read_file tool, so that you can make proper changes.
-Use the replace_string_in_file tool to replace a string in a file, but only if you are sure that the string is unique enough to not cause any issues. You can use this tool multiple times per file.
-Use the insert_edit_into_file tool to insert code into a file.
+Use the replace_string_in_file tool to edit files, paying attention to context to ensure your replacement is unique. You can use this tool multiple times per file.
+Use the insert_edit_into_file tool to insert code into a file ONLY if replace_string_in_file has failed.
 When editing files, group your changes by file.
 NEVER show the changes to the user, just call the tool, and the edits will be applied and shown to the user.
-NEVER print a codeblock that represents a change to a file, use insert_edit_into_file or replace_string_in_file instead.
+NEVER print a codeblock that represents a change to a file, use replace_string_in_file or insert_edit_into_file instead.
 For each file, give a short description of what needs to be changed, then use the replace_string_in_file or insert_edit_into_file tools. You can use any tool multiple times in a response, and you can keep writing text after using a tool.
 Follow best practices when editing files. If a popular external library exists to solve a problem, use it and properly install the package e.g. creating a "requirements.txt".
 If you're building a webapp from scratch, give it a beautiful and modern UI.
@@ -259,7 +259,7 @@ copilot_cache_control: {"type":"ephemeral"}
 <reminderInstructions>
 When using the insert_edit_into_file tool, avoid repeating existing code, instead use a line comment with /\`...existing code.../\` to represent regions of unchanged code.
 When using the replace_string_in_file tool, include 3-5 lines of unchanged code before and after the string you want to replace, to make it unambiguous which part of the file should be edited.
-
+It is much faster to edit using the replace_string_in_file tool. Prefer replace_string_in_file for making edits and only fall back to insert_edit_into_file if it fails.
 </reminderInstructions>
 <userRequest>
 hello

--- a/src/extension/prompts/node/panel/editCodePrompt2.tsx
+++ b/src/extension/prompts/node/panel/editCodePrompt2.tsx
@@ -5,7 +5,7 @@
 
 import { PromptElement, PromptSizing, SystemMessage, UserMessage } from '@vscode/prompt-tsx';
 import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
-import { modelPrefersInstructionsAfterHistory } from '../../../../platform/endpoint/common/chatModelCapabilities';
+import { modelNeedsStrongReplaceStringHint, modelPrefersInstructionsAfterHistory } from '../../../../platform/endpoint/common/chatModelCapabilities';
 import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { isLocation, isUri } from '../../../../util/common/types';
 import { ToolName } from '../../../tools/common/toolNames';
@@ -148,7 +148,7 @@ export class EditCode2UserMessage extends PromptElement<AgentPromptProps> {
 					<ChatToolReferences flexGrow={4} priority={898} promptContext={this.props.promptContext} documentContext={this.props.documentContext} />
 					<ChatVariables flexGrow={3} priority={898} chatVariables={chatVariables} />
 					<Tag name='reminder'>
-						{getEditingReminder(hasEditFileTool, hasReplaceStringTool)}
+						{getEditingReminder(hasEditFileTool, hasReplaceStringTool, modelNeedsStrongReplaceStringHint(this.props.endpoint))}
 						<NotebookReminderInstructions chatVariables={chatVariables} query={query} />
 						<NewFilesLocationHint />
 					</Tag>

--- a/src/extension/tools/node/editFileCorrectorGemini.tsx
+++ b/src/extension/tools/node/editFileCorrectorGemini.tsx
@@ -1,0 +1,560 @@
+// Copyright 2025 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//        http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// eslint-disable-next-line header/header
+import { Raw } from '@vscode/prompt-tsx';
+import * as JSONC from 'jsonc-parser';
+import { ChatFetchResponseType, ChatLocation } from '../../../platform/chat/common/commonTypes.js';
+import { ObjectJsonSchema } from '../../../platform/configuration/common/jsonSchema.js';
+import { IChatEndpoint } from '../../../platform/networking/common/networking.js';
+import { extractCodeBlocks } from '../../../util/common/markdown.js';
+import { CancellationToken } from '../../../util/vs/base/common/cancellation.js';
+import { count } from '../../../util/vs/base/common/strings.js';
+import { findAndReplaceOne } from './editFileToolUtils.js';
+import { IReplaceStringToolParams } from './replaceStringTool.js';
+
+/**
+ * Defines the structure of the parameters within CorrectedEditResult
+ */
+interface CorrectedEditParams {
+	filePath: string;
+	oldString: string;
+	newString: string;
+}
+
+/**
+ * Defines the result structure for ensureCorrectEdit.
+ */
+export interface CorrectedEditResult {
+	params: CorrectedEditParams;
+	occurrences: number;
+}
+
+function matchAndCount(currentContent: string, oldString: string, eol: string) {
+	const r = findAndReplaceOne(currentContent, oldString, '<none>', eol);
+	return r.type === 'multiple' ? r.matchInfo!.matchPositions!.length : r.type === 'none' ? 0 : 1;
+}
+
+/**
+ * Attempts to correct edit parameters if the original oldString is not found.
+ * It tries unescaping, and then LLM-based correction.
+ * Results are cached to avoid redundant processing.
+ *
+ * @param currentContent The current content of the file.
+ * @param originalParams The original EditToolParams
+ * @param healEndpoint The GeminiClient for LLM calls.
+ * @returns A promise resolving to an object containing the (potentially corrected)
+ *          EditToolParams (as CorrectedEditParams) and the final occurrences count.
+ */
+export async function ensureCorrectEdit(
+	currentContent: string,
+	originalParams: IReplaceStringToolParams & { expected_replacements?: number }, // This is the EditToolParams from edit.ts, without \'corrected\'
+	eol: string,
+	healEndpoint: IChatEndpoint,
+	token: CancellationToken,
+): Promise<CorrectedEditResult> {
+	let finalNewString = originalParams.newString!;
+	const newStringPotentiallyEscaped =
+		unescapeStringForGeminiBug(originalParams.newString!) !==
+		originalParams.newString;
+
+	const expectedReplacements = originalParams.expected_replacements ?? 1;
+
+	let finalOldString = originalParams.oldString!;
+	let occurrences = count(currentContent, finalOldString);
+
+	if (occurrences === expectedReplacements) {
+		if (newStringPotentiallyEscaped) {
+			finalNewString = await correctNewStringEscaping(
+				healEndpoint,
+				finalOldString,
+				originalParams.newString!,
+				token,
+			);
+		}
+	} else if (occurrences > expectedReplacements) {
+		const expectedReplacements = originalParams.expected_replacements ?? 1;
+
+		// If user expects multiple replacements, return as-is
+		if (occurrences === expectedReplacements) {
+			const result: CorrectedEditResult = {
+				params: { ...originalParams },
+				occurrences,
+			};
+			return result;
+		}
+
+		// If user expects 1 but found multiple, try to correct (existing behavior)
+		if (expectedReplacements === 1) {
+			const result: CorrectedEditResult = {
+				params: { ...originalParams },
+				occurrences,
+			};
+			return result;
+		}
+
+		// If occurrences don't match expected, return as-is (will fail validation later)
+		const result: CorrectedEditResult = {
+			params: { ...originalParams },
+			occurrences,
+		};
+		return result;
+	} else {
+		// occurrences is 0 or some other unexpected state initially
+		const unescapedOldStringAttempt = unescapeStringForGeminiBug(
+			originalParams.oldString,
+		);
+		occurrences = matchAndCount(currentContent, unescapedOldStringAttempt, eol);
+
+		if (occurrences === expectedReplacements) {
+			finalOldString = unescapedOldStringAttempt;
+			if (newStringPotentiallyEscaped) {
+				finalNewString = await correctNewString(
+					healEndpoint,
+					originalParams.oldString, // original old
+					unescapedOldStringAttempt, // corrected old
+					originalParams.newString, // original new (which is potentially escaped)
+					token,
+				);
+			}
+		} else if (occurrences === 0) {
+			const llmCorrectedOldString = await correctOldStringMismatch(
+				healEndpoint,
+				currentContent,
+				unescapedOldStringAttempt,
+				token,
+			);
+			const llmOldOccurrences = matchAndCount(
+				currentContent,
+				llmCorrectedOldString,
+				eol,
+			);
+
+			if (llmOldOccurrences === expectedReplacements) {
+				finalOldString = llmCorrectedOldString;
+				occurrences = llmOldOccurrences;
+
+				if (newStringPotentiallyEscaped) {
+					const baseNewStringForLLMCorrection = unescapeStringForGeminiBug(
+						originalParams.newString,
+					);
+					finalNewString = await correctNewString(
+						healEndpoint,
+						originalParams.oldString, // original old
+						llmCorrectedOldString, // corrected old
+						baseNewStringForLLMCorrection, // base new for correction
+						token,
+					);
+				}
+			} else {
+				// LLM correction also failed for oldString
+				const result: CorrectedEditResult = {
+					params: { ...originalParams },
+					occurrences: 0, // Explicitly 0 as LLM failed
+				};
+				return result;
+			}
+		} else {
+			// Unescaping oldString resulted in > 1 occurrences
+			const result: CorrectedEditResult = {
+				params: { ...originalParams },
+				occurrences, // This will be > 1
+			};
+			return result;
+		}
+	}
+
+	const { targetString, pair } = trimPairIfPossible(
+		finalOldString,
+		finalNewString,
+		currentContent,
+		expectedReplacements,
+	);
+	finalOldString = targetString;
+	finalNewString = pair;
+
+	// Final result construction
+	const result: CorrectedEditResult = {
+		params: {
+			filePath: originalParams.filePath,
+			oldString: finalOldString,
+			newString: finalNewString,
+		},
+		occurrences: count(currentContent, finalOldString), // Recalculate occurrences with the final oldString
+	};
+	return result;
+}
+
+export async function ensureCorrectFileContent(
+	content: string,
+	healEndpoint: IChatEndpoint,
+	token: CancellationToken,
+): Promise<string> {
+	const contentPotentiallyEscaped =
+		unescapeStringForGeminiBug(content) !== content;
+	if (!contentPotentiallyEscaped) {
+		return content;
+	}
+
+	const correctedContent = await correctStringEscaping(
+		content,
+		healEndpoint,
+		token,
+	);
+	return correctedContent;
+}
+
+// Define the expected JSON schema for the LLM response for oldString correction
+const oldString_CORRECTION_SCHEMA: ObjectJsonSchema = {
+	type: 'object',
+	properties: {
+		corrected_target_snippet: {
+			type: 'string',
+			description:
+				'The corrected version of the target snippet that exactly and uniquely matches a segment within the provided file content.',
+		},
+	},
+	required: ['corrected_target_snippet'],
+};
+
+export async function correctOldStringMismatch(
+	healEndpoint: IChatEndpoint,
+	fileContent: string,
+	problematicSnippet: string,
+	token: CancellationToken,
+): Promise<string> {
+	const prompt = `
+Context: A process needs to find an exact literal, unique match for a specific text snippet within a file's content. The provided snippet failed to match exactly. This is most likely because it has been overly escaped.
+
+Task: Analyze the provided file content and the problematic target snippet. Identify the segment in the file content that the snippet was *most likely* intended to match. Output the *exact*, literal text of that segment from the file content. Focus *only* on removing extra escape characters and correcting formatting, whitespace, or minor differences to achieve a PERFECT literal match. The output must be the exact literal text as it appears in the file.
+
+Problematic target snippet:
+\`\`\`
+${problematicSnippet}
+\`\`\`
+
+File Content:
+\`\`\`
+${fileContent}
+\`\`\`
+
+For example, if the problematic target snippet was "\\\\\\nconst greeting = \`Hello \\\\\`\${name}\\\\\`\`;" and the file content had content that looked like "\nconst greeting = \`Hello ${'\\`'}\${name}${'\\`'}\`;", then corrected_target_snippet should likely be "\nconst greeting = \`Hello ${'\\`'}\${name}${'\\`'}\`;" to fix the incorrect escaping to match the original file content.
+If the differences are only in whitespace or formatting, apply similar whitespace/formatting changes to the corrected_target_snippet.
+
+Return ONLY the corrected target snippet in the specified JSON format with the key 'corrected_target_snippet'. If no clear, unique match can be found, return an empty string for 'corrected_target_snippet'.
+`.trim();
+
+	try {
+		const result = await getJsonResponse(healEndpoint, prompt, oldString_CORRECTION_SCHEMA, token);
+		if (
+			result &&
+			typeof result.corrected_target_snippet === 'string' &&
+			result.corrected_target_snippet.length > 0
+		) {
+			return result.corrected_target_snippet;
+		} else {
+			return problematicSnippet;
+		}
+	} catch (error) {
+		return problematicSnippet;
+	}
+}
+
+// Define the expected JSON schema for the newString correction LLM response
+const newString_CORRECTION_SCHEMA: ObjectJsonSchema = {
+	type: 'object',
+	properties: {
+		corrected_newString: {
+			type: 'string',
+			description:
+				'The original_newString adjusted to be a suitable replacement for the corrected_oldString, while maintaining the original intent of the change.',
+		},
+	},
+	required: ['corrected_newString'],
+};
+
+/**
+ * Adjusts the newString to align with a corrected oldString, maintaining the original intent.
+ */
+export async function correctNewString(
+	endpoint: IChatEndpoint,
+	originalOldString: string,
+	correctedOldString: string,
+	originalNewString: string,
+	token: CancellationToken,
+): Promise<string> {
+	if (originalOldString === correctedOldString) {
+		return originalNewString;
+	}
+
+	const prompt = `
+Context: A text replacement operation was planned. The original text to be replaced (original_oldString) was slightly different from the actual text in the file (corrected_oldString). The original_oldString has now been corrected to match the file content.
+We now need to adjust the replacement text (original_newString) so that it makes sense as a replacement for the corrected_oldString, while preserving the original intent of the change.
+
+original_oldString (what was initially intended to be found):
+\`\`\`
+${originalOldString}
+\`\`\`
+
+corrected_oldString (what was actually found in the file and will be replaced):
+\`\`\`
+${correctedOldString}
+\`\`\`
+
+original_newString (what was intended to replace original_oldString):
+\`\`\`
+${originalNewString}
+\`\`\`
+
+Task: Based on the differences between original_oldString and corrected_oldString, and the content of original_newString, generate a corrected_newString. This corrected_newString should be what original_newString would have been if it was designed to replace corrected_oldString directly, while maintaining the spirit of the original transformation.
+
+For example, if original_oldString was "\\\\\\nconst greeting = \`Hello \\\\\`\${name}\\\\\`\`;" and corrected_oldString is "\nconst greeting = \`Hello ${'\\`'}\${name}${'\\`'}\`;", and original_newString was "\\\\\\nconst greeting = \`Hello \\\\\`\${name} \${lastName}\\\\\`\`;", then corrected_newString should likely be "\nconst greeting = \`Hello ${'\\`'}\${name} \${lastName}${'\\`'}\`;" to fix the incorrect escaping.
+If the differences are only in whitespace or formatting, apply similar whitespace/formatting changes to the corrected_newString.
+
+Return ONLY the corrected string in the specified JSON format with the key 'corrected_newString'. If no adjustment is deemed necessary or possible, return the original_newString.
+  `.trim();
+
+	try {
+		const result = await getJsonResponse(endpoint, prompt, newString_CORRECTION_SCHEMA, token);
+		if (
+			result &&
+			typeof result.corrected_newString === 'string' &&
+			result.corrected_newString.length > 0
+		) {
+			return result.corrected_newString;
+		} else {
+			return originalNewString;
+		}
+	} catch (error) {
+		return originalNewString;
+	}
+}
+
+const CORRECT_newString_ESCAPING_SCHEMA: ObjectJsonSchema = {
+	type: 'object',
+	properties: {
+		corrected_newString_escaping: {
+			type: 'string',
+			description:
+				'The newString with corrected escaping, ensuring it is a proper replacement for the oldString, especially considering potential over-escaping issues from previous LLM generations.',
+		},
+	},
+	required: ['corrected_newString_escaping'],
+};
+
+export async function correctNewStringEscaping(
+	geminiClient: IChatEndpoint,
+	oldString: string,
+	potentiallyProblematicNewString: string,
+	token: CancellationToken,
+): Promise<string> {
+	const prompt = `
+Context: A text replacement operation is planned. The text to be replaced (oldString) has been correctly identified in the file. However, the replacement text (newString) might have been improperly escaped by a previous LLM generation (e.g. too many backslashes for newlines like \\n instead of \n, or unnecessarily quotes like \\"Hello\\" instead of "Hello").
+
+oldString (this is the exact text that will be replaced):
+\`\`\`
+${oldString}
+\`\`\`
+
+potentially_problematic_newString (this is the text that should replace oldString, but MIGHT have bad escaping, or might be entirely correct):
+\`\`\`
+${potentiallyProblematicNewString}
+\`\`\`
+
+Task: Analyze the potentially_problematic_newString. If it's syntactically invalid due to incorrect escaping (e.g., "\n", "\t", "\\", "\\'", "\\""), correct the invalid syntax. The goal is to ensure the newString, when inserted into the code, will be a valid and correctly interpreted.
+
+For example, if oldString is "foo" and potentially_problematic_newString is "bar\\nbaz", the corrected_newString_escaping should be "bar\nbaz".
+If potentially_problematic_newString is console.log(\\"Hello World\\"), it should be console.log("Hello World").
+
+Return ONLY the corrected string in the specified JSON format with the key 'corrected_newString_escaping'. If no escaping correction is needed, return the original potentially_problematic_newString.
+  `.trim();
+
+	try {
+		const result = await getJsonResponse(geminiClient, prompt, CORRECT_newString_ESCAPING_SCHEMA, token);
+		if (
+			result &&
+			typeof result.corrected_newString_escaping === 'string' &&
+			result.corrected_newString_escaping.length > 0
+		) {
+			return result.corrected_newString_escaping;
+		} else {
+			return potentiallyProblematicNewString;
+		}
+	} catch (error) {
+		return potentiallyProblematicNewString;
+	}
+}
+
+const CORRECT_STRING_ESCAPING_SCHEMA: ObjectJsonSchema = {
+	type: 'object',
+	properties: {
+		corrected_string_escaping: {
+			type: 'string',
+			description:
+				'The string with corrected escaping, ensuring it is valid, specially considering potential over-escaping issues from previous LLM generations.',
+		},
+	},
+	required: ['corrected_string_escaping'],
+};
+
+async function getJsonResponse(endpoint: IChatEndpoint, prompt: string, schema: ObjectJsonSchema, token: CancellationToken) {
+	prompt += `\n\nYour response must follow the JSON format:
+
+	\`\`\`
+${JSON.stringify(schema, null, 2)}
+\`\`\`
+`.trim();
+
+	const contents: Raw.ChatMessage[] = [
+		// Some system message to avoid tripping CAPI
+		{ role: Raw.ChatRole.System, content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'You are an expert at analyzing files and patterns.' }] },
+		{ role: Raw.ChatRole.User, content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: prompt }] },
+	];
+
+	const result = await endpoint.makeChatRequest(
+		'healStringReplace',
+		contents,
+		undefined,
+		token,
+		ChatLocation.Other
+	);
+
+	if (result.type !== ChatFetchResponseType.Success) {
+		return undefined;
+	}
+
+	for (const block of extractCodeBlocks(result.value)) {
+		try {
+			return JSONC.parse(block.code);
+		} catch {
+			// ignored
+		}
+	}
+
+	const idx = result.value.indexOf('{');
+	return JSONC.parse(result.value.slice(idx)) || undefined;
+}
+
+export async function correctStringEscaping(
+	potentiallyProblematicString: string,
+	endpoint: IChatEndpoint,
+	token: CancellationToken,
+): Promise<string> {
+	const prompt = `
+Context: An LLM has just generated potentially_problematic_string and the text might have been improperly escaped (e.g. too many backslashes for newlines like \\n instead of \n, or unnecessarily quotes like \\"Hello\\" instead of "Hello").
+
+potentially_problematic_string (this text MIGHT have bad escaping, or might be entirely correct):
+\`\`\`
+${potentiallyProblematicString}
+\`\`\`
+
+Task: Analyze the potentially_problematic_string. If it's syntactically invalid due to incorrect escaping (e.g., "\n", "\t", "\\", "\\'", "\\""), correct the invalid syntax. The goal is to ensure the text will be a valid and correctly interpreted.
+
+For example, if potentially_problematic_string is "bar\\nbaz", the corrected_newString_escaping should be "bar\nbaz".
+If potentially_problematic_string is console.log(\\"Hello World\\"), it should be console.log("Hello World").
+
+Return ONLY the corrected string in the specified JSON format with the key 'corrected_string_escaping'. If no escaping correction is needed, return the original potentially_problematic_string.
+  `.trim();
+
+
+	try {
+		const result = await getJsonResponse(endpoint, prompt, CORRECT_STRING_ESCAPING_SCHEMA, token);
+
+		if (
+			result &&
+			typeof result.corrected_string_escaping === 'string' &&
+			result.corrected_string_escaping.length > 0
+		) {
+			return result.corrected_string_escaping;
+		} else {
+			return potentiallyProblematicString;
+		}
+	} catch (error) {
+		return potentiallyProblematicString;
+	}
+}
+
+function trimPairIfPossible(
+	target: string,
+	trimIfTargetTrims: string,
+	currentContent: string,
+	expectedReplacements: number,
+) {
+	const trimmedTargetString = target.trim();
+	if (target.length !== trimmedTargetString.length) {
+		const trimmedTargetOccurrences = count(
+			currentContent,
+			trimmedTargetString,
+		);
+
+		if (trimmedTargetOccurrences === expectedReplacements) {
+			const trimmedReactiveString = trimIfTargetTrims.trim();
+			return {
+				targetString: trimmedTargetString,
+				pair: trimmedReactiveString,
+			};
+		}
+	}
+
+	return {
+		targetString: target,
+		pair: trimIfTargetTrims,
+	};
+}
+
+/**
+ * Unescapes a string that might have been overly escaped by an LLM.
+ */
+export function unescapeStringForGeminiBug(inputString: string): string {
+	// Regex explanation:
+	// \\ : Matches exactly one literal backslash character.
+	// (n|t|r|'|"|`|\\|\n) : This is a capturing group. It matches one of the following:
+	//   n, t, r, ', ", ` : These match the literal characters 'n', 't', 'r', single quote, double quote, or backtick.
+	//                       This handles cases like "\\n", "\\`", etc.
+	//   \\ : This matches a literal backslash. This handles cases like "\\\\" (escaped backslash).
+	//   \n : This matches an actual newline character. This handles cases where the input
+	//        string might have something like "\\\n" (a literal backslash followed by a newline).
+	// g : Global flag, to replace all occurrences.
+
+	return inputString.replace(
+		/\\+(n|t|r|'|"|`|\\|\n)/g,
+		(match, capturedChar) => {
+			// 'match' is the entire erroneous sequence, e.g., if the input (in memory) was "\\\\`", match is "\\\\`".
+			// 'capturedChar' is the character that determines the true meaning, e.g., '`'.
+
+			switch (capturedChar) {
+				case 'n':
+					return '\n'; // Correctly escaped: \n (newline character)
+				case 't':
+					return '\t'; // Correctly escaped: \t (tab character)
+				case 'r':
+					return '\r'; // Correctly escaped: \r (carriage return character)
+				case "'":
+					return "'"; // Correctly escaped: ' (apostrophe character)
+				case '"':
+					return '"'; // Correctly escaped: " (quotation mark character)
+				case '`':
+					return '`'; // Correctly escaped: ` (backtick character)
+				case '\\': // This handles when 'capturedChar' is a literal backslash
+					return '\\'; // Replace escaped backslash (e.g., "\\\\") with single backslash
+				case '\n': // This handles when 'capturedChar' is an actual newline
+					return '\n'; // Replace the whole erroneous sequence (e.g., "\\\n" in memory) with a clean newline
+				default:
+					// This fallback should ideally not be reached if the regex captures correctly.
+					// It would return the original matched sequence if an unexpected character was captured.
+					return match;
+			}
+		},
+	);
+}

--- a/src/extension/tools/node/editFileCorrectorGemini.tsx
+++ b/src/extension/tools/node/editFileCorrectorGemini.tsx
@@ -43,7 +43,7 @@ export interface CorrectedEditResult {
 
 function matchAndCount(currentContent: string, oldString: string, eol: string) {
 	const r = findAndReplaceOne(currentContent, oldString, '<none>', eol);
-	return r.type === 'multiple' ? r.matchInfo!.matchPositions!.length : r.type === 'none' ? 0 : 1;
+	return r.type === 'multiple' ? r.matchPositions.length : r.editPosition.length;
 }
 
 /**

--- a/src/extension/tools/node/editFileHealing.tsx
+++ b/src/extension/tools/node/editFileHealing.tsx
@@ -1,5 +1,9 @@
 // Copyright 2025 Google LLC
-
+//
+// This is adapted from the edit corrector in the Gemini CLI which can be found
+// at https://github.com/google-gemini/gemini-cli/blob/5008aea90d4ea7ac6bb5872f3702f3c7a7878ed0/packages/core/src/utils/editCorrector.ts
+// and is available under the following license:
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -57,7 +61,7 @@ function matchAndCount(currentContent: string, oldString: string, eol: string) {
  * @returns A promise resolving to an object containing the (potentially corrected)
  *          EditToolParams (as CorrectedEditParams) and the final occurrences count.
  */
-export async function ensureCorrectEdit(
+export async function healReplaceStringParams(
 	currentContent: string,
 	originalParams: IReplaceStringToolParams & { expected_replacements?: number }, // This is the EditToolParams from edit.ts, without \'corrected\'
 	eol: string,

--- a/src/extension/tools/node/editFileHealing.tsx
+++ b/src/extension/tools/node/editFileHealing.tsx
@@ -47,7 +47,7 @@ export interface CorrectedEditResult {
 
 function matchAndCount(currentContent: string, oldString: string, eol: string) {
 	const r = findAndReplaceOne(currentContent, oldString, '<none>', eol);
-	return r.type === 'multiple' ? r.matchPositions.length : r.editPosition.length;
+	return r.type === 'multiple' ? (r.matchInfo?.matchPositions?.length ?? 2) : r.type === 'none' ? 0 : 1;
 }
 
 /**

--- a/src/extension/tools/node/editFileToolResult.tsx
+++ b/src/extension/tools/node/editFileToolResult.tsx
@@ -6,6 +6,7 @@
 import { BasePromptElementProps, PromptElement, PromptElementProps, PromptSizing } from '@vscode/prompt-tsx';
 import type * as vscode from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
+import { modelNeedsStrongReplaceStringHint } from '../../../platform/endpoint/common/chatModelCapabilities';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { ILanguageDiagnosticsService } from '../../../platform/languages/common/languageDiagnosticsService';
 import { IPromptPathRepresentationService } from '../../../platform/prompts/common/promptPathRepresentationService';
@@ -98,8 +99,10 @@ export class EditFileResult extends PromptElement<IEditFileResultProps> {
 				{successfullyEditedFiles.length > 0 &&
 					<>The following files were successfully edited:<br />
 						{successfullyEditedFiles.join('\n')}<br /></>}
-				{editingErrors.length > 0 &&
-					<>{editingErrors.join('\n')}</>}
+				{editingErrors.length > 0 && <>
+					{editingErrors.join('\n')}
+					{this.props.model && modelNeedsStrongReplaceStringHint(this.props.model) && <><br /><br />You may use the {ToolName.EditFile} tool to retry these edits.</>}
+				</>}
 				{editsWithDiagnostics.length > 0 &&
 					editsWithDiagnostics.map(edit => {
 						return <>

--- a/src/extension/tools/node/editFileToolUtils.tsx
+++ b/src/extension/tools/node/editFileToolUtils.tsx
@@ -109,27 +109,20 @@ function calculateSimilarity(str1: string, str2: string): number {
 	return 1 - distance / maxLength;
 }
 
-interface MatchResultCommon {
-	type: string;
-	/** Replacement text */
-	text: string;
-	/** Array of [startIndex, endIndex] to replace in the file content */
-	editPosition: [number, number][];
-	/** Model suggestion to correct a fialing match */
-	suggestion?: string;
-}
-
 /**
- * Type-safe union type for match results with discriminated unions
+ * Interface for match result with additional information
  */
-type MatchResult = MatchResultCommon & (
-	| { text: string; type: 'none'; suggestion?: string }
-	| { text: string; type: 'exact' }
-	| { text: string; type: 'fuzzy' }
-	| { text: string; type: 'whitespace' }
-	| { text: string; type: 'similarity'; suggestion: string; similarity: number }
-	| { text: string; type: 'multiple'; suggestion: string; matchPositions: number[]; strategy: 'exact' | 'fuzzy' | 'whitespace' }
-);
+interface MatchResult {
+	text: string;
+	type: 'exact' | 'fuzzy' | 'whitespace' | 'similarity' | 'multiple' | 'none';
+	editPosition: number[] | undefined;
+	matchInfo?: {
+		strategy: string;
+		matchPositions?: number[];
+		similarity?: number;
+		suggestion?: string;
+	};
+}
 
 /**
  * Enhanced version of findAndReplaceOne with more robust matching strategies
@@ -174,8 +167,11 @@ export function findAndReplaceOne(
 	return {
 		text,
 		type: 'none',
-		editPosition: [],
-		suggestion: `Try making your search string more specific or checking for whitespace/formatting differences.`
+		editPosition: undefined,
+		matchInfo: {
+			strategy: 'none',
+			suggestion: `Try making your search string more specific or checking for whitespace/formatting differences.`
+		}
 	};
 }
 
@@ -183,36 +179,35 @@ export function findAndReplaceOne(
  * Tries to find an exact match of oldStr in text.
  */
 function tryExactMatch(text: string, oldStr: string, newStr: string): MatchResult {
-	const matchPositions: number[] = [];
-	for (let searchIdx = 0; ;) {
-		const idx = text.indexOf(oldStr, searchIdx);
-		if (idx === -1) { break; }
-		matchPositions.push(idx);
-		searchIdx = idx + oldStr.length;
-	}
-	if (matchPositions.length === 0) {
-		return { text, editPosition: [], type: 'none' };
-	}
-
-	// Check for multiple exact occurrences.
-	if (matchPositions.length > 1) {
+	const firstExactIdx = text.indexOf(oldStr);
+	if (firstExactIdx !== -1) {
+		// Check for multiple exact occurrences.
+		const secondExactIdx = text.indexOf(oldStr, firstExactIdx + oldStr.length);
+		if (secondExactIdx !== -1) {
+			return {
+				text,
+				type: 'multiple',
+				editPosition: [firstExactIdx, firstExactIdx + oldStr.length],
+				matchInfo: {
+					strategy: 'exact',
+					matchPositions: [firstExactIdx, secondExactIdx],
+					suggestion: "Multiple exact matches found. Make your search string more specific."
+				}
+			};
+		}
+		// Exactly one exact match found.
+		const replaced = text.slice(0, firstExactIdx) + newStr + text.slice(firstExactIdx + oldStr.length);
 		return {
-			text,
-			type: 'multiple',
-			editPosition: matchPositions.map(idx => [idx, idx + oldStr.length]),
-			strategy: 'exact',
-			matchPositions,
-			suggestion: "Multiple exact matches found. Make your search string more specific."
+			text: replaced,
+			type: 'exact',
+			editPosition: [firstExactIdx, firstExactIdx + oldStr.length],
+			matchInfo: {
+				strategy: 'exact',
+				matchPositions: [firstExactIdx]
+			}
 		};
 	}
-	// Exactly one exact match found.
-	const firstExactIdx = matchPositions[0];
-	const replaced = text.slice(0, firstExactIdx) + newStr + text.slice(firstExactIdx + oldStr.length);
-	return {
-		text: replaced,
-		type: 'exact',
-		editPosition: [[firstExactIdx, firstExactIdx + oldStr.length]],
-	};
+	return { text, editPosition: undefined, type: 'none' };
 }
 
 /**
@@ -232,12 +227,7 @@ function tryWhitespaceFlexibleMatch(text: string, oldStr: string, newStr: string
 		}
 	}
 	if (matchedLines.length === 0) {
-		return {
-			text,
-			editPosition: [],
-			type: 'none',
-			suggestion: 'No whitespace-flexible match found.'
-		};
+		return { text, editPosition: undefined, type: 'none' };
 	}
 
 	const positions = matchedLines.map(match => convert.positionToOffset(new EditorPosition(match + 1, 1)));
@@ -246,10 +236,12 @@ function tryWhitespaceFlexibleMatch(text: string, oldStr: string, newStr: string
 		return {
 			text,
 			type: 'multiple',
-			editPosition: [],
-			matchPositions: positions,
-			suggestion: "Multiple matches found with flexible whitespace. Make your search string more unique.",
-			strategy: 'whitespace',
+			editPosition: undefined,
+			matchInfo: {
+				strategy: 'whitespace',
+				matchPositions: positions,
+				suggestion: "Multiple matches found with flexible whitespace. Make your search string more unique."
+			}
 		};
 	}
 
@@ -259,8 +251,12 @@ function tryWhitespaceFlexibleMatch(text: string, oldStr: string, newStr: string
 	const replaced = text.slice(0, startIdx) + newStr + eol + text.slice(endIdx);
 	return {
 		text: replaced,
-		editPosition: [[startIdx, endIdx]],
+		editPosition: [startIdx, endIdx],
 		type: 'whitespace',
+		matchInfo: {
+			strategy: 'whitespace-flexible',
+			matchPositions: positions
+		}
 	};
 }
 
@@ -289,21 +285,18 @@ function tryFuzzyMatch(text: string, oldStr: string, newStr: string, eol: string
 
 	const matches = Array.from(text.matchAll(regex));
 	if (matches.length === 0) {
-		return {
-			text,
-			editPosition: [],
-			type: 'none',
-			suggestion: 'No fuzzy match found.'
-		};
+		return { text, editPosition: undefined, type: 'none' };
 	}
 	if (matches.length > 1) {
 		return {
 			text,
 			type: 'multiple',
-			editPosition: [],
-			suggestion: "Multiple fuzzy matches found. Try including more context in your search string.",
-			strategy: 'fuzzy',
-			matchPositions: matches.map(match => match.index || 0),
+			editPosition: undefined,
+			matchInfo: {
+				strategy: 'fuzzy',
+				matchPositions: matches.map(match => match.index || 0),
+				suggestion: "Multiple fuzzy matches found. Try including more context in your search string."
+			}
 		};
 	}
 
@@ -315,7 +308,11 @@ function tryFuzzyMatch(text: string, oldStr: string, newStr: string, eol: string
 	return {
 		text: replaced,
 		type: 'fuzzy',
-		editPosition: [[startIdx, endIdx]],
+		editPosition: [startIdx, endIdx],
+		matchInfo: {
+			strategy: 'fuzzy',
+			matchPositions: [startIdx]
+		}
 	};
 }
 
@@ -326,7 +323,7 @@ function tryFuzzyMatch(text: string, oldStr: string, newStr: string, eol: string
 function trySimilarityMatch(text: string, oldStr: string, newStr: string, eol: string, threshold: number = 0.95): MatchResult {
 	// Skip similarity matching for very large strings or too many lines
 	if (oldStr.length > 1000 || oldStr.split(eol).length > 20) {
-		return { text, editPosition: [], type: 'none' };
+		return { text, editPosition: undefined, type: 'none' };
 	}
 
 	const lines = text.split(eol);
@@ -334,7 +331,7 @@ function trySimilarityMatch(text: string, oldStr: string, newStr: string, eol: s
 
 	// Don't try similarity matching for very large files
 	if (lines.length > 1000) {
-		return { text, editPosition: [], type: 'none' };
+		return { text, editPosition: undefined, type: 'none' };
 	}
 
 	let bestMatch = { index: -1, similarity: 0, length: 0 };
@@ -366,13 +363,17 @@ function trySimilarityMatch(text: string, oldStr: string, newStr: string, eol: s
 		return {
 			text: newLines.join(eol),
 			type: 'similarity',
-			editPosition: [[startIndex, startIndex + bestMatch.length]],
-			similarity: bestMatch.similarity,
-			suggestion: `Used similarity matching (${(bestMatch.similarity * 100).toFixed(1)}% similar). Verify the replacement.`
+			editPosition: [startIndex, startIndex + bestMatch.length],
+			matchInfo: {
+				strategy: 'similarity',
+				similarity: bestMatch.similarity,
+				matchPositions: [startIndex],
+				suggestion: `Used similarity matching (${(bestMatch.similarity * 100).toFixed(1)}% similar). Verify the replacement.`
+			}
 		};
 	}
 
-	return { text, editPosition: [], type: 'none' };
+	return { text, editPosition: undefined, type: 'none' };
 }
 
 // Function to generate a simple patch
@@ -432,20 +433,19 @@ export async function applyEdit(
 					if (!old_string.endsWith(eol) && originalFile.includes(old_string + eol)) {
 						updatedFile = originalFile.replace(old_string + eol, new_string);
 
-						if (result.editPosition.length) {
-							const [start, end] = result.editPosition[0];
-							const range = new Range(document.positionAt(start), document.positionAt(end));
+						if (result.editPosition) {
+							const range = new Range(document.positionAt(result.editPosition[0]), document.positionAt(result.editPosition[1]));
 							workspaceEdit.delete(uri, range);
 						}
 					} else {
-						const suggestion = result?.suggestion || 'The string to replace must match exactly.';
+						const suggestion = result.matchInfo?.suggestion || 'The string to replace must match exactly.';
 						throw new NoMatchError(
 							`Could not find matching text to replace. ${suggestion}`,
 							filePath
 						);
 					}
 				} else if (result.type === 'multiple') {
-					const suggestion = result?.suggestion || 'Please provide a more specific string.';
+					const suggestion = result.matchInfo?.suggestion || 'Please provide a more specific string.';
 					throw new MultipleMatchesError(
 						`Multiple matches found for the text to replace. ${suggestion}`,
 						filePath
@@ -453,9 +453,8 @@ export async function applyEdit(
 				} else {
 					updatedFile = result.text;
 
-					if (result.editPosition.length) {
-						const [start, end] = result.editPosition[0];
-						const range = new Range(document.positionAt(start), document.positionAt(end));
+					if (result.editPosition) {
+						const range = new Range(document.positionAt(result.editPosition[0]), document.positionAt(result.editPosition[1]));
 						workspaceEdit.delete(uri, range);
 					}
 				}
@@ -464,13 +463,13 @@ export async function applyEdit(
 				const result = findAndReplaceOne(originalFile, old_string, new_string, eol);
 
 				if (result.type === 'none') {
-					const suggestion = result?.suggestion || 'The string to replace must match exactly or be a valid fuzzy match.';
+					const suggestion = result.matchInfo?.suggestion || 'The string to replace must match exactly or be a valid fuzzy match.';
 					throw new NoMatchError(
 						`Could not find matching text to replace. ${suggestion}`,
 						filePath
 					);
 				} else if (result.type === 'multiple') {
-					const suggestion = result?.suggestion || 'Please provide a more specific string.';
+					const suggestion = result.matchInfo?.suggestion || 'Please provide a more specific string.';
 					throw new MultipleMatchesError(
 						`Multiple matches found for the text to replace. ${suggestion}`,
 						filePath
@@ -478,22 +477,21 @@ export async function applyEdit(
 				} else {
 					updatedFile = result.text;
 
-					if (result.editPosition.length) {
-						const [start, end] = result.editPosition[0];
-						const range = new Range(document.positionAt(start), document.positionAt(end));
+					if (result.editPosition) {
+						const range = new Range(document.positionAt(result.editPosition[0]), document.positionAt(result.editPosition[1]));
 						workspaceEdit.replace(uri, range, new_string);
 					}
 
 					// If we used similarity matching, add a warning
-					if (result.type === 'similarity' && result?.similarity) {
-						console.warn(`Used similarity matching with ${(result.similarity * 100).toFixed(1)}% confidence. Verify the result is correct.`);
+					if (result.type === 'similarity' && result.matchInfo?.similarity) {
+						console.warn(`Used similarity matching with ${(result.matchInfo.similarity * 100).toFixed(1)}% confidence. Verify the result is correct.`);
 					}
 				}
 			}
 
 			if (updatedFile === originalFile) {
 				throw new NoChangeError(
-					'Original and edited file match exactly. Failed to apply edit. Use the ${ToolName.ReadFile} tool to re-read the file and and determine the correct edit.',
+					'Original and edited file match exactly. Failed to apply edit.',
 					filePath
 				);
 			}

--- a/src/extension/tools/node/editFileToolUtils.tsx
+++ b/src/extension/tools/node/editFileToolUtils.tsx
@@ -109,20 +109,27 @@ function calculateSimilarity(str1: string, str2: string): number {
 	return 1 - distance / maxLength;
 }
 
-/**
- * Interface for match result with additional information
- */
-interface MatchResult {
+interface MatchResultCommon {
+	type: string;
+	/** Replacement text */
 	text: string;
-	type: 'exact' | 'fuzzy' | 'whitespace' | 'similarity' | 'multiple' | 'none';
-	editPosition: number[] | undefined;
-	matchInfo?: {
-		strategy: string;
-		matchPositions?: number[];
-		similarity?: number;
-		suggestion?: string;
-	};
+	/** Array of [startIndex, endIndex] to replace in the file content */
+	editPosition: [number, number][];
+	/** Model suggestion to correct a fialing match */
+	suggestion?: string;
 }
+
+/**
+ * Type-safe union type for match results with discriminated unions
+ */
+type MatchResult = MatchResultCommon & (
+	| { text: string; type: 'none'; suggestion?: string }
+	| { text: string; type: 'exact' }
+	| { text: string; type: 'fuzzy' }
+	| { text: string; type: 'whitespace' }
+	| { text: string; type: 'similarity'; suggestion: string; similarity: number }
+	| { text: string; type: 'multiple'; suggestion: string; matchPositions: number[]; strategy: 'exact' | 'fuzzy' | 'whitespace' }
+);
 
 /**
  * Enhanced version of findAndReplaceOne with more robust matching strategies
@@ -167,11 +174,8 @@ export function findAndReplaceOne(
 	return {
 		text,
 		type: 'none',
-		editPosition: undefined,
-		matchInfo: {
-			strategy: 'none',
-			suggestion: `Try making your search string more specific or checking for whitespace/formatting differences.`
-		}
+		editPosition: [],
+		suggestion: `Try making your search string more specific or checking for whitespace/formatting differences.`
 	};
 }
 
@@ -179,35 +183,36 @@ export function findAndReplaceOne(
  * Tries to find an exact match of oldStr in text.
  */
 function tryExactMatch(text: string, oldStr: string, newStr: string): MatchResult {
-	const firstExactIdx = text.indexOf(oldStr);
-	if (firstExactIdx !== -1) {
-		// Check for multiple exact occurrences.
-		const secondExactIdx = text.indexOf(oldStr, firstExactIdx + oldStr.length);
-		if (secondExactIdx !== -1) {
-			return {
-				text,
-				type: 'multiple',
-				editPosition: [firstExactIdx, firstExactIdx + oldStr.length],
-				matchInfo: {
-					strategy: 'exact',
-					matchPositions: [firstExactIdx, secondExactIdx],
-					suggestion: "Multiple exact matches found. Make your search string more specific."
-				}
-			};
-		}
-		// Exactly one exact match found.
-		const replaced = text.slice(0, firstExactIdx) + newStr + text.slice(firstExactIdx + oldStr.length);
+	const matchPositions: number[] = [];
+	for (let searchIdx = 0; ;) {
+		const idx = text.indexOf(oldStr, searchIdx);
+		if (idx === -1) { break; }
+		matchPositions.push(idx);
+		searchIdx = idx + oldStr.length;
+	}
+	if (matchPositions.length === 0) {
+		return { text, editPosition: [], type: 'none' };
+	}
+
+	// Check for multiple exact occurrences.
+	if (matchPositions.length > 1) {
 		return {
-			text: replaced,
-			type: 'exact',
-			editPosition: [firstExactIdx, firstExactIdx + oldStr.length],
-			matchInfo: {
-				strategy: 'exact',
-				matchPositions: [firstExactIdx]
-			}
+			text,
+			type: 'multiple',
+			editPosition: matchPositions.map(idx => [idx, idx + oldStr.length]),
+			strategy: 'exact',
+			matchPositions,
+			suggestion: "Multiple exact matches found. Make your search string more specific."
 		};
 	}
-	return { text, editPosition: undefined, type: 'none' };
+	// Exactly one exact match found.
+	const firstExactIdx = matchPositions[0];
+	const replaced = text.slice(0, firstExactIdx) + newStr + text.slice(firstExactIdx + oldStr.length);
+	return {
+		text: replaced,
+		type: 'exact',
+		editPosition: [[firstExactIdx, firstExactIdx + oldStr.length]],
+	};
 }
 
 /**
@@ -227,7 +232,12 @@ function tryWhitespaceFlexibleMatch(text: string, oldStr: string, newStr: string
 		}
 	}
 	if (matchedLines.length === 0) {
-		return { text, editPosition: undefined, type: 'none' };
+		return {
+			text,
+			editPosition: [],
+			type: 'none',
+			suggestion: 'No whitespace-flexible match found.'
+		};
 	}
 
 	const positions = matchedLines.map(match => convert.positionToOffset(new EditorPosition(match + 1, 1)));
@@ -236,12 +246,10 @@ function tryWhitespaceFlexibleMatch(text: string, oldStr: string, newStr: string
 		return {
 			text,
 			type: 'multiple',
-			editPosition: undefined,
-			matchInfo: {
-				strategy: 'whitespace',
-				matchPositions: positions,
-				suggestion: "Multiple matches found with flexible whitespace. Make your search string more unique."
-			}
+			editPosition: [],
+			matchPositions: positions,
+			suggestion: "Multiple matches found with flexible whitespace. Make your search string more unique.",
+			strategy: 'whitespace',
 		};
 	}
 
@@ -251,12 +259,8 @@ function tryWhitespaceFlexibleMatch(text: string, oldStr: string, newStr: string
 	const replaced = text.slice(0, startIdx) + newStr + eol + text.slice(endIdx);
 	return {
 		text: replaced,
-		editPosition: [startIdx, endIdx],
+		editPosition: [[startIdx, endIdx]],
 		type: 'whitespace',
-		matchInfo: {
-			strategy: 'whitespace-flexible',
-			matchPositions: positions
-		}
 	};
 }
 
@@ -285,18 +289,21 @@ function tryFuzzyMatch(text: string, oldStr: string, newStr: string, eol: string
 
 	const matches = Array.from(text.matchAll(regex));
 	if (matches.length === 0) {
-		return { text, editPosition: undefined, type: 'none' };
+		return {
+			text,
+			editPosition: [],
+			type: 'none',
+			suggestion: 'No fuzzy match found.'
+		};
 	}
 	if (matches.length > 1) {
 		return {
 			text,
 			type: 'multiple',
-			editPosition: undefined,
-			matchInfo: {
-				strategy: 'fuzzy',
-				matchPositions: matches.map(match => match.index || 0),
-				suggestion: "Multiple fuzzy matches found. Try including more context in your search string."
-			}
+			editPosition: [],
+			suggestion: "Multiple fuzzy matches found. Try including more context in your search string.",
+			strategy: 'fuzzy',
+			matchPositions: matches.map(match => match.index || 0),
 		};
 	}
 
@@ -308,11 +315,7 @@ function tryFuzzyMatch(text: string, oldStr: string, newStr: string, eol: string
 	return {
 		text: replaced,
 		type: 'fuzzy',
-		editPosition: [startIdx, endIdx],
-		matchInfo: {
-			strategy: 'fuzzy',
-			matchPositions: [startIdx]
-		}
+		editPosition: [[startIdx, endIdx]],
 	};
 }
 
@@ -323,7 +326,7 @@ function tryFuzzyMatch(text: string, oldStr: string, newStr: string, eol: string
 function trySimilarityMatch(text: string, oldStr: string, newStr: string, eol: string, threshold: number = 0.95): MatchResult {
 	// Skip similarity matching for very large strings or too many lines
 	if (oldStr.length > 1000 || oldStr.split(eol).length > 20) {
-		return { text, editPosition: undefined, type: 'none' };
+		return { text, editPosition: [], type: 'none' };
 	}
 
 	const lines = text.split(eol);
@@ -331,7 +334,7 @@ function trySimilarityMatch(text: string, oldStr: string, newStr: string, eol: s
 
 	// Don't try similarity matching for very large files
 	if (lines.length > 1000) {
-		return { text, editPosition: undefined, type: 'none' };
+		return { text, editPosition: [], type: 'none' };
 	}
 
 	let bestMatch = { index: -1, similarity: 0, length: 0 };
@@ -363,17 +366,13 @@ function trySimilarityMatch(text: string, oldStr: string, newStr: string, eol: s
 		return {
 			text: newLines.join(eol),
 			type: 'similarity',
-			editPosition: [startIndex, startIndex + bestMatch.length],
-			matchInfo: {
-				strategy: 'similarity',
-				similarity: bestMatch.similarity,
-				matchPositions: [startIndex],
-				suggestion: `Used similarity matching (${(bestMatch.similarity * 100).toFixed(1)}% similar). Verify the replacement.`
-			}
+			editPosition: [[startIndex, startIndex + bestMatch.length]],
+			similarity: bestMatch.similarity,
+			suggestion: `Used similarity matching (${(bestMatch.similarity * 100).toFixed(1)}% similar). Verify the replacement.`
 		};
 	}
 
-	return { text, editPosition: undefined, type: 'none' };
+	return { text, editPosition: [], type: 'none' };
 }
 
 // Function to generate a simple patch
@@ -433,19 +432,20 @@ export async function applyEdit(
 					if (!old_string.endsWith(eol) && originalFile.includes(old_string + eol)) {
 						updatedFile = originalFile.replace(old_string + eol, new_string);
 
-						if (result.editPosition) {
-							const range = new Range(document.positionAt(result.editPosition[0]), document.positionAt(result.editPosition[1]));
+						if (result.editPosition.length) {
+							const [start, end] = result.editPosition[0];
+							const range = new Range(document.positionAt(start), document.positionAt(end));
 							workspaceEdit.delete(uri, range);
 						}
 					} else {
-						const suggestion = result.matchInfo?.suggestion || 'The string to replace must match exactly.';
+						const suggestion = result?.suggestion || 'The string to replace must match exactly.';
 						throw new NoMatchError(
 							`Could not find matching text to replace. ${suggestion}`,
 							filePath
 						);
 					}
 				} else if (result.type === 'multiple') {
-					const suggestion = result.matchInfo?.suggestion || 'Please provide a more specific string.';
+					const suggestion = result?.suggestion || 'Please provide a more specific string.';
 					throw new MultipleMatchesError(
 						`Multiple matches found for the text to replace. ${suggestion}`,
 						filePath
@@ -453,8 +453,9 @@ export async function applyEdit(
 				} else {
 					updatedFile = result.text;
 
-					if (result.editPosition) {
-						const range = new Range(document.positionAt(result.editPosition[0]), document.positionAt(result.editPosition[1]));
+					if (result.editPosition.length) {
+						const [start, end] = result.editPosition[0];
+						const range = new Range(document.positionAt(start), document.positionAt(end));
 						workspaceEdit.delete(uri, range);
 					}
 				}
@@ -463,13 +464,13 @@ export async function applyEdit(
 				const result = findAndReplaceOne(originalFile, old_string, new_string, eol);
 
 				if (result.type === 'none') {
-					const suggestion = result.matchInfo?.suggestion || 'The string to replace must match exactly or be a valid fuzzy match.';
+					const suggestion = result?.suggestion || 'The string to replace must match exactly or be a valid fuzzy match.';
 					throw new NoMatchError(
 						`Could not find matching text to replace. ${suggestion}`,
 						filePath
 					);
 				} else if (result.type === 'multiple') {
-					const suggestion = result.matchInfo?.suggestion || 'Please provide a more specific string.';
+					const suggestion = result?.suggestion || 'Please provide a more specific string.';
 					throw new MultipleMatchesError(
 						`Multiple matches found for the text to replace. ${suggestion}`,
 						filePath
@@ -477,14 +478,15 @@ export async function applyEdit(
 				} else {
 					updatedFile = result.text;
 
-					if (result.editPosition) {
-						const range = new Range(document.positionAt(result.editPosition[0]), document.positionAt(result.editPosition[1]));
+					if (result.editPosition.length) {
+						const [start, end] = result.editPosition[0];
+						const range = new Range(document.positionAt(start), document.positionAt(end));
 						workspaceEdit.replace(uri, range, new_string);
 					}
 
 					// If we used similarity matching, add a warning
-					if (result.type === 'similarity' && result.matchInfo?.similarity) {
-						console.warn(`Used similarity matching with ${(result.matchInfo.similarity * 100).toFixed(1)}% confidence. Verify the result is correct.`);
+					if (result.type === 'similarity' && result?.similarity) {
+						console.warn(`Used similarity matching with ${(result.similarity * 100).toFixed(1)}% confidence. Verify the result is correct.`);
 					}
 				}
 			}

--- a/src/extension/tools/node/editFileToolUtils.tsx
+++ b/src/extension/tools/node/editFileToolUtils.tsx
@@ -493,7 +493,7 @@ export async function applyEdit(
 
 			if (updatedFile === originalFile) {
 				throw new NoChangeError(
-					'Original and edited file match exactly. Failed to apply edit.',
+					'Original and edited file match exactly. Failed to apply edit. Use the ${ToolName.ReadFile} tool to re-read the file and and determine the correct edit.',
 					filePath
 				);
 			}

--- a/src/extension/tools/node/replaceStringTool.tsx
+++ b/src/extension/tools/node/replaceStringTool.tsx
@@ -20,6 +20,7 @@ import { IWorkspaceService } from '../../../platform/workspace/common/workspaceS
 import { ChatResponseStreamImpl } from '../../../util/common/chatResponseStreamImpl';
 import { removeLeadingFilepathComment } from '../../../util/common/markdown';
 import { timeout } from '../../../util/vs/base/common/async';
+import { URI } from '../../../util/vs/base/common/uri';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { ChatResponseTextEditPart, EndOfLine, LanguageModelPromptTsxPart, LanguageModelToolResult, WorkspaceEdit } from '../../../vscodeTypes';
 import { IBuildPromptContext } from '../../prompt/common/intents';
@@ -29,7 +30,7 @@ import { ToolName } from '../common/toolNames';
 import { ICopilotTool, ToolRegistry } from '../common/toolsRegistry';
 import { IToolsService } from '../common/toolsService';
 import { ActionType } from './applyPatch/parser';
-import { CorrectedEditResult, ensureCorrectEdit } from './editFileCorrectorGemini';
+import { CorrectedEditResult, healReplaceStringParams } from './editFileHealing';
 import { EditFileResult } from './editFileToolResult';
 import { EditError, NoMatchError, applyEdit } from './editFileToolUtils';
 import { sendEditNotebookTelemetry } from './editNotebookTool';
@@ -67,13 +68,13 @@ export class ReplaceStringTool implements ICopilotTool<IReplaceStringToolParams>
 		try {
 			await this.instantiationService.invokeFunction(accessor => assertFileOkForTool(accessor, uri));
 		} catch (error) {
-			this.sendReplaceTelemetry('invalidFile', options, undefined, undefined);
+			this.sendReplaceTelemetry('invalidFile', options, undefined, undefined, undefined);
 			throw error;
 		}
 
 		// Validate parameters
 		if (!options.input.filePath || options.input.oldString === undefined || options.input.newString === undefined || !this._promptContext?.stream) {
-			this.sendReplaceTelemetry('invalidStrings', options, undefined, undefined);
+			this.sendReplaceTelemetry('invalidStrings', options, undefined, undefined, undefined);
 			throw new Error('Invalid input');
 		}
 
@@ -99,75 +100,9 @@ export class ReplaceStringTool implements ICopilotTool<IReplaceStringToolParams>
 				});
 			}
 
-			const filePath = this.promptPathRepresentationService.getFilePath(document.uri);
-
-			let originalError = 'none';
-			let ensuredGenerationError = 'none';
-			let postCorrectError = 'none';
-
-
-			const eol = document instanceof TextDocumentSnapshot && document.eol === EndOfLine.CRLF ? '\r\n' : '\n';
-			const oldString = removeLeadingFilepathComment(options.input.oldString, document.languageId, filePath).replace(/\r?\n/g, eol);
-			const newString = removeLeadingFilepathComment(options.input.newString, document.languageId, filePath).replace(/\r?\n/g, eol);
-
+			const didHealRef = { didHeal: false };
 			try {
-				// Apply the edit using the improved applyEdit function that uses VS Code APIs
-				const workspaceEdit = new WorkspaceEdit();
-				let updatedFile: string;
-				try {
-					const result = await applyEdit(
-						uri,
-						oldString,
-						newString,
-						workspaceEdit,
-						this.workspaceService,
-						this.notebookService,
-						this.alternativeNotebookContent,
-						this._promptContext.request?.model
-					);
-					updatedFile = result.updatedFile;
-				} catch (e) {
-					originalError = (e as any).kindForTelemetry || e.constructor.name;
-					if (e instanceof NoMatchError) {
-						let corrected: CorrectedEditResult;
-						try {
-							corrected = await ensureCorrectEdit(
-								document.getText(),
-								{
-									explanation: options.input.explanation,
-									filePath: filePath,
-									oldString,
-									newString,
-								},
-								eol,
-								await this.endpointProvider.getChatEndpoint(CHAT_MODEL.GPT4OMINI),
-								token
-							);
-						} catch (e2) {
-							ensuredGenerationError = e2.stack || String(e2);
-							throw e;
-						}
-
-						try {
-							const result = await applyEdit(
-								uri,
-								corrected.params.oldString,
-								corrected.params.newString,
-								workspaceEdit,
-								this.workspaceService,
-								this.notebookService,
-								this.alternativeNotebookContent,
-								this._promptContext.request?.model
-							);
-							updatedFile = result.updatedFile;
-						} catch (e3) {
-							postCorrectError = (e3 as any).kindForTelemetry || e3.constructor.name;
-							throw e;
-						}
-					} else {
-						throw e;
-					}
-				}
+				const { workspaceEdit, updatedFile } = await this.generateEdit(uri, document, options, didHealRef, token);
 
 				this._promptContext.stream.markdown('\n```\n');
 				this._promptContext.stream.codeblockUri(uri, true);
@@ -217,7 +152,7 @@ export class ReplaceStringTool implements ICopilotTool<IReplaceStringToolParams>
 
 				this._promptContext.stream.markdown('\n```\n');
 
-				void this.sendReplaceTelemetry('success', options, document.getText(), isNotebook);
+				void this.sendReplaceTelemetry('success', options, document.getText(), isNotebook, didHealRef.didHeal);
 				return new LanguageModelToolResult([
 					new LanguageModelPromptTsxPart(
 						await renderPromptElementJSON(
@@ -255,7 +190,7 @@ export class ReplaceStringTool implements ICopilotTool<IReplaceStringToolParams>
 					errorMessage += `${error.message}`;
 				}
 
-				void this.sendReplaceTelemetry(outcome, options, document.getText(), isNotebook);
+				void this.sendReplaceTelemetry(outcome, options, document.getText(), isNotebook, didHealRef.didHeal);
 
 				// No edit, so no need to wait for diagnostics
 				const diagnosticsTimeout = 0;
@@ -273,20 +208,80 @@ export class ReplaceStringTool implements ICopilotTool<IReplaceStringToolParams>
 						),
 					)
 				]);
-			} finally {
-				console.log('#stringReplaceErr', JSON.stringify({
-					originalError,
-					ensuredGenerationError,
-					postCorrectError,
-					didPostCorrect: originalError === 'none' && ensuredGenerationError === 'none' && postCorrectError !== 'none',
-					okInitially: originalError === 'none',
-				}));
 			}
 		}
 	}
 
-	private async sendReplaceTelemetry(outcome: string, options: vscode.LanguageModelToolInvocationOptions<IReplaceStringToolParams>, file: string | undefined, isNotebookDocument: boolean | undefined) {
-		const model = options.model && (await this.endpointProvider.getChatEndpoint(options.model)).model;
+	private async generateEdit(uri: URI, document: TextDocumentSnapshot | NotebookDocumentSnapshot, options: vscode.LanguageModelToolInvocationOptions<IReplaceStringToolParams>, didHealRef: { didHeal: boolean }, token: vscode.CancellationToken) {
+		const filePath = this.promptPathRepresentationService.getFilePath(document.uri);
+		const eol = document instanceof TextDocumentSnapshot && document.eol === EndOfLine.CRLF ? '\r\n' : '\n';
+		const oldString = removeLeadingFilepathComment(options.input.oldString, document.languageId, filePath).replace(/\r?\n/g, eol);
+		const newString = removeLeadingFilepathComment(options.input.newString, document.languageId, filePath).replace(/\r?\n/g, eol);
+
+		// Apply the edit using the improved applyEdit function that uses VS Code APIs
+		const workspaceEdit = new WorkspaceEdit();
+		let updatedFile: string;
+		try {
+			const result = await applyEdit(
+				uri,
+				oldString,
+				newString,
+				workspaceEdit,
+				this.workspaceService,
+				this.notebookService,
+				this.alternativeNotebookContent,
+				this._promptContext?.request?.model
+			);
+			updatedFile = result.updatedFile;
+		} catch (e) {
+			if (!(e instanceof NoMatchError)) {
+				throw e;
+			}
+
+			didHealRef.didHeal = true;
+
+			let healed: CorrectedEditResult;
+			try {
+				healed = await healReplaceStringParams(
+					document.getText(),
+					{
+						explanation: options.input.explanation,
+						filePath: filePath,
+						oldString,
+						newString,
+					},
+					eol,
+					await this.endpointProvider.getChatEndpoint(CHAT_MODEL.GPT4OMINI),
+					token
+				);
+			} catch (e2) {
+				this.sendHealingTelemetry(options, String(e2), undefined);
+				throw e; // original error
+			}
+
+			try {
+				const result = await applyEdit(
+					uri,
+					healed.params.oldString,
+					healed.params.newString,
+					workspaceEdit,
+					this.workspaceService,
+					this.notebookService,
+					this.alternativeNotebookContent,
+					this._promptContext?.request?.model
+				);
+				updatedFile = result.updatedFile;
+			} catch (e2) {
+				this.sendHealingTelemetry(options, undefined, String(e2));
+				throw e; // original error
+			}
+		}
+
+		return { workspaceEdit, updatedFile };
+	}
+
+	private async sendReplaceTelemetry(outcome: string, options: vscode.LanguageModelToolInvocationOptions<IReplaceStringToolParams>, file: string | undefined, isNotebookDocument: boolean | undefined, didHeal: boolean | undefined) {
+		const model = await this.modelForTelemetry(options);
 		const isNotebook = isNotebookDocument ? 1 : (isNotebookDocument === false ? 0 : -1);
 		/* __GDPR__
 			"replaceStringToolInvoked" : {
@@ -296,7 +291,8 @@ export class ReplaceStringTool implements ICopilotTool<IReplaceStringToolParams>
 				"interactionId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The id of the current interaction." },
 				"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the invocation was successful, or a failure reason" },
 				"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model that invoked the tool" },
-				"isNotebook": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Whether the document is a notebook, 1 = yes, 0 = no, other = unknown." }
+				"isNotebook": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Whether the document is a notebook, 1 = yes, 0 = no, other = unknown." },
+				"didHeal": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Whether the document is a notebook, 1 = yes, 0 = no, other = unknown." }
 			}
 		*/
 		this.telemetryService.sendMSFTTelemetryEvent('replaceStringToolInvoked',
@@ -305,7 +301,7 @@ export class ReplaceStringTool implements ICopilotTool<IReplaceStringToolParams>
 				interactionId: options.chatRequestId,
 				outcome,
 				model
-			}, { isNotebook }
+			}, { isNotebook, didHeal: didHeal === undefined ? -1 : (didHeal ? 1 : 0) }
 		);
 
 		this.telemetryService.sendEnhancedGHTelemetryEvent('replaceStringTool', multiplexProperties({
@@ -315,6 +311,35 @@ export class ReplaceStringTool implements ICopilotTool<IReplaceStringToolParams>
 			completionTextJson: JSON.stringify(options.input),
 			postProcessingOutcome: outcome,
 		}), { isNotebook });
+	}
+
+	private async sendHealingTelemetry(options: vscode.LanguageModelToolInvocationOptions<IReplaceStringToolParams>, healError: string | undefined, applicationError: string | undefined) {
+		/* __GDPR__
+			"replaceStringHealingStat" : {
+				"owner": "roblourens",
+				"comment": "The replace_string tool was invoked",
+				"requestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The id of the current request turn." },
+				"interactionId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The id of the current interaction." },
+				"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model that invoked the tool" },
+				"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the invocation was successful, or a failure reason" },
+				"healError": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Any error that happened during healing" },
+				"applicationError": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Any error that happened after application" },
+				"success": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Whether the document is a notebook, 1 = yes, 0 = no, other = unknown." }
+			}
+		*/
+		this.telemetryService.sendMSFTTelemetryEvent('replaceStringHealingStat',
+			{
+				requestId: options.chatRequestId,
+				interactionId: options.chatRequestId,
+				model: await this.modelForTelemetry(options),
+				healError,
+				applicationError,
+			}, { success: healError === undefined && applicationError === undefined ? 1 : 0 }
+		);
+	}
+
+	private async modelForTelemetry(options: vscode.LanguageModelToolInvocationOptions<IReplaceStringToolParams>) {
+		return options.model && (await this.endpointProvider.getChatEndpoint(options.model)).model;
 	}
 
 	async resolveInput(input: IReplaceStringToolParams, promptContext: IBuildPromptContext): Promise<IReplaceStringToolParams> {

--- a/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -43,3 +43,12 @@ export function modelSupportsReplaceString(model: LanguageModelChat | IChatEndpo
 export function modelMightUseReplaceStringExclusively(model: LanguageModelChat | IChatEndpoint): boolean {
 	return model.family.startsWith('claude') || model.family.startsWith('Anthropic');
 }
+
+/**
+ * Whether, when replace_string and insert_edit tools are both available,
+ * verbiage should be added in the system prompt directing the model to prefer
+ * replace_string.
+ */
+export function modelNeedsStrongReplaceStringHint(model: LanguageModelChat | IChatEndpoint): boolean {
+	return model.family.toLowerCase().includes('gemini');
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/microsoft/vscode-copilot-chat/pull/251. What this does:

- Updates the tool description of replace_string_in_file to be more explicit for Gemini (does not appear to have much impact either way for Sonnet)
- Updates edit instructions such that the model prefers replace_string_in_file when present (note: Sonnet sees replace_string_in_file as its only edit tool, so no effect there)
- Adds a "healing" step for replace_string_in_file, can be disabled via EXP.