### PR TITLE
language context providers: include mandatory fields that exist in latest language context providers API

### DIFF
--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -368,7 +368,9 @@ export class XtabProvider extends ChainedStatelessNextEditProvider {
 					offset: textDoc.offsetAt(cursorPositionVscode)
 				},
 				activeExperiments: new Map(),
-				timeBudget: debounceTime
+				timeBudget: debounceTime,
+				timeoutEnd: Date.now() + debounceTime,
+				source: 'nes',
 			};
 			const langCtxItems: LanguageContextEntry[] = [];
 			const getContextPromise = async () => {

--- a/src/platform/inlineCompletions/common/api.ts
+++ b/src/platform/inlineCompletions/common/api.ts
@@ -109,6 +109,11 @@ export namespace Copilot {
 		uri: DocumentUri;
 		languageId: string;
 		version: number;
+		// Position and offset are relative to the provided version of the document.
+		// The position after an edit is applied is found in ProposedTextEdit.positionAfterEdit.
+		/**
+		 * @deprecated Use `position` instead.
+		 */
 		offset: number;
 		position?: Position;
 		proposedEdits?: ProposedTextEdit[];
@@ -128,14 +133,35 @@ export namespace Copilot {
 		 * After the time budget runs out, the request will be cancelled via the CancellationToken.
 		 * Providers can use this value as a hint when computing context. Providers should expect the
 		 * request to be cancelled once the time budget runs out.
+		 *
+		 * @deprecated Use `timeoutEnd` instead.
 		 */
 		timeBudget: number;
+
+		/**
+		 * Unix timestamp representing the exact time the request will be cancelled via the CancellationToken.
+		 */
+		timeoutEnd: number;
 
 		/**
 		 * Various statistics about the last completion request. This can be used by the context provider
 		 * to make decisions about what context to provide for the current call.
 		 */
 		previousUsageStatistics?: ContextUsageStatistics;
+
+		/**
+		 * Data from completionItem
+		 *
+		 * See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem
+		 */
+		data?: unknown;
+
+		/**
+		 * Allows specifying the source of the context item, e.g., 'nes'.
+		 *
+		 * @experimental
+		 */
+		source: string;
 	}
 
 	/**


### PR DESCRIPTION
based on changes in https://github.com/microsoft/vscode-copilot-chat/pull/457/commits/10e45e60f30cda8ac6ac48127ccd0e88f823cd1c -- with `source` field in `ResolveRequest`

fixes https://github.com/microsoft/vscode/issues/259787