### PR TITLE
tools: prep for moving run test tool to core

### DIFF
--- a/package.json
+++ b/package.json
@@ -525,9 +525,10 @@
 				"when": "config.github.copilot.chat.enableUserPreferences"
 			},
 			{
-				"name": "copilot_runTests",
-				"toolReferenceName": "runTests",
-				"canBeReferencedInPrompt": true,
+				"name": "copilot_runTests1",
+				"toolReferenceName": "runTests1",
+				"canBeReferencedInPrompt": false,
+				"when": "!chat.coreTestFailureToolEnabled",
 				"displayName": "%copilot.tools.runTests.name%",
 				"modelDescription": "Runs unit tests in files. Use this tool if the user asks to run tests or when you want to validate changes using unit tests. When possible, always try to provide `files` paths containing the relevant unit tests in order to avoid unnecessarily long test runs.",
 				"inputSchema": {

--- a/src/extension/tools/common/toolNames.ts
+++ b/src/extension/tools/common/toolNames.ts
@@ -10,7 +10,8 @@ export const enum ToolName {
 	Codebase = 'semantic_search',
 	VSCodeAPI = 'get_vscode_api',
 	TestFailure = 'test_failure',
-	RunTests = 'run_tests',
+	/** @deprecated moving to core soon */
+	RunTests = 'run_tests1',
 	FindFiles = 'file_search',
 	FindTextInFiles = 'grep_search',
 	ReadFile = 'read_file',
@@ -62,7 +63,8 @@ export const enum ContributedToolName {
 	UpdateUserPreferences = 'copilot_updateUserPreferences',
 	VSCodeAPI = 'copilot_getVSCodeAPI',
 	TestFailure = 'copilot_testFailure',
-	RunTests = 'copilot_runTests',
+	/** @deprecated moving to core soon */
+	RunTests = 'copilot_runTests1',
 	FindFiles = 'copilot_findFiles',
 	FindTextInFiles = 'copilot_findTextInFiles',
 	ReadFile = 'copilot_readFile',

--- a/src/extension/tools/node/runTestsTool.tsx
+++ b/src/extension/tools/node/runTestsTool.tsx
@@ -26,6 +26,7 @@ export interface IRunTestToolsInput {
 	files?: string[];
 }
 
+/** @deprecated moving to core soon */
 export class RunTestsTool implements ICopilotTool<IRunTestToolsInput> {
 	public static readonly toolName = ToolName.RunTests;
 

--- a/src/extension/tools/node/test/testFailure.spec.tsx
+++ b/src/extension/tools/node/test/testFailure.spec.tsx
@@ -91,7 +91,7 @@ suite('TestFailureTool', () => {
 	test('returns a message when no failures exist', async () => {
 		failures = [];
 		const result = await resolver.invoke({ input: {}, toolInvocationToken: '' as any });
-		expect(await toolResultToString(accessor, result)).toMatchInlineSnapshot(`"No test failures were found yet, call the tool run_tests to run tests and find failures."`);
+		expect(await toolResultToString(accessor, result)).toMatchInlineSnapshot(`"No test failures were found yet, call the tool run_tests1 to run tests and find failures."`);
 	});
 
 	test('formats stack frames', async () => {
@@ -129,7 +129,7 @@ suite('TestFailureTool', () => {
 			## Rules:
 			- Always try to find an error in the implementation code first. Don't suggest any changes in my test cases unless I tell you to.
 			- If you need more information about anything in the codebase, use a tool like read_file, list_dir, or file_search to find and read it. Never ask the user to provide it themselves.
-			- If you make changes to fix the test, call run_tests to run the tests and verify the fix.
+			- If you make changes to fix the test, call run_tests1 to run the tests and verify the fix.
 			- Don't try to make the same changes you made before to fix the test. If you're stuck, ask the user for pointers.
 			"
 		`);
@@ -165,7 +165,7 @@ suite('TestFailureTool', () => {
 			## Rules:
 			- Always try to find an error in the implementation code first. Don't suggest any changes in my test cases unless I tell you to.
 			- If you need more information about anything in the codebase, use a tool like read_file, list_dir, or file_search to find and read it. Never ask the user to provide it themselves.
-			- If you make changes to fix the test, call run_tests to run the tests and verify the fix.
+			- If you make changes to fix the test, call run_tests1 to run the tests and verify the fix.
 			- Don't try to make the same changes you made before to fix the test. If you're stuck, ask the user for pointers.
 			"
 		`);
@@ -264,7 +264,7 @@ suite('TestFailureTool', () => {
 			## Rules:
 			- Always try to find an error in the implementation code first. Don't suggest any changes in my test cases unless I tell you to.
 			- If you need more information about anything in the codebase, use a tool like read_file, list_dir, or file_search to find and read it. Never ask the user to provide it themselves.
-			- If you make changes to fix the test, call run_tests to run the tests and verify the fix.
+			- If you make changes to fix the test, call run_tests1 to run the tests and verify the fix.
 			- Don't try to make the same changes you made before to fix the test. If you're stuck, ask the user for pointers.
 			"
 		`);


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode/pull/257350

Tool just has an ugly `1` prefix in here to avoid conflicts with tool
registration, but I will just remove it entirely in tomorrow's build.