### PR TITLE
check if task already exists in create and run task and if so, return with appropriate wording

### DIFF
--- a/src/extension/tools/node/runTaskTool.tsx
+++ b/src/extension/tools/node/runTaskTool.tsx
@@ -18,6 +18,7 @@ import { CancellationToken } from '../../../util/vs/base/common/cancellation';
 import { ChatLocation, LanguageModelTextPart, LanguageModelToolResult, MarkdownString } from '../../../vscodeTypes';
 import { ToolName } from '../common/toolNames';
 import { ToolRegistry } from '../common/toolsRegistry';
+import { getTaskRepresentation } from './toolUtils.task';
 
 interface IRunTaskToolInput {
 	id: string;
@@ -173,20 +174,9 @@ class RunTaskTool implements vscode.LanguageModelTool<IRunTaskToolInput> {
 			invocationMessage: trustedMark(l10n.t`Running ${taskLabel ?? link(options.input.id)}`),
 			pastTenseMessage: trustedMark(task?.isBackground ? l10n.t`Started ${link(taskLabel ?? options.input.id)}` : l10n.t`Ran ${link(taskLabel ?? options.input.id)}`),
 			confirmationMessages: task && task.group !== 'build'
-				? { title: l10n.t`Allow task run?`, message: trustedMark(l10n.t`Allow Copilot to run the \`${task.type}\` task ${link(`\`${this.getTaskRepresentation(task)}\``)}?`) }
+				? { title: l10n.t`Allow task run?`, message: trustedMark(l10n.t`Allow Copilot to run the \`${task.type}\` task ${link(`\`${getTaskRepresentation(task)}\``)}?`) }
 				: undefined
 		};
-	}
-
-	private getTaskRepresentation(task: vscode.TaskDefinition): string {
-		if ('label' in task) {
-			return task.label;
-		} else if ('script' in task) {
-			return task.script;
-		} else if ('command' in task) {
-			return task.command;
-		}
-		return '';
 	}
 
 	private getTaskDefinition(input: IRunTaskToolInput) {

--- a/src/extension/tools/node/toolUtils.task.ts
+++ b/src/extension/tools/node/toolUtils.task.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import type * as vscode from 'vscode';
+
+export function getTaskRepresentation(task: vscode.TaskDefinition): string {
+	if ('label' in task) {
+		return task.label;
+	} else if ('script' in task) {
+		return task.script;
+	} else if ('command' in task) {
+		return task.command;
+	}
+	return '';
+}


### PR DESCRIPTION
fixes [#256516](https://github.com/microsoft/vscode/issues/256516)

It shouldn't be calling this tool for this case, but I don't think tool calling can ever be perfect, so want to handle this correctly.