### PR TITLE
Add a save icon for the Copilot Chat debug view

### DIFF
--- a/src/extension/log/vscode-node/requestLogTree.ts
+++ b/src/extension/log/vscode-node/requestLogTree.ts
@@ -164,13 +164,13 @@ export class RequestLogTree extends Disposable implements IExtensionContribution
 			// Determine a default filename from the virtual URI
 			const parsed = ChatRequestScheme.parseUri(resource.toString());
 			const defaultBase = parsed && parsed.kind === 'request' ? parsed.id : 'latestrequest';
-			const defaultFilename = `${defaultBase}.copilotmd`;
+			const defaultFilename = `${defaultBase}.md`;
 
 			const saveUri = await vscode.window.showSaveDialog({
 				defaultUri: vscode.Uri.file(path.join(os.homedir(), defaultFilename)),
 				filters: {
-					'Copilot Markdown': ['copilotmd'],
 					'Markdown': ['md'],
+					'Copilot Markdown': ['copilotmd'],
 					'All Files': ['*']
 				},
 				title: 'Save Markdown As'


### PR DESCRIPTION
This PR adds a save icon to the Copilot Chat log that opens after clicking an entry in the Copilot Chat debug view. The save experience defaults to using .md rather than .copilotmd (which GitHub does not like as an attachment).

<img width="709" height="111" alt="image" src="https://github.com/user-attachments/assets/3403847e-bf59-402d-ac64-ffdd75791f0f" />

This allows faster bug reporting from Chat logs.