### PR TITLE
don't have duplicate terminals in prompt, properly filter out task terminals so they're not redundant

### DIFF
--- a/src/extension/prompts/node/agent/test/terminalAndTaskPrompt.spec.tsx
+++ b/src/extension/prompts/node/agent/test/terminalAndTaskPrompt.spec.tsx
@@ -11,9 +11,9 @@ suite('TerminalAndTaskStatePromptElement', () => {
 	const tasksService: any = {};
 	tasksService.getTerminalForTask = (task: any) => {
 		if (task.command === 'build') {
-			return { name: 'Terminal 1', id: '1' };
+			return { name: 'Terminal 3', processId: 3434, id: '3' };
 		} else if (task.command === 'watch') {
-			return { name: 'Terminal 2', id: '2' };
+			return { name: 'Terminal 4', processId: 5545, id: '4' };
 		}
 		return undefined;
 	};
@@ -45,6 +45,8 @@ suite('TerminalAndTaskStatePromptElement', () => {
 		terminalService.terminals = [
 			{ name: 'Terminal 1', id: '1', processId: 1234 },
 			{ name: 'Terminal 2', id: '2', processId: 5678 },
+			{ name: 'Terminal 3', id: '3', processId: 3434 },
+			{ name: 'Terminal 4', id: '4', processId: 5545 },
 		];
 		terminalService.getLastCommandForTerminal = (term: { id: string }) => {
 			if (term.id === '1') {
@@ -92,6 +94,8 @@ suite('TerminalAndTaskStatePromptElement', () => {
 		terminalService.terminals = [
 			{ name: 'Terminal 1', id: '1', processId: 1234 },
 			{ name: 'Terminal 2', id: '2', processId: 5678 },
+			{ name: 'Terminal 3', id: '3', processId: 3434 },
+			{ name: 'Terminal 4', id: '4', processId: 5545 },
 		];
 		terminalService.getLastCommandForTerminal = (term: { id: string }) => {
 			if (term.id === '1') {

--- a/src/extension/prompts/node/agent/test/terminalAndTaskPrompt.spec.tsx
+++ b/src/extension/prompts/node/agent/test/terminalAndTaskPrompt.spec.tsx
@@ -98,9 +98,9 @@ suite('TerminalAndTaskStatePromptElement', () => {
 			{ name: 'Terminal 4', id: '4', processId: 5545 },
 		];
 		terminalService.getLastCommandForTerminal = (term: { id: string }) => {
-			if (term.id === '1') {
+			if (term.id === '3') {
 				return { commandLine: 'npm run build', cwd: '/workspace', exitCode: 0 };
-			} else if (term.id === '2') {
+			} else if (term.id === '4') {
 				return { commandLine: 'npm test', cwd: '/workspace', exitCode: 1 };
 			}
 			return undefined;

--- a/src/platform/tasks/common/testTasksService.ts
+++ b/src/platform/tasks/common/testTasksService.ts
@@ -39,6 +39,11 @@ export class TestTasksService implements ITasksService {
 	}
 
 	getTerminalForTask(task: vscode.TaskDefinition): vscode.Terminal | undefined {
-		return undefined;
+		// Return a mock terminal with a defined processId for testing
+		return {
+			name: task.label || 'mock-terminal',
+			processId: Promise.resolve(12345),
+			// Add any other properties/methods as needed for your tests
+		} as unknown as vscode.Terminal;
 	}
 }


### PR DESCRIPTION
fix [#258714](https://github.com/microsoft/vscode/issues/258714)

This will also mean the get terminal output tool isn't erroneously called for task terminals (that don't have associated background executions)

Before:
<img width="413" height="367" alt="Screenshot 2025-07-31 at 4 48 08 PM" src="https://github.com/user-attachments/assets/bd097050-09e8-4093-8d45-15dc55daf50f" />

After:
<img width="543" height="361" alt="Screenshot 2025-07-31 at 4 49 15 PM" src="https://github.com/user-attachments/assets/026d9dd2-9c12-48fc-a976-f2a3054bd245" />

fyi @tyriar