### PR TITLE
tools: add a config option to enable gemini replace string

### DIFF
--- a/src/extension/intents/node/agentIntent.ts
+++ b/src/extension/intents/node/agentIntent.ts
@@ -59,7 +59,7 @@ const getTools = (instaService: IInstantiationService, request: vscode.ChatReque
 
 		const allowTools: Record<string, boolean> = {};
 		allowTools[ToolName.EditFile] = true;
-		allowTools[ToolName.ReplaceString] = modelSupportsReplaceString(model) || !!(model.family.includes('gemini') && experimentationService.getTreatmentVariable<boolean>('vscode', 'copilotchat.geminiReplaceString'));
+		allowTools[ToolName.ReplaceString] = modelSupportsReplaceString(model) || !!(model.family.includes('gemini') && configurationService.getExperimentBasedConfig(ConfigKey.Internal.GeminiReplaceString, experimentationService));
 		allowTools[ToolName.ApplyPatch] = modelSupportsApplyPatch(model) && !!toolsService.getTool(ToolName.ApplyPatch);
 
 		if (modelCanUseReplaceStringExclusively(model)) {

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -399,6 +399,7 @@ export interface Config<T> extends BaseConfig<T> {
 
 export interface ExperimentBasedConfig<T extends ExperimentBasedConfigType> extends BaseConfig<T> {
 	readonly configType: ConfigType.ExperimentBased;
+	readonly experimentName: string | undefined;
 }
 
 let packageJsonDefaults: Map<string, any> | undefined = undefined;
@@ -488,8 +489,8 @@ function defineSetting<T>(key: string, defaultValue: T | DefaultValueWithTeamVal
  *     config.github.copilot.chat.advanced.inlineEdits.internalRollout
  * ```
  */
-export function defineExpSetting<T extends ExperimentBasedConfigType>(key: string, defaultValue: T | DefaultValueWithTeamValue<T> | DefaultValueWithTeamAndInternalValue<T>, options?: ConfigOptions): ExperimentBasedConfig<T> {
-	const value: ExperimentBasedConfig<T> = { ...toBaseConfig(key, defaultValue, options), configType: ConfigType.ExperimentBased };
+export function defineExpSetting<T extends ExperimentBasedConfigType>(key: string, defaultValue: T | DefaultValueWithTeamValue<T> | DefaultValueWithTeamAndInternalValue<T>, options?: ConfigOptions, expOptions?: { experimentName?: string }): ExperimentBasedConfig<T> {
+	const value: ExperimentBasedConfig<T> = { ...toBaseConfig(key, defaultValue, options), configType: ConfigType.ExperimentBased, experimentName: expOptions?.experimentName };
 	if (value.advancedSubKey) {
 		// This is a `github.copilot.advanced.*` setting
 		throw new BugIndicatingError('Shared settings cannot be experiment based');
@@ -714,6 +715,7 @@ export namespace ConfigKey {
 		export const VerifyTextDocumentChanges = defineExpSetting<boolean>('chat.advanced.inlineEdits.verifyTextDocumentChanges', true, INTERNAL_RESTRICTED);
 		export const EnableApplyPatchForNotebooks = defineExpSetting<boolean>('chat.advanced.enableApplyPatchForNotebooks', false, INTERNAL_RESTRICTED);
 		export const OmitBaseAgentInstructions = defineSetting<boolean>('chat.advanced.omitBaseAgentInstructions', false, INTERNAL);
+		export const GeminiReplaceString = defineExpSetting<boolean>('chat.advanced.geminiReplaceString.enabled', false, INTERNAL, { experimentName: 'copilotchat.geminiReplaceString' });
 	}
 
 	export const AgentThinkingTool = defineSetting<boolean>('chat.agent.thinkingTool', false);

--- a/src/platform/configuration/vscode/configurationServiceImpl.ts
+++ b/src/platform/configuration/vscode/configurationServiceImpl.ts
@@ -170,6 +170,13 @@ export class ConfigurationServiceImpl extends AbstractConfigurationService {
 			return configuredValue;
 		}
 
+		if (key.experimentName) {
+			const expValue = experimentationService.getTreatmentVariable<Exclude<T, undefined>>('vscode', key.experimentName);
+			if (expValue !== undefined) {
+				return expValue;
+			}
+		}
+
 		// This is the pattern we've been using for a while now. We need to maintain it for older experiments.
 		const expValue = experimentationService.getTreatmentVariable<Exclude<T, undefined>>('vscode', `copilotchat.config.${key.id}`);
 		if (expValue !== undefined) {


### PR DESCRIPTION
Useful for testing. Also, add a way to explicitly specify config experiments so we don't have to restart ours.