### PR TITLE
nes: fix `hasNextEdit` field to be more trustworthy

### DIFF
--- a/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -266,6 +266,8 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		}
 
 		tracer.trace('returning next edit result');
+		telemetryBuilder.setHasNextEdit(true);
+
 		return nextEditResult;
 	}
 

--- a/src/extension/inlineEdits/node/nextEditProviderTelemetry.ts
+++ b/src/extension/inlineEdits/node/nextEditProviderTelemetry.ts
@@ -70,6 +70,7 @@ export interface ILlmNESTelemetry extends Partial<IStatelessNextEditTelemetry> {
 	readonly activeDocumentEditsCount: number | undefined;
 	readonly activeDocumentLanguageId: string | undefined;
 	readonly activeDocumentRepository: string | undefined;
+	readonly hasNextEdit: boolean;
 	readonly wasPreviouslyRejected: boolean;
 	readonly status: NextEditTelemetryStatus;
 	readonly nesConfigs: INesConfigs | undefined;
@@ -236,6 +237,7 @@ export class LlmNESTelemetryBuilder extends Disposable {
 			activeDocumentLanguageId,
 			activeDocumentOriginalLineCount,
 			fetchStartedAfterMs,
+			hasNextEdit: this._hasNextEdit,
 			wasPreviouslyRejected: this._wasPreviouslyRejected,
 			isNotebook: isNotebook,
 			status: this._status,
@@ -314,6 +316,12 @@ export class LlmNESTelemetryBuilder extends Disposable {
 	private _statelessNextEditTelemetry: IStatelessNextEditTelemetry | undefined;
 	public setStatelessNextEditTelemetry(statelessNextEditTelemetry: IStatelessNextEditTelemetry): this {
 		this._statelessNextEditTelemetry = statelessNextEditTelemetry;
+		return this;
+	}
+
+	private _hasNextEdit: boolean = false;
+	public setHasNextEdit(hasNextEdit: boolean): this {
+		this._hasNextEdit = hasNextEdit;
 		return this;
 	}
 
@@ -701,7 +709,7 @@ export class TelemetrySender implements IDisposable {
 		"promptCharCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Number of characters in the prompt", "isMeasurement": true },
 		"hadLowLogProbSuggestion": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the suggestion had low log probability", "isMeasurement": true },
 		"nEditsSuggested": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Number of edits suggested", "isMeasurement": true },
-		"hasNextEdit": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether there is a next edit", "isMeasurement": true },
+		"hasNextEdit": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether next edit provider returned an edit (if an edit was previously rejected, this field is false)", "isMeasurement": true },
 		"nextEditLogprob": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Log probability of the next edit", "isMeasurement": true },
 		"lineDistanceToMostRecentEdit": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Line distance to most recent edit", "isMeasurement": true },
 		"isCursorAtEndOfLine": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the cursor is at the end of the line", "isMeasurement": true },

--- a/src/platform/inlineEdits/common/statelessNextEditProvider.ts
+++ b/src/platform/inlineEdits/common/statelessNextEditProvider.ts
@@ -287,7 +287,6 @@ export interface IStatelessNextEditTelemetry {
 	readonly lineDistanceToMostRecentEdit: number | undefined;
 
 	/* result info */
-	readonly hasNextEdit: boolean;
 	readonly nextEditLogprob: number | undefined;
 	readonly noNextEditReasonKind: string | undefined;
 	readonly noNextEditReasonMessage: string | undefined;
@@ -323,7 +322,6 @@ export class StatelessNextEditTelemetryBuilder {
 		const promptLineCount = promptText?.split('\n').length;
 		const promptCharCount = promptText?.length;
 
-		const hasNextEdit = result.isOk();
 		const noNextEditReasonKind = result.isOk() ? undefined : result.err.kind;
 
 		let noNextEditReasonMessage: string | undefined;
@@ -342,7 +340,6 @@ export class StatelessNextEditTelemetryBuilder {
 		return {
 			hadStatelessNextEditProviderCall: true,
 
-			hasNextEdit,
 			noNextEditReasonKind,
 			noNextEditReasonMessage,
 


### PR DESCRIPTION
Previous way of computation of this field came from stateless provider, ie it missed if the edit would come from cache, and in general if stream errored, then it could still be set, etc. Now it should be more fail-proof
