### PR TITLE
Allow package names to differ just by case

### DIFF
--- a/src/extension/mcp/vscode-node/commands.ts
+++ b/src/extension/mcp/vscode-node/commands.ts
@@ -83,7 +83,8 @@ export class McpSetupCommands extends Disposable {
 		super();
 		this._register(toDisposable(() => this.pendingSetup?.cts.dispose(true)));
 		this._register(vscode.commands.registerCommand('github.copilot.chat.mcp.setup.flow', (args: { name: string }) => {
-			if (this.pendingSetup?.name !== args.name) {
+			// allow case-insensitive comparison
+			if (this.pendingSetup?.name.toUpperCase() !== args.name.toUpperCase()) {
 				return undefined;
 			}
 

--- a/src/extension/mcp/vscode-node/commands.ts
+++ b/src/extension/mcp/vscode-node/commands.ts
@@ -35,7 +35,9 @@ interface PromptStringInputInfo {
 	password?: boolean;
 }
 
-type ValidatePackageResult = { state: 'ok'; publisher: string; version?: string } | { state: 'error'; error: string };
+type ValidatePackageResult =
+	{ state: 'ok'; publisher: string; name?: string; version?: string }
+	| { state: 'error'; error: string };
 
 interface NpmPackageResponse {
 	maintainers?: Array<{ name: string }>;
@@ -48,6 +50,7 @@ interface PyPiPackageResponse {
 		author?: string;
 		author_email?: string;
 		description?: string;
+		name?: string;
 		version?: string;
 	};
 }
@@ -200,9 +203,11 @@ export class McpSetupCommands extends Disposable {
 					return { state: 'error', error: `Package ${args.name} not found in PyPI registry` };
 				}
 				const data = await response.json() as PyPiPackageResponse;
+				const publisher = data.info?.author || data.info?.author_email || 'unknown';
+				const name = data.info?.name || args.name;
 				const version = data.info?.version;
-				this.enqueuePendingSetup(args.targetConfig, args.name, args.type, data.info?.description, version);
-				return { state: 'ok', publisher: data.info?.author || data.info?.author_email || 'unknown', version };
+				this.enqueuePendingSetup(args.targetConfig, name, args.type, data.info?.description, version);
+				return { state: 'ok', publisher, name, version };
 			} else if (args.type === 'nuget') {
 				// read the service index to find the search URL
 				// https://learn.microsoft.com/en-us/nuget/api/service-index
@@ -256,7 +261,7 @@ export class McpSetupCommands extends Disposable {
 				}
 
 				this.enqueuePendingSetup(args.targetConfig, id, args.type, description, version);
-				return { state: 'ok', publisher, version };
+				return { state: 'ok', publisher, name: id, version };
 			} else if (args.type === 'docker') {
 				// Docker Hub API uses namespace/repository format
 				// Handle both formats: 'namespace/repository' or just 'repository' (assumes 'library/' namespace)


### PR DESCRIPTION
If the user types in a package name that does not match the exact case of actual package, NuGet and PyPI fail silently. This is because the HTTP metadata request accepts different casing but the extension code rejects it.

https://github.com/microsoft/vscode-copilot-chat/blob/adb9c16c03f36679bf039418ea21f5484a9823e5/src/extension/mcp/vscode-node/commands.ts#L86-L88

This addresses the problem and adds the canonical casing and version (for an improved message) to the result. A separate PR to VSCode main will use the canonical casing if it's provided.

Resolve https://github.com/microsoft/vscode/issues/257675.