### PR TITLE
language context: comment out left-over console log

### DIFF
--- a/src/extension/typescriptContext/vscode-node/languageContextService.ts
+++ b/src/extension/typescriptContext/vscode-node/languageContextService.ts
@@ -1614,7 +1614,7 @@ export class InlineCompletionContribution implements vscode.Disposable, TokenBud
 			const self = this;
 			const resolver: Copilot.ContextResolver<Copilot.SupportedContextItem> = {
 				async *resolve(request: Copilot.ResolveRequest, token: vscode.CancellationToken): AsyncIterable<Copilot.SupportedContextItem> {
-					console.log(`Resolve request ${Date.now()}`);
+					// console.log(`Resolve request ${Date.now()}`);
 					const isSpeculativeRequest = request.documentContext.proposedEdits !== undefined;
 					const [document, position] = self.getDocumentAndPosition(request, token);
 					if (document === undefined || position === undefined) {


### PR DESCRIPTION
@dbaeumer I was reading the code and noticed this and since other console.log's were commented out, I thought this log was also left unintentionally