### PR TITLE
Refactor Diagnostic class and related components

### DIFF
--- a/src/extension/inlineEdits/vscode-node/features/diagnosticsBasedCompletions/diagnosticsCompletions.ts
+++ b/src/extension/inlineEdits/vscode-node/features/diagnosticsBasedCompletions/diagnosticsCompletions.ts
@@ -228,10 +228,8 @@ export class Diagnostic {
 		return new Diagnostic(
 			diagnostic.message,
 			DiagnosticSeverity.fromVSCode(diagnostic.severity),
-			diagnostic.source,
 			toInternalRange(diagnostic.range),
 			diagnostic.code && !(typeof diagnostic.code === 'number') && !(typeof diagnostic.code === 'string') ? diagnostic.code.value : diagnostic.code,
-			diagnostic,
 		);
 	}
 
@@ -248,20 +246,17 @@ export class Diagnostic {
 		return this._isValid;
 	}
 
-	private constructor(
+	constructor(
 		public readonly message: string,
 		public readonly severity: DiagnosticSeverity,
-		public readonly source: string | undefined,
 		private _range: Range,
 		public readonly code: string | number | undefined,
-		public readonly reference: vscode.Diagnostic
 	) { }
 
 	equals(other: Diagnostic): boolean {
 		return this.code === other.code
 			&& this.isValid() === other.isValid()
 			&& this.severity === other.severity
-			&& this.source === other.source
 			&& this.message === other.message
 			&& Range.equalsRange(this._range, other._range);
 	}

--- a/src/extension/inlineEdits/vscode-node/parts/vscodeWorkspace.ts
+++ b/src/extension/inlineEdits/vscode-node/parts/vscodeWorkspace.ts
@@ -310,7 +310,8 @@ export class VSCodeWorkspace extends ObservableWorkspace implements IDisposable 
 			doc.textDocument.uri,
 			diagnostic.message,
 			diagnostic.severity === DiagnosticSeverity.Error ? 'error' : 'warning',
-			range
+			range,
+			diagnostic.code && !(typeof diagnostic.code === 'number') && !(typeof diagnostic.code === 'string') ? diagnostic.code.value : diagnostic.code,
 		);
 		return diag;
 	}
@@ -332,7 +333,8 @@ export class VSCodeWorkspace extends ObservableWorkspace implements IDisposable 
 			altNotebook.notebook.uri,
 			diagnostic.message,
 			diagnostic.severity === DiagnosticSeverity.Error ? 'error' : 'warning',
-			offsetRanges[0]
+			offsetRanges[0],
+			diagnostic.code && !(typeof diagnostic.code === 'number') && !(typeof diagnostic.code === 'string') ? diagnostic.code.value : diagnostic.code,
 		);
 		return diag;
 	}

--- a/src/platform/inlineEdits/common/dataTypes/diagnosticData.ts
+++ b/src/platform/inlineEdits/common/dataTypes/diagnosticData.ts
@@ -12,6 +12,7 @@ export class DiagnosticData {
 		public readonly message: string,
 		public readonly severity: 'error' | 'warning',
 		public readonly range: OffsetRange,
+		public readonly code: string | number | undefined,
 	) { }
 
 	public toString(): string {


### PR DESCRIPTION
```Copilot Generated Description:``` Simplify the Diagnostic class by removing the source and reference properties. Update the DiagnosticsCompletionProcessor to utilize autorun for handling diagnostics changes and streamline the retrieval of available diagnostics. Adjust the VSCodeWorkspace to include diagnostic codes in the diagnostic creation process.