### PR TITLE
Show token use against available context window on Chat message hover

### DIFF
--- a/src/extension/prompt/common/conversation.ts
+++ b/src/extension/prompt/common/conversation.ts
@@ -328,6 +328,16 @@ export interface IResultMetadata {
 	toolCallResults?: Record<string, LanguageModelToolResult>;
 	maxToolCallsExceeded?: boolean;
 	summary?: { toolCallRoundId: string; text: string };
+
+	/**
+	 * Token usage information for the response
+	 */
+	tokenUsage?: {
+		promptTokens: number;
+		completionTokens?: number;
+		totalTokens: number;
+		contextWindow: number;
+	};
 }
 
 /** There may be no metadata for results coming from old persisted messages, or from messages that are currently in progress (TODO, try to handle this case) */

--- a/src/extension/prompt/node/chatParticipantRequestHandler.ts
+++ b/src/extension/prompt/node/chatParticipantRequestHandler.ts
@@ -264,13 +264,16 @@ export class ChatParticipantRequestHandler {
 			// mixin fixed metadata shape into result. Modified in place because the object is already
 			// cached in the conversation store and we want the full information when looking this up
 			// later
+			// Merge in required metadata fields. Preserve any existing metadata (e.g. tokenCount/contextWindow injected downstream).
+			const existingMeta: any = (result as ICopilotChatResult).metadata ?? {};
 			mixin(result, {
 				metadata: {
+					...existingMeta,
 					modelMessageId: this.turn.responseId ?? '',
 					responseId: this.turn.id,
 					sessionId: this.conversation.sessionId,
 					agentId: this.chatAgentArgs.agentId,
-					command: this.request.command
+					command: this.request.command,
 				}
 			} satisfies ICopilotChatResult, true);
 

--- a/src/extension/prompt/node/chatParticipantRequestHandler.ts
+++ b/src/extension/prompt/node/chatParticipantRequestHandler.ts
@@ -256,7 +256,14 @@ export class ChatParticipantRequestHandler {
 
 				result = await chatResult;
 				const endpoint = await this._endpointProvider.getChatEndpoint(this.request);
-				result.details = `${endpoint.name} • ${endpoint.multiplier ?? 0}x`;
+
+				// Build details string with model info and token usage if available
+				let details = `${endpoint.name} • ${endpoint.multiplier ?? 0}x`;
+				if (result.metadata?.tokenUsage) {
+					const { totalTokens, contextWindow } = result.metadata.tokenUsage;
+					details += ` • ${totalTokens}/${contextWindow} tokens`;
+				}
+				result.details = details;
 			}
 
 			this._conversationStore.addConversation(this.turn.id, this.conversation);

--- a/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -153,10 +153,17 @@ export class DefaultIntentRequestHandler {
 				const lastMsgs = resultDetails.lastRequestMessages ?? [];
 				const tokenCount = await tokenizer.countMessagesTokens(lastMsgs);
 				const contextWindow = ep.modelMaxPromptTokens;
-				// Merge into metadata; preserve any existing metadata fields.
+
+				// Merge into metadata with structured token usage information
 				const existingMeta: any = chatResult.metadata ?? {};
+				const tokenUsage = typeof tokenCount === 'number' && typeof contextWindow === 'number' ? {
+					promptTokens: tokenCount,
+					totalTokens: tokenCount, // For now, only tracking prompt tokens
+					contextWindow: contextWindow
+				} : undefined;
+
 				// chatResult.metadata is read-only in the ChatResult type, so build a new object.
-				chatResult = { ...chatResult, metadata: { ...existingMeta, tokenCount, contextWindow } };
+				chatResult = { ...chatResult, metadata: { ...existingMeta, tokenCount, contextWindow, tokenUsage } };
 			} catch {
 				// ignore token counting failures; metadata will simply omit token info
 			}

--- a/src/extension/prompts/node/panel/conversationHistory.tsx
+++ b/src/extension/prompts/node/panel/conversationHistory.tsx
@@ -87,11 +87,7 @@ export class ConversationHistory extends PromptElement<ConversationHistoryProps>
 				history.push(<ChatVariablesAndQuery priority={900} chatVariables={promptVariables} query={turn.request.message} omitReferences={true} embeddedInsideUserMessage={false} />);
 			}
 			if (turn.responseMessage?.type === 'model' && ![TurnStatus.OffTopic, TurnStatus.Filtered].includes(turn.responseStatus)) {
-				history.push(
-					<AssistantMessage name={turn.responseMessage.name}>
-						{turn.responseMessage.message}
-					</AssistantMessage>
-				);
+				history.push(<AssistantMessage name={turn.responseMessage.name}>{turn.responseMessage.message}</AssistantMessage>);
 			}
 		});
 
@@ -176,9 +172,7 @@ export class ConversationHistoryWithTools extends PromptElement<ConversationHist
 					isHistorical={!(toolCallResultInNextTurn && i === contextHistory.length - 1)}
 				/>);
 			} else if (turn.responseMessage) {
-				history.push(
-					<AssistantMessage>{turn.responseMessage?.message ?? ''}</AssistantMessage>
-				);
+				history.push(<AssistantMessage>{turn.responseMessage?.message}</AssistantMessage>);
 			}
 		}
 

--- a/src/extension/prompts/node/panel/conversationHistory.tsx
+++ b/src/extension/prompts/node/panel/conversationHistory.tsx
@@ -87,19 +87,9 @@ export class ConversationHistory extends PromptElement<ConversationHistoryProps>
 				history.push(<ChatVariablesAndQuery priority={900} chatVariables={promptVariables} query={turn.request.message} omitReferences={true} embeddedInsideUserMessage={false} />);
 			}
 			if (turn.responseMessage?.type === 'model' && ![TurnStatus.OffTopic, TurnStatus.Filtered].includes(turn.responseStatus)) {
-				// Get token usage + context window from ChatResult metadata injected by request handler.
-				// Fall back to raw usage/modelMaxPromptTokens when absent (older turns).
-				const meta = turn.resultMetadata as any;
-				const tokenCount = meta?.tokenCount ?? meta?.usage?.total_tokens;
-				const contextWindow = meta?.contextWindow ?? meta?.modelMaxPromptTokens;
-				const showTokenInfo = typeof tokenCount === 'number' && typeof contextWindow === 'number';
-				let message = turn.responseMessage.message;
-				if (showTokenInfo) {
-					message += `\n\n_Tokens used: ${tokenCount} / ${contextWindow}_`;
-				}
 				history.push(
 					<AssistantMessage name={turn.responseMessage.name}>
-						{message}
+						{turn.responseMessage.message}
 					</AssistantMessage>
 				);
 			}
@@ -186,17 +176,8 @@ export class ConversationHistoryWithTools extends PromptElement<ConversationHist
 					isHistorical={!(toolCallResultInNextTurn && i === contextHistory.length - 1)}
 				/>);
 			} else if (turn.responseMessage) {
-				// Render token info in footer details if available (tokenCount/contextWindow injected in metadata)
-				const metaAny = metadata as any;
-				const tokenCount = metaAny?.tokenCount ?? metaAny?.usage?.total_tokens;
-				const contextWindow = metaAny?.contextWindow ?? metaAny?.modelMaxPromptTokens;
-				const showTokenInfo = typeof tokenCount === 'number' && typeof contextWindow === 'number';
-				let message = turn.responseMessage?.message ?? '';
-				if (showTokenInfo) {
-					message += `\n\n_Tokens used: ${tokenCount} / ${contextWindow}_`;
-				}
 				history.push(
-					<AssistantMessage>{message}</AssistantMessage>
+					<AssistantMessage>{turn.responseMessage?.message ?? ''}</AssistantMessage>
 				);
 			}
 		}

--- a/src/extension/prompts/node/panel/conversationHistory.tsx
+++ b/src/extension/prompts/node/panel/conversationHistory.tsx
@@ -87,7 +87,19 @@ export class ConversationHistory extends PromptElement<ConversationHistoryProps>
 				history.push(<ChatVariablesAndQuery priority={900} chatVariables={promptVariables} query={turn.request.message} omitReferences={true} embeddedInsideUserMessage={false} />);
 			}
 			if (turn.responseMessage?.type === 'model' && ![TurnStatus.OffTopic, TurnStatus.Filtered].includes(turn.responseStatus)) {
-				history.push(<AssistantMessage name={turn.responseMessage.name}>{turn.responseMessage.message}</AssistantMessage>);
+				// Get token count/context window from metadata if available
+				const meta = turn.resultMetadata as any;
+				const tokenCount = meta?.tokenCount ?? meta?.usage?.total_tokens;
+				const contextWindow = meta?.contextWindow ?? meta?.modelMaxPromptTokens;
+				const showTokenInfo = typeof tokenCount === 'number' && typeof contextWindow === 'number';
+				history.push(
+					<AssistantMessage name={turn.responseMessage.name}>
+						<Chunk>
+							{turn.responseMessage.message}
+							{showTokenInfo ? `  [${tokenCount} / ${contextWindow} tokens]` : ''}
+						</Chunk>
+					</AssistantMessage>
+				);
 			}
 		});
 


### PR DESCRIPTION
This PR adds support for visualizing current token usage against the model's available context window upon hover on a chat message:
<img width="1052" height="1046" alt="image" src="https://github.com/user-attachments/assets/d1b54d9c-b4db-45b9-990b-8b00eef48e8a" />

This information was already present in the Copilot Chat debug log that is available with "Developer: Show Chat Debug View", but now is more visible and present directly within the chat message.