### PR TITLE
Allow skipping `models` cache

### DIFF
--- a/src/extension/test/node/services.ts
+++ b/src/extension/test/node/services.ts
@@ -45,6 +45,7 @@ export interface ISimulationModelConfig {
 	fastChatModel?: string;
 	embeddingModel?: EMBEDDING_MODEL;
 	fastRewriteModel?: string;
+	skipModelMetadataCache?: boolean;
 }
 
 export function createExtensionUnitTestingServices(currentTestRunInfo?: any, modelConfig?: ISimulationModelConfig): TestingServiceCollection {
@@ -57,6 +58,7 @@ export function createExtensionUnitTestingServices(currentTestRunInfo?: any, mod
 			modelConfig?.embeddingModel,
 			modelConfig?.fastRewriteModel,
 			currentTestRunInfo,
+			!!modelConfig?.skipModelMetadataCache
 		])
 	);
 	testingServiceCollection.define(IGithubCodeSearchService, new SyncDescriptor(GithubCodeSearchService));

--- a/src/extension/test/vscode-node/services.ts
+++ b/src/extension/test/vscode-node/services.ts
@@ -106,7 +106,7 @@ export function createExtensionTestingServices(): TestingServiceCollection {
 	testingServiceCollection.define(ISimulationTestContext, new SyncDescriptor(NulSimulationTestContext));
 	testingServiceCollection.define(IRequestLogger, new SyncDescriptor(NullRequestLogger));
 	testingServiceCollection.define(IFeedbackReporter, new SyncDescriptor(NullFeedbackReporterImpl));
-	testingServiceCollection.define(IEndpointProvider, new SyncDescriptor(TestEndpointProvider, [undefined, undefined, undefined, undefined, undefined]));
+	testingServiceCollection.define(IEndpointProvider, new SyncDescriptor(TestEndpointProvider, [undefined, undefined, undefined, undefined, undefined, false]));
 	testingServiceCollection.define(ICopilotTokenStore, new SyncDescriptor(CopilotTokenStore));
 	testingServiceCollection.define(IDomainService, new SyncDescriptor(DomainService));
 	testingServiceCollection.define(ICAPIClientService, new SyncDescriptor(CAPIClientImpl));

--- a/src/platform/endpoint/test/node/testEndpointProvider.ts
+++ b/src/platform/endpoint/test/node/testEndpointProvider.ts
@@ -65,6 +65,7 @@ export class TestModelMetadataFetcher extends ModelMetadataFetcher {
 		collectFetcherTelemetry: ((accessor: ServicesAccessor) => void) | undefined,
 		_isModelLab: boolean,
 		info: CurrentTestRunInfo | undefined,
+		private readonly _skipModelMetadataCache: boolean = false,
 		@IFetcherService _fetcher: IFetcherService,
 		@IDomainService _domainService: IDomainService,
 		@ICAPIClientService _capiClientService: ICAPIClientService,
@@ -99,6 +100,9 @@ export class TestModelMetadataFetcher extends ModelMetadataFetcher {
 		const req = new ModelMetadataRequest(type);
 
 		return await TestModelMetadataFetcher.Queues.queue(type, async () => {
+			if (this._skipModelMetadataCache) {
+				return super.getAllChatModels();
+			}
 			const result = await this.cache.get(req);
 			if (result) {
 				return result;
@@ -127,10 +131,11 @@ export class TestEndpointProvider implements IEndpointProvider {
 		private readonly embeddingModelToRunAgainst: EMBEDDING_MODEL | undefined,
 		_fastRewriteModelToRunAgainst: string | undefined,
 		info: CurrentTestRunInfo | undefined,
+		skipModelMetadataCache: boolean,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService
 	) {
-		const prodModelMetadata = this._instantiationService.createInstance(TestModelMetadataFetcher, undefined, false, info);
-		const modelLabModelMetadata = this._instantiationService.createInstance(TestModelMetadataFetcher, undefined, true, info);
+		const prodModelMetadata = this._instantiationService.createInstance(TestModelMetadataFetcher, undefined, false, info, skipModelMetadataCache);
+		const modelLabModelMetadata = this._instantiationService.createInstance(TestModelMetadataFetcher, undefined, true, info, skipModelMetadataCache);
 		this._prodChatModelMetadata = getModelMetadataMap(prodModelMetadata);
 		this._modelLabChatModelMetadata = getModelMetadataMap(modelLabModelMetadata);
 	}

--- a/test/base/simulationOptions.ts
+++ b/test/base/simulationOptions.ts
@@ -36,6 +36,7 @@ export class SimulationOptions {
 	public readonly boost: boolean;
 	public readonly parallelism: number;
 	public readonly lmCacheMode: CacheMode;
+	public readonly modelCacheMode: CacheMode;
 	public readonly resourcesCacheMode: CacheMode;
 	public readonly cachePath: string | undefined;
 	public readonly externalBaseline: string | undefined;
@@ -108,6 +109,7 @@ export class SimulationOptions {
 		this.swebenchPrompt = boolean(argv['swebench-prompt'], false);
 		this.embeddingModel = cliOptionsToEmbeddingsModel(this.argv['embedding-model']);
 		this.parallelism = this.argv['parallelism'] ?? this.argv['p'] ?? 20;
+		this.modelCacheMode = this.argv['skip-model-cache'] ? CacheMode.Disable : CacheMode.Default;
 		this.lmCacheMode = (
 			this.argv['skip-cache'] ? CacheMode.Disable
 				: (this.argv['require-cache'] ? CacheMode.Require : CacheMode.Default)
@@ -189,6 +191,7 @@ export class SimulationOptions {
 			`  --require-cache                    [experimental] Require cache hits, fail on cache misses`,
 			`  --regenerate-cache                 [experimental] Fetch all responses and refresh the cache`,
 			`  --skip-resources-cache             [experimental] Do not use the cache for computed resources`,
+			`  --skip-model-cache                 [experimental] Do not use the cache for model metadata`,
 			`  --stage-cache-entries              [experimental] Stage cache files that were used in current simulation run`,
 			`  --list-tests                       List tests without running them`,
 			`  --json                             Print output in JSONL format`,

--- a/test/simulationMain.ts
+++ b/test/simulationMain.ts
@@ -99,7 +99,7 @@ async function run(opts: SimulationOptions): Promise<RunResult> {
 		case opts.help:
 			return opts.printHelp();
 		case opts.listModels:
-			await listChatModels();
+			await listChatModels(opts.modelCacheMode === CacheMode.Disable);
 			return;
 		case opts.listSuites: // intentional fallthrough
 		case opts.listTests: {
@@ -488,8 +488,8 @@ function listTests(allSuites: readonly SimulationSuite[], opts: SimulationOption
 	}
 }
 
-async function listChatModels() {
-	const accessor = createExtensionUnitTestingServices().createTestingAccessor();
+async function listChatModels(skipCache: boolean = false) {
+	const accessor = createExtensionUnitTestingServices(undefined, { skipModelMetadataCache: skipCache }).createTestingAccessor();
 	const endpointProvider = accessor.get(IEndpointProvider);
 	const chatEndpoints = await endpointProvider.getAllChatEndpoints();
 	console.log('Available Chat Models:\n');
@@ -568,7 +568,8 @@ function createSimulationTestContext(
 		fastChatModel: opts.fastChatModel,
 		smartChatModel: opts.smartChatModel,
 		embeddingModel: opts.embeddingModel,
-		fastRewriteModel: opts.fastRewriteModel
+		fastRewriteModel: opts.fastRewriteModel,
+		skipModelMetadataCache: opts.modelCacheMode === CacheMode.Disable,
 	};
 
 

--- a/test/testExecutor.ts
+++ b/test/testExecutor.ts
@@ -26,7 +26,7 @@ import { safeStringify } from '../src/util/vs/base/common/objects';
 import { SyncDescriptor } from '../src/util/vs/platform/instantiation/common/descriptors';
 import { SimulationExtHostToolsService } from './base/extHostContext/simulationExtHostToolsService';
 import { SimulationBaseline, TestBaselineComparison } from './base/simulationBaseline';
-import { createSimulationAccessor, CurrentTestRunInfo, SimulationServicesOptions } from './base/simulationContext';
+import { CacheMode, createSimulationAccessor, CurrentTestRunInfo, SimulationServicesOptions } from './base/simulationContext';
 import { ISimulationEndpointHealth } from './base/simulationEndpointHealth';
 import { SimulationOptions } from './base/simulationOptions';
 import { ISimulationOutcome } from './base/simulationOutcome';
@@ -404,7 +404,7 @@ export const executeTestOnce = async (
 		const fastChatModel = (opts.fastChatModel ?? opts.chatModel) ?? test.model;
 		const fastRewriteModel = (opts.fastRewriteModel ?? opts.chatModel) ?? test.model;
 		const embeddingsModel = opts.embeddingModel ?? test.embeddingsModel;
-		testingServiceCollection.define(IEndpointProvider, new SyncDescriptor(TestEndpointProvider, [smartChatModel, fastChatModel, embeddingsModel, fastRewriteModel, currentTestRunInfo]));
+		testingServiceCollection.define(IEndpointProvider, new SyncDescriptor(TestEndpointProvider, [smartChatModel, fastChatModel, embeddingsModel, fastRewriteModel, currentTestRunInfo, opts.modelCacheMode === CacheMode.Disable]));
 	}
 
 	const simulationTestRuntime = (ctx.externalScenariosPath !== undefined)


### PR DESCRIPTION
This adds a new flag `--skip-model-cache` to allow skip reading from the `models` cache and directly hit the endpoint which provides us with model information