### PR TITLE
Use a location based agent to select the notebook inline chat intent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1482,7 +1482,7 @@
 				]
 			},
 			{
-				"id": "github.copilot.notebook",
+				"id": "github.copilot.notebookEditorAgent",
 				"name": "GitHubCopilot",
 				"fullName": "GitHub Copilot",
 				"description": "%copilot.description%",
@@ -1490,7 +1490,7 @@
 				"locations": [
 					"notebook"
 				],
-				"when": "!config.inlineChat.enableV2 && !config.github.copilot.chat.advanced.inlineChat2",
+				"when": "config.inlineChat.enableV2",
 				"commands": [
 					{
 						"name": "fix",

--- a/src/extension/conversation/vscode-node/chatParticipants.ts
+++ b/src/extension/conversation/vscode-node/chatParticipants.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
-import { IChatAgentService, defaultAgentName, editingSessionAgent2Name, editingSessionAgentEditorName, editingSessionAgentName, editorAgentName, editsAgentName, getChatParticipantIdFromName, terminalAgentName, vscodeAgentName, workspaceAgentName } from '../../../platform/chat/common/chatAgents';
+import { IChatAgentService, defaultAgentName, editingSessionAgent2Name, editingSessionAgentEditorName, editingSessionAgentName, editorAgentName, editsAgentName, getChatParticipantIdFromName, notebookEditorAgentName, terminalAgentName, vscodeAgentName, workspaceAgentName } from '../../../platform/chat/common/chatAgents';
 import { IChatQuotaService } from '../../../platform/chat/common/chatQuotaService';
 import { IInteractionService } from '../../../platform/chat/common/interactionService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
@@ -236,7 +236,7 @@ Learn more about [GitHub Copilot](https://docs.github.com/copilot/using-github-c
 	}
 
 	private registerNotebookDefaultAgent(): IDisposable {
-		const defaultAgent = this.createAgent('notebook', Intent.Editor);
+		const defaultAgent = this.createAgent(notebookEditorAgentName, Intent.notebookEditor);
 		defaultAgent.iconPath = new vscode.ThemeIcon('copilot');
 
 		return defaultAgent;

--- a/src/extension/intents/node/editCodeIntent.ts
+++ b/src/extension/intents/node/editCodeIntent.ts
@@ -331,7 +331,7 @@ export class EditCodeIntentInvocation implements IIntentInvocation {
 		@IToolsService protected readonly toolsService: IToolsService,
 		@IConfigurationService protected readonly configurationService: IConfigurationService,
 		@IEditLogService private readonly editLogService: IEditLogService,
-		@ICommandService private readonly commandService: ICommandService,
+		@ICommandService protected readonly commandService: ICommandService,
 		@ITelemetryService protected readonly telemetryService: ITelemetryService,
 		@INotebookService private readonly notebookService: INotebookService,
 	) { }

--- a/src/extension/intents/node/explainIntent.ts
+++ b/src/extension/intents/node/explainIntent.ts
@@ -69,7 +69,7 @@ export class ExplainIntent implements IIntent {
 
 	static readonly ID = Intent.Explain;
 	readonly id: string = Intent.Explain;
-	readonly locations = [ChatLocation.Panel, ChatLocation.Editor];
+	readonly locations = [ChatLocation.Panel, ChatLocation.Editor, ChatLocation.Notebook];
 	readonly description: string = l10n.t('Explain how the code in your active editor works');
 
 	readonly commandInfo: IIntentSlashCommandInfo | undefined;

--- a/src/extension/intents/node/fixIntent.ts
+++ b/src/extension/intents/node/fixIntent.ts
@@ -23,7 +23,7 @@ export class FixIntent implements IIntent {
 
 	static readonly ID = Intent.Fix;
 	readonly id = Intent.Fix;
-	readonly locations = [ChatLocation.Editor, ChatLocation.Panel];
+	readonly locations = [ChatLocation.Editor, ChatLocation.Panel, ChatLocation.Notebook];
 	readonly description = l10n.t('Propose a fix for the problems in the selected code');
 
 	readonly commandInfo: IIntentSlashCommandInfo = { toolEquivalent: ContributedToolName.GetErrors };

--- a/src/extension/intents/node/notebookEditorIntent.ts
+++ b/src/extension/intents/node/notebookEditorIntent.ts
@@ -19,15 +19,16 @@ import { ITabsAndEditorsService } from '../../../platform/tabs/common/tabsAndEdi
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
+import { generateUuid } from '../../../util/vs/base/common/uuid';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { ICommandService } from '../../commands/node/commandService';
 import { Intent } from '../../common/constants';
 import { ChatVariablesCollection } from '../../prompt/common/chatVariablesCollection';
-import { IBuildPromptContext } from '../../prompt/common/intents';
+import { IBuildPromptContext, InternalToolReference } from '../../prompt/common/intents';
 import { IDefaultIntentRequestHandlerOptions } from '../../prompt/node/defaultIntentRequestHandler';
 import { IBuildPromptResult, IIntent, IntentLinkificationOptions } from '../../prompt/node/intents';
 import { ICodeMapperService } from '../../prompts/node/codeMapper/codeMapperService';
-import { ToolName } from '../../tools/common/toolNames';
+import { getToolName, ToolName } from '../../tools/common/toolNames';
 import { IToolsService } from '../../tools/common/toolsService';
 import { EditCodeIntent, EditCodeIntentOptions } from './editCodeIntent';
 import { EditCode2IntentInvocation } from './editCodeIntent2';
@@ -126,7 +127,22 @@ export class NotebookEditorIntentInvocation extends EditCode2IntentInvocation {
 	}
 
 	public override buildPrompt(promptContext: IBuildPromptContext, progress: vscode.Progress<vscode.ChatResponseReferencePart | vscode.ChatResponseProgressPart>, token: vscode.CancellationToken): Promise<IBuildPromptResult> {
-		let variables = promptContext.chatVariables;
+		const variables = this.createReferencesForActiveEditor() ?? promptContext.chatVariables;
+
+		const { query, commandToolReferences } = this.processSlashCommand(promptContext.query);
+
+		return super.buildPrompt({
+			...promptContext,
+			chatVariables: variables,
+			query,
+			tools: promptContext.tools && {
+				...promptContext.tools,
+				toolReferences: this.stableToolReferences.filter((r) => r.name !== ToolName.Codebase).concat(commandToolReferences),
+			},
+		}, progress, token);
+	}
+
+	private createReferencesForActiveEditor(): ChatVariablesCollection | undefined {
 
 		const editor = this.tabsAndEditorsService.activeNotebookEditor;
 
@@ -165,9 +181,23 @@ export class NotebookEditorIntentInvocation extends EditCode2IntentInvocation {
 				});
 			}
 
-			variables = new ChatVariablesCollection([...this.request.references, ...refsForActiveEditor]);
+			return new ChatVariablesCollection([...this.request.references, ...refsForActiveEditor]);
+		}
+	}
+
+	private processSlashCommand(query: string): { query: string; commandToolReferences: InternalToolReference[] } {
+		const commandToolReferences: InternalToolReference[] = [];
+		const command = this.request.command && this.commandService.getCommand(this.request.command, this.location);
+		if (command) {
+			if (command.toolEquivalent) {
+				commandToolReferences.push({
+					id: `${this.request.command}->${generateUuid()}`,
+					name: getToolName(command.toolEquivalent)
+				});
+			}
+			query = query ? `${command.details}.\n${query}` : command.details;
 		}
 
-		return super.buildPrompt({ ...promptContext, chatVariables: variables }, progress, token);
+		return { query, commandToolReferences };
 	}
 }

--- a/src/extension/prompt/node/chatParticipantRequestHandler.ts
+++ b/src/extension/prompt/node/chatParticipantRequestHandler.ts
@@ -278,12 +278,10 @@ export class ChatParticipantRequestHandler {
 	}
 
 	private async selectIntent(command: CommandDetails | undefined, history: Turn[]): Promise<IIntent> {
-		if (!command?.intent && (this.location === ChatLocation.Editor || this.location === ChatLocation.Notebook)) { // TODO@jrieken do away with location specific code
+		if (!command?.intent && this.location === ChatLocation.Editor) { // TODO@jrieken do away with location specific code
 
 			let preferredIntent: Intent | undefined;
-			if (this.documentContext && this.location === ChatLocation.Notebook) {
-				preferredIntent = Intent.notebookEditor;
-			} else if (this.documentContext && this.request.attempt === 0 && history.length === 0) {
+			if (this.documentContext && this.request.attempt === 0 && history.length === 0) {
 				if (this.documentContext.selection.isEmpty && this.documentContext.document.lineAt(this.documentContext.selection.start.line).text.trim() === '') {
 					preferredIntent = Intent.Generate;
 				} else if (!this.documentContext.selection.isEmpty && this.documentContext.selection.start.line !== this.documentContext.selection.end.line) {

--- a/src/platform/chat/common/chatAgents.ts
+++ b/src/platform/chat/common/chatAgents.ts
@@ -21,6 +21,7 @@ export const terminalAgentName = 'terminal';
 export const editingSessionAgentName = 'editingSession';
 export const editingSessionAgent2Name = 'editingSession2';
 export const editingSessionAgentEditorName = 'editingSessionEditor';
+export const notebookEditorAgentName = 'notebookEditorAgent';
 export const editsAgentName = 'editsAgent';
 
 export const CHAT_PARTICIPANT_ID_PREFIX = 'github.copilot.';


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-copilot/issues/15211

Now that we set the location to notebook for inline v2, we can use a participant to select the intent, which is more consistent with other location-based intents. 
We can also then surface the appropriate slash commands and implement them correctly within the intent's invocation.