### PR TITLE
When rendering the prompts, exclude turns from the history that errored due to prompt filtration

### DIFF
--- a/src/extension/intents/node/toolCallingLoop.ts
+++ b/src/extension/intents/node/toolCallingLoop.ts
@@ -132,7 +132,7 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 			'Please continue' :
 			this.turn.request.message;
 		// exclude turns from the history that errored due to prompt filtration
-		const history = this.options.conversation.turns.slice(0, -1).filter(turn => turn.responseStatus !== TurnStatus.Filtered);
+		const history = this.options.conversation.turns.slice(0, -1).filter(turn => turn.responseStatus !== TurnStatus.PromptFiltered);
 
 		return {
 			requestId: this.turn.id,

--- a/src/extension/intents/node/toolCallingLoop.ts
+++ b/src/extension/intents/node/toolCallingLoop.ts
@@ -131,11 +131,13 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 		const query = isContinuation ?
 			'Please continue' :
 			this.turn.request.message;
+		// exclude turns from the history that errored due to prompt filtration
+		const history = this.options.conversation.turns.slice(0, -1).filter(turn => turn.responseStatus !== TurnStatus.Filtered);
 
 		return {
 			requestId: this.turn.id,
 			query,
-			history: this.options.conversation.turns.slice(0, -1),
+			history,
 			toolCallResults: this.toolCallResults,
 			toolCallRounds: this.toolCallRounds,
 			editedFileEvents: this.options.request.editedFileEvents,

--- a/src/extension/prompt/common/conversation.ts
+++ b/src/extension/prompt/common/conversation.ts
@@ -5,6 +5,7 @@
 
 import { PromptReference, Raw } from '@vscode/prompt-tsx';
 import type { ChatRequestEditedFileEvent, ChatResponseStream, ChatResult, LanguageModelToolResult } from 'vscode';
+import { FilterReason } from '../../../platform/networking/common/openai';
 import { isLocation, toLocation } from '../../../util/common/types';
 import { ResourceMap } from '../../../util/vs/base/common/map';
 import { assertType } from '../../../util/vs/base/common/types';
@@ -22,6 +23,7 @@ export enum TurnStatus {
 	Cancelled = 'cancelled',
 	OffTopic = 'off-topic',
 	Filtered = 'filtered',
+	PromptFiltered = 'prompt-filtered',
 	Error = 'error',
 }
 
@@ -315,6 +317,7 @@ export interface IResultMetadata {
 	renderedUserMessage?: Raw.ChatCompletionContentPart[];
 	renderedGlobalContext?: Raw.ChatCompletionContentPart[];
 	command?: string;
+	filterCategory?: FilterReason;
 
 	/**
 	 * All code blocks that were in the response

--- a/src/extension/prompt/node/chatMLFetcher.ts
+++ b/src/extension/prompt/node/chatMLFetcher.ts
@@ -499,7 +499,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			return { type: ChatFetchResponseType.Failed, reason, requestId, serverRequestId };
 		}
 		if (response.failKind === ChatFailKind.ContentFilter) {
-			return { type: ChatFetchResponseType.Filtered, reason, category: FilterReason.Prompt, requestId, serverRequestId };
+			return { type: ChatFetchResponseType.PromptFiltered, reason, category: FilterReason.Prompt, requestId, serverRequestId };
 		}
 		if (response.failKind === ChatFailKind.AgentUnauthorized) {
 			return { type: ChatFetchResponseType.AgentUnauthorized, reason, authorizationUrl: response.data!.authorize_url, requestId, serverRequestId };

--- a/src/extension/prompt/node/chatParticipantRequestHandler.ts
+++ b/src/extension/prompt/node/chatParticipantRequestHandler.ts
@@ -11,6 +11,7 @@ import { CanceledMessage, ChatLocation } from '../../../platform/chat/common/com
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { IIgnoreService } from '../../../platform/ignore/common/ignoreService';
 import { ILogService } from '../../../platform/log/common/logService';
+import { FilterReason } from '../../../platform/networking/common/openai';
 import { ITabsAndEditorsService } from '../../../platform/tabs/common/tabsAndEditorsService';
 import { getWorkspaceFileDisplayPath, IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
 import { ChatResponseStreamImpl } from '../../../util/common/chatResponseStreamImpl';
@@ -413,7 +414,11 @@ function createTurnFromVSCodeChatHistoryTurns(
 	if (!chatResponseTurn.result.errorDetails) {
 		status = TurnStatus.Success;
 	} else if (chatResponseTurn.result.errorDetails?.responseIsFiltered) {
-		status = TurnStatus.Filtered;
+		if (chatResponseTurn.result.metadata?.category === FilterReason.Prompt) {
+			status = TurnStatus.PromptFiltered;
+		} else {
+			status = TurnStatus.Filtered;
+		}
 	} else if (chatResponseTurn.result.errorDetails.message === 'Cancelled' || chatResponseTurn.result.errorDetails.message === CanceledMessage.message) {
 		status = TurnStatus.Cancelled;
 	} else {

--- a/src/extension/prompts/node/panel/conversationHistory.tsx
+++ b/src/extension/prompts/node/panel/conversationHistory.tsx
@@ -73,7 +73,7 @@ export class HistoryWithInstructions extends PromptElement<Omit<ConversationHist
 export class ConversationHistory extends PromptElement<ConversationHistoryProps> {
 	override render(_state: void, _sizing: PromptSizing): PromptPiece<any, any> | undefined {
 		// exclude turns from the history that errored due to prompt filtration
-		let turnHistory = this.props.history.filter(turn => turn.responseStatus !== TurnStatus.Filtered);
+		let turnHistory = this.props.history.filter(turn => turn.responseStatus !== TurnStatus.PromptFiltered);
 
 		if (this.props.inline && turnHistory.length > 0) {
 			const historyMessage = `The current code is a result of a previous interaction with you. Here are my previous messages: \n- ${turnHistory.map(r => r.request.message).join('\n- ')}`;

--- a/src/extension/prompts/node/panel/conversationHistory.tsx
+++ b/src/extension/prompts/node/panel/conversationHistory.tsx
@@ -72,7 +72,8 @@ export class HistoryWithInstructions extends PromptElement<Omit<ConversationHist
  */
 export class ConversationHistory extends PromptElement<ConversationHistoryProps> {
 	override render(_state: void, _sizing: PromptSizing): PromptPiece<any, any> | undefined {
-		let turnHistory = this.props.history;
+		// exclude turns from the history that errored due to prompt filtration
+		let turnHistory = this.props.history.filter(turn => turn.responseStatus !== TurnStatus.Filtered);
 
 		if (this.props.inline && turnHistory.length > 0) {
 			const historyMessage = `The current code is a result of a previous interaction with you. Here are my previous messages: \n- ${turnHistory.map(r => r.request.message).join('\n- ')}`;

--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -774,6 +774,7 @@ export class XtabProvider extends ChainedStatelessNextEditProvider {
 				return new NoNextEditReason.GotCancelled('afterFetchCall');
 			case ChatFetchResponseType.OffTopic:
 			case ChatFetchResponseType.Filtered:
+			case ChatFetchResponseType.PromptFiltered:
 			case ChatFetchResponseType.Length:
 			case ChatFetchResponseType.RateLimited:
 			case ChatFetchResponseType.QuotaExceeded:

--- a/test/base/cachingChatMLFetcher.ts
+++ b/test/base/cachingChatMLFetcher.ts
@@ -239,6 +239,7 @@ export class CachingChatMLFetcher extends AbstractChatMLFetcher implements IDisp
 			if (
 				result.type === ChatFetchResponseType.OffTopic
 				|| result.type === ChatFetchResponseType.Filtered
+				|| result.type === ChatFetchResponseType.PromptFiltered
 				|| result.type === ChatFetchResponseType.Length
 				|| result.type === ChatFetchResponseType.Success
 			) {


### PR DESCRIPTION
This was resulting in users getting stuck in a state where, after one prompt that triggered an RAI 422 error, all their subsequent requests were being filtered.