### PR TITLE
Don't offer a "Try again" button on filtered content

### DIFF
--- a/src/extension/intents/node/agentIntent.ts
+++ b/src/extension/intents/node/agentIntent.ts
@@ -319,9 +319,11 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation {
 	}
 
 	modifyErrorDetails(errorDetails: vscode.ChatErrorDetails, response: ChatResponse): vscode.ChatErrorDetails {
-		errorDetails.confirmationButtons = [
-			{ data: { copilotContinueOnError: true } satisfies IContinueOnErrorConfirmation, label: l10n.t('Try Again') },
-		];
+		if (!errorDetails.responseIsFiltered) {
+			errorDetails.confirmationButtons = [
+				{ data: { copilotContinueOnError: true } satisfies IContinueOnErrorConfirmation, label: l10n.t('Try Again') },
+			];
+		}
 		return errorDetails;
 	}
 


### PR DESCRIPTION
Don't offer a "Try again" button on filtered content (either prompt filtered or response filtered)

<img width="349" height="95" alt="image" src="https://github.com/user-attachments/assets/711467a9-5592-4182-8cac-2aa8cea39506" />
<img width="346" height="90" alt="image" src="https://github.com/user-attachments/assets/9b3db216-b06d-4f71-a2fb-6046c33dcffa" />

Not only is it either likely to trigger the same filter, but the error asks the user to rephrase the prompt so it's weird to offer the option to try again with no changes.