### PR TITLE
wait longer for tasks to become idle

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,6 +12,12 @@
 			"script": "watch",
 			"label": "npm: watch - DO NOT USE", // The auto-discovered npm task is also called watch, so we change its name here. This is here until people clear their histories.
 		},
+		  {
+		"label": "Test",
+		"type": "shell",
+		"command": "sleep 1000 && ls -la",
+		"problemMatcher": []
+	},
 		{
 			"label": "watch",
 			"dependsOn": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,12 +12,6 @@
 			"script": "watch",
 			"label": "npm: watch - DO NOT USE", // The auto-discovered npm task is also called watch, so we change its name here. This is here until people clear their histories.
 		},
-		  {
-		"label": "Test",
-		"type": "shell",
-		"command": "sleep 1000 && ls -la",
-		"problemMatcher": []
-	},
 		{
 			"label": "watch",
 			"dependsOn": [

--- a/src/extension/tools/node/runTaskTool.tsx
+++ b/src/extension/tools/node/runTaskTool.tsx
@@ -174,6 +174,7 @@ class RunTaskTool implements vscode.LanguageModelTool<IRunTaskToolInput> {
 			return {
 				invocationMessage: trustedMark(l10n.t`${link(taskLabel ?? options.input.id)} is already running.`),
 				pastTenseMessage: trustedMark(l10n.t`${link(taskLabel ?? options.input.id)} was already running.`),
+				renderStopButton: true,
 				confirmationMessages: undefined
 			};
 		}
@@ -181,6 +182,7 @@ class RunTaskTool implements vscode.LanguageModelTool<IRunTaskToolInput> {
 		return {
 			invocationMessage: trustedMark(l10n.t`Running ${taskLabel ?? link(options.input.id)}`),
 			pastTenseMessage: trustedMark(task?.isBackground ? l10n.t`Started ${link(taskLabel ?? options.input.id)}` : l10n.t`Ran ${link(taskLabel ?? options.input.id)}`),
+			renderStopButton: true,
 			confirmationMessages: task && task.group !== 'build'
 				? { title: l10n.t`Allow task run?`, message: trustedMark(l10n.t`Allow Copilot to run the \`${task.type}\` task ${link(`\`${this.getTaskRepresentation(task)}\``)}?`) }
 				: undefined

--- a/src/extension/tools/node/runTaskTool.tsx
+++ b/src/extension/tools/node/runTaskTool.tsx
@@ -54,8 +54,8 @@ class RunTaskTool implements vscode.LanguageModelTool<IRunTaskToolInput> {
 		const taskRunDurationMs = taskEndTime - taskStartTime;
 		let totalDurationMs: number | undefined;
 
-		// Start with 1000 to ensure the buffer has content, wait up to 13 seconds for the task to become idle
-		const checkIntervals = [1000, 100, 100, 100, 100, 100, 200, 200, 200, 200, 200, 200, 500, 500, 500, 1000, 1000, 2000, 5000];
+		// Start with 1000 to ensure the buffer has content, wait up to 20 seconds for the task to become idle
+		const checkIntervals = [1000, 100, 100, 100, 100, 100, 200, 200, 200, 200, 200, 200, 500, 500, 500, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000];
 
 		let pollStartTime: number | undefined;
 		let pollEndTime: number | undefined;

--- a/src/extension/tools/node/runTaskTool.tsx
+++ b/src/extension/tools/node/runTaskTool.tsx
@@ -54,8 +54,8 @@ class RunTaskTool implements vscode.LanguageModelTool<IRunTaskToolInput> {
 		const taskRunDurationMs = taskEndTime - taskStartTime;
 		let totalDurationMs: number | undefined;
 
-		// Start with 500 to ensure the buffer has content
-		const checkIntervals = [1000, 100, 100, 100, 100, 100];
+		// Start with 1000 to ensure the buffer has content, wait up to 13 seconds for the task to become idle
+		const checkIntervals = [1000, 100, 100, 100, 100, 100, 200, 200, 200, 200, 200, 200, 500, 500, 500, 1000, 1000, 2000, 5000];
 
 		let pollStartTime: number | undefined;
 		let pollEndTime: number | undefined;

--- a/src/extension/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/extension/vscode.proposed.chatParticipantPrivate.d.ts
@@ -203,6 +203,7 @@ declare module 'vscode' {
 	export interface PreparedToolInvocation {
 		pastTenseMessage?: string | MarkdownString;
 		presentation?: 'hidden' | undefined;
+		renderStopButton?: boolean;
 	}
 
 	export interface LanguageModelTool<T> {
@@ -214,12 +215,14 @@ declare module 'vscode' {
 		readonly language: string;
 		readonly confirmationMessages?: LanguageModelToolConfirmationMessages;
 		readonly presentation?: 'hidden' | undefined;
+		readonly renderStopButton?: boolean;
 
 		constructor(
 			command: string,
 			language: string,
 			confirmationMessages?: LanguageModelToolConfirmationMessages,
-			presentation?: 'hidden'
+			presentation?: 'hidden',
+			renderStopButton?: boolean
 		);
 	}
 

--- a/src/extension/vscode.proposed.invocationMessageWithStopAction.d.ts
+++ b/src/extension/vscode.proposed.invocationMessageWithStopAction.d.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	/**
+	 * The result of a call to {@link LanguageModelTool.prepareInvocation}.
+	 */
+	export interface PreparedToolInvocation {
+		renderStopButton: true,
+	}
+
+}


### PR DESCRIPTION
Wait up to 20 seconds with polling to get task output. I'm not sure what time amount is appropriate here 🤔 , but 20 seems like a reasonable amount. Should I increase it to like 120 seconds? I imagine stuff takes that long or longer on windows for example.

fixes https://github.com/microsoft/vscode/issues/256099