### PR TITLE
tools: add parallel loop for validation of virtual group and preselection

### DIFF
--- a/src/extension/intents/node/toolCallingLoop.ts
+++ b/src/extension/intents/node/toolCallingLoop.ts
@@ -109,7 +109,7 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 		@ILogService protected readonly _logService: ILogService,
 		@IRequestLogger private readonly _requestLogger: IRequestLogger,
 		@IAuthenticationChatUpgradeService private readonly _authenticationChatUpgradeService: IAuthenticationChatUpgradeService,
-		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@ITelemetryService protected readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 	}
@@ -428,12 +428,12 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 			},
 			{
 				tools: promptContextTools?.map(tool => ({
-					function:
-					{
+					function: {
 						name: tool.name,
 						description: tool.description,
 						parameters: tool.parameters && Object.keys(tool.parameters).length ? tool.parameters : undefined
-					}, type: 'function'
+					},
+					type: 'function',
 				})),
 			},
 			iterationNumber === 0 && !isContinuation,

--- a/src/extension/tools/common/virtualTools/virtualTool.ts
+++ b/src/extension/tools/common/virtualTools/virtualTool.ts
@@ -33,19 +33,17 @@ export class VirtualTool {
 	 * Looks up a tool. Update the {@link lastUsedOnTurn} of all virtual tools
 	 * it touches.
 	 */
-	public findAndTouch(name: string, turnNumber: number): undefined | {
+	public find(name: string): undefined | {
 		tool: VirtualTool | LanguageModelToolInformation;
 		path: VirtualTool[];
 	} {
-		this.lastUsedOnTurn = turnNumber;
-
 		if (this.name === name) {
 			return { tool: this, path: [] };
 		}
 
 		for (const content of this.contents) {
 			if (content instanceof VirtualTool) {
-				const found = content.findAndTouch(name, turnNumber);
+				const found = content.find(name);
 				if (found) {
 					found.path.unshift(this);
 					return found;

--- a/src/extension/tools/common/virtualTools/virtualToolTypes.ts
+++ b/src/extension/tools/common/virtualTools/virtualToolTypes.ts
@@ -34,6 +34,11 @@ export interface IToolGrouping {
 	didInvalidateCache(): void;
 
 	/**
+	 * Gets the virtual tool containing the given tool, or undefined.
+	 */
+	getContainerFor(toolName: string): VirtualTool | undefined;
+
+	/**
 	 * Returns a list of tools that should be used for the given request.
 	 * Internally re-reads the request and conversation state.
 	 */


### PR DESCRIPTION
This adds a parallel loop run for internal users who haven't enabled
parallel tool calling. For the first MCP tool call made per tool loop,
we try replaying that loop with virtual tools and ensure the correct
virtual tool is called to expand the group. Or, if the tool is
preselected to be expanded, then we record that, too.

This is internal-only to avoid using premium requests for paying users
on this background query.

This can be disabled via an EXP flag if we see it causes unexpected load
(but since this is internal-only I don't anticipate any issues.)

This builds on #318 which is still in review. Only the last commit is new.