### PR TITLE
Fix: Resolve git-lfs and husky hooks conflict in devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -20,6 +20,11 @@
       "resolved": "ghcr.io/devcontainers/features/dotnet@sha256:06f4ef2c23792da4832a74da195d478d8f64316c45c7624a0367d6bd5c3fc500",
       "integrity": "sha256:06f4ef2c23792da4832a74da195d478d8f64316c45c7624a0367d6bd5c3fc500"
     },
+    "ghcr.io/devcontainers/features/git-lfs:1": {
+      "version": "1.2.5",
+      "resolved": "ghcr.io/devcontainers/features/git-lfs@sha256:71c2b371cf12ab7fcec47cf17369c6f59156100dad9abf9e4c593049d789de72",
+      "integrity": "sha256:71c2b371cf12ab7fcec47cf17369c6f59156100dad9abf9e4c593049d789de72"
+    },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "1.7.1",
       "resolved": "ghcr.io/devcontainers/features/python@sha256:cf9b6d879790a594b459845b207c5e1762a0c8f954bb8033ff396e497f9c301b",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,5 +33,6 @@
 	"containerUser": "node",
 	"onCreateCommand": {
 		"npmInstall": "npm install || true"
-	}
+	},
+	"postCreateCommand": "bash .devcontainer/fix-lfs-husky-hooks.sh --autoMergeLfsHusky; git lfs pull"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,5 +34,5 @@
 	"onCreateCommand": {
 		"npmInstall": "npm install || true"
 	},
-	"postCreateCommand": "bash .devcontainer/fix-lfs-husky-hooks.sh --autoMergeLfsHusky; git lfs pull"
+	"postCreateCommand": "cd ${containerWorkspaceFolder}; bash .devcontainer/fix-lfs-husky-hooks.sh --autoMergeLfsHusky; git lfs pull"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,6 @@
 	},
 	"containerUser": "node",
 	"onCreateCommand": {
-		"initGitLfs": "git lfs install --force",
 		"npmInstall": "npm install || true"
 	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,9 @@
 		"ghcr.io/devcontainers/features/python:1": {},
 		"ghcr.io/devcontainers/features/dotnet:2": {},
 		"ghcr.io/devcontainers/features/desktop-lite:1": {},
-		"ghcr.io/devcontainers/features/git-lfs:1": {}
+		"ghcr.io/devcontainers/features/git-lfs:1": {
+			"autoPull": false // see https://github.com/devcontainers/features/blob/main/src/git-lfs/README.md#options
+		}
 	},
 	"containerEnv": {
 		"DEBIAN_FRONTEND": "noninteractive"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,5 +34,5 @@
 	"onCreateCommand": {
 		"npmInstall": "npm install || true"
 	},
-	"postCreateCommand": "cd ${containerWorkspaceFolder}; bash .devcontainer/fix-lfs-husky-hooks.sh --autoMergeLfsHusky; git lfs pull"
+	"postCreateCommand": "cd ${containerWorkspaceFolder} && bash .devcontainer/fix-lfs-husky-hooks.sh --autoMergeLfsHusky && (git lfs pull || echo 'Warning: git lfs pull failed')"
 }

--- a/.devcontainer/fix-lfs-husky-hooks.sh
+++ b/.devcontainer/fix-lfs-husky-hooks.sh
@@ -113,8 +113,10 @@ backup_hooks() {
 generate_lfs_hook() {
     local hook_type="$1"
     cat << EOF
+# === BEGIN GIT LFS HOOK (added by fix-lfs-husky-hooks.sh) ===
 command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the '$hook_type' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks' but with husky it is '.husky/_')."; exit 2; }
 git lfs $hook_type "\$@"
+# === END GIT LFS HOOK ===
 EOF
 }
 
@@ -127,8 +129,8 @@ merge_hooks() {
         LFS_HOOK=$(generate_lfs_hook "$hook")
 
         if [ -f "$HUSKY_DIR/$hook" ]; then
-            # Check if hook already contains Git LFS content
-            if grep -q "git lfs $hook" "$HUSKY_DIR/$hook"; then
+            # Check if hook already contains Git LFS content with our specific markers
+            if grep -q "=== BEGIN GIT LFS HOOK (added by fix-lfs-husky-hooks.sh) ===" "$HUSKY_DIR/$hook"; then
                 echo "✓ $hook: Already contains Git LFS hook"
                 continue
             fi

--- a/.devcontainer/fix-lfs-husky-hooks.sh
+++ b/.devcontainer/fix-lfs-husky-hooks.sh
@@ -77,6 +77,10 @@ validate_environment() {
         if [ "$AUTO_MODE" = false ]; then
             read -p "Continue anyway? (y/N): " confirm
             [[ "$confirm" == [yY] ]] || exit 0
+        else
+            echo "Error: Git LFS is not installed and --auto mode is enabled"
+            echo "Please install Git LFS first or run without --auto to be prompted"
+            exit 1
         fi
     fi
 

--- a/.devcontainer/fix-lfs-husky-hooks.sh
+++ b/.devcontainer/fix-lfs-husky-hooks.sh
@@ -154,8 +154,13 @@ merge_hooks() {
             if [ -n "$HEADER_END" ]; then
                 # Extract header (up to and including the initialization line)
                 HUSKY_HEADER=$(head -n "$HEADER_END" "$HUSKY_DIR/$hook")
-                # Extract content after the header
-                EXISTING_CONTENT=$(tail -n +$((HEADER_END + 1)) "$HUSKY_DIR/$hook")
+                # Extract content after the header, checking if there are more lines
+                TOTAL_LINES=$(wc -l < "$HUSKY_DIR/$hook")
+                if [ "$TOTAL_LINES" -gt "$HEADER_END" ]; then
+                    EXISTING_CONTENT=$(tail -n +$((HEADER_END + 1)) "$HUSKY_DIR/$hook")
+                else
+                    EXISTING_CONTENT=""
+                fi
             else
                 # Fallback: assume standard 2-line header
                 HUSKY_HEADER=$(head -n 2 "$HUSKY_DIR/$hook" 2>/dev/null || echo "")
@@ -170,7 +175,7 @@ merge_hooks() {
                 if [ -n "$EXISTING_CONTENT" ]; then
                     echo ""  # Add separator line
                     echo "# Original hook content"
-                    echo "$EXISTING_CONTENT"
+                    printf "%s\n" "$EXISTING_CONTENT"
                 fi
             } > "$HUSKY_DIR/$hook.new"
 

--- a/.devcontainer/fix-lfs-husky-hooks.sh
+++ b/.devcontainer/fix-lfs-husky-hooks.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Git LFS and Husky Integration Script
+#
+# PURPOSE: Resolves conflicts between Git LFS and Husky hook management
+# by merging Git LFS hooks into Husky's hook structure.
+#
+# PROBLEM: When using both Git LFS and Husky in a project, their hook management
+# systems can conflict. Husky sets core.hooksPath to .husky/_, but Git LFS
+# expects hooks in the standard location or its own registered location.
+#
+# USAGE:
+#   ./fix-lfs-husky-hooks.sh               # Interactive mode
+#   ./fix-lfs-husky-hooks.sh --auto        # Automatic mode, no prompts
+
+set -eo pipefail
+
+# Configuration
+HUSKY_DIR=".husky/_"
+BACKUP_DIR=".husky/_backups/$(date +%Y%m%d_%H%M%S)"
+HOOKS=("pre-push" "post-checkout" "post-commit" "post-merge")
+AUTO_MODE=false
+
+# Process arguments
+for arg in "$@"; do
+    case "$arg" in
+        --auto|--autoMergeLfsHusky)
+            AUTO_MODE=true
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--auto|--autoMergeLfsHusky] [--help|-h]"
+            echo ""
+            echo "Options:"
+            echo "  --auto, --autoMergeLfsHusky  Run in automatic mode without prompts"
+            echo "  --help, -h                   Show this help message"
+            exit 0
+            ;;
+    esac
+done
+
+# Validate environment
+validate_environment() {
+    # Check if we're in a git repository
+    if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+        echo "Error: Not in a git repository"
+        exit 1
+    fi
+
+    # Check if Husky is configured
+    if [ ! -d "$HUSKY_DIR" ]; then
+        echo "Error: Husky directory '$HUSKY_DIR' not found"
+        exit 1
+    fi
+
+    # Check if Git LFS is installed
+    if ! command -v git-lfs > /dev/null 2>&1; then
+        echo "Warning: Git LFS is not installed"
+        if [ "$AUTO_MODE" = false ]; then
+            read -p "Continue anyway? (y/N): " confirm
+            [[ "$confirm" == [yY] ]] || exit 0
+        fi
+    fi
+}
+
+# Create backup of hooks
+backup_hooks() {
+    echo "Creating backup of hooks in $BACKUP_DIR"
+    mkdir -p "$BACKUP_DIR"
+    for hook in "${HOOKS[@]}"; do
+        if [ -f "$HUSKY_DIR/$hook" ]; then
+            cp "$HUSKY_DIR/$hook" "$BACKUP_DIR/$hook"
+            echo "✓ Backed up $hook"
+        fi
+    done
+}
+
+# Generate Git LFS hook content for a specific hook
+generate_lfs_hook() {
+    local hook_type="$1"
+    cat << EOF
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the '$hook_type' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks' but with husky it is '.husky/_')."; exit 2; }
+git lfs $hook_type "\$@"
+EOF
+}
+
+# Merge Git LFS hooks with Husky hooks
+merge_hooks() {
+    echo "Merging Git LFS hooks with Husky hooks..."
+
+    for hook in "${HOOKS[@]}"; do
+        # Generate Git LFS hook content
+        LFS_HOOK=$(generate_lfs_hook "$hook")
+
+        if [ -f "$HUSKY_DIR/$hook" ]; then
+            # Check if hook already contains Git LFS content
+            if grep -q "git lfs $hook" "$HUSKY_DIR/$hook"; then
+                echo "✓ $hook: Already contains Git LFS hook"
+                continue
+            fi
+
+            # Extract Husky header (first 2 lines typically)
+            HUSKY_HEADER=$(head -n 2 "$HUSKY_DIR/$hook")
+
+            # Create merged hook
+            {
+                echo "$HUSKY_HEADER"
+                echo "$LFS_HOOK"
+            } > "$HUSKY_DIR/$hook.new"
+
+            # Verify the new file was created successfully
+            if [ ! -s "$HUSKY_DIR/$hook.new" ]; then
+                echo "⚠ Error creating new hook file for $hook"
+                continue
+            fi
+
+            # Replace the original with the new version and make executable
+            mv "$HUSKY_DIR/$hook.new" "$HUSKY_DIR/$hook"
+            chmod +x "$HUSKY_DIR/$hook"
+            echo "✓ $hook: Successfully merged"
+        else
+            echo "Creating new hook: $hook"
+            # Create new hook with both Husky and Git LFS parts
+            {
+                echo '#!/usr/bin/env sh'
+                echo '. "$(dirname "$0")/h"'
+                echo "$LFS_HOOK"
+            } > "$HUSKY_DIR/$hook"
+            chmod +x "$HUSKY_DIR/$hook"
+            echo "✓ $hook: Created"
+        fi
+    done
+}
+
+# Main execution
+main() {
+    echo "Git LFS and Husky Integration Script"
+
+    validate_environment
+
+    if [ "$AUTO_MODE" = false ]; then
+        read -p "This will modify Husky hooks to include Git LFS functionality. Continue? (y/N): " confirm
+        [[ "$confirm" == [yY] ]] || exit 0
+    fi
+
+    backup_hooks
+    merge_hooks
+
+    echo "✅ Git LFS and Husky integration complete!"
+    echo "You can now use Git LFS commands normally."
+}
+
+main

--- a/.devcontainer/fix-lfs-husky-hooks.sh
+++ b/.devcontainer/fix-lfs-husky-hooks.sh
@@ -16,7 +16,7 @@ set -eo pipefail
 
 # Configuration
 HUSKY_DIR=".husky/_"
-BACKUP_DIR=".husky/_backups/$(date +%Y%m%d_%H%M%S)"
+BACKUP_DIR="$HUSKY_DIR/_backups/$(date +%Y%m%d_%H%M%S)"
 HOOKS=("pre-push" "post-checkout" "post-commit" "post-merge")
 AUTO_MODE=false
 

--- a/.devcontainer/fix-lfs-husky-hooks.sh
+++ b/.devcontainer/fix-lfs-husky-hooks.sh
@@ -100,10 +100,19 @@ merge_hooks() {
             # Extract Husky header (first 2 lines typically)
             HUSKY_HEADER=$(head -n 2 "$HUSKY_DIR/$hook")
 
-            # Create merged hook
+            # Extract existing content after header (preserving custom hook logic)
+            EXISTING_CONTENT=$(tail -n +3 "$HUSKY_DIR/$hook")
+
+            # Create merged hook with: header + LFS hook + existing content
             {
                 echo "$HUSKY_HEADER"
                 echo "$LFS_HOOK"
+                # Only add existing content if it's not empty
+                if [ -n "$EXISTING_CONTENT" ]; then
+                    echo ""  # Add separator line
+                    echo "# Original hook content"
+                    echo "$EXISTING_CONTENT"
+                fi
             } > "$HUSKY_DIR/$hook.new"
 
             # Verify the new file was created successfully

--- a/.devcontainer/fix-lfs-husky-hooks.sh
+++ b/.devcontainer/fix-lfs-husky-hooks.sh
@@ -150,7 +150,7 @@ merge_hooks() {
             fi
 
             # Find the Husky initialization line to extract header and remaining content
-            HEADER_END=$(grep -n '^\. "$(dirname "$0")/h"' "$HUSKY_DIR/$hook" | cut -d: -f1)
+            HEADER_END=$(grep -n '^[[:space:]]*\. "$(dirname "\$0")/h"' "$HUSKY_DIR/$hook" | cut -d: -f1)
             if [ -n "$HEADER_END" ]; then
                 # Extract header (up to and including the initialization line)
                 HUSKY_HEADER=$(head -n "$HEADER_END" "$HUSKY_DIR/$hook")
@@ -187,7 +187,11 @@ merge_hooks() {
 
             # Replace the original with the new version and make executable
             mv "$HUSKY_DIR/$hook.new" "$HUSKY_DIR/$hook"
-            chmod +x "$HUSKY_DIR/$hook"
+
+            if ! chmod +x "$HUSKY_DIR/$hook"; then
+                echo "⚠ Error: Could not make $hook executable"
+                continue
+            fi
             echo "✓ $hook: Successfully merged"
         else
             echo "Creating new hook: $hook"

--- a/.devcontainer/fix-lfs-husky-hooks.sh
+++ b/.devcontainer/fix-lfs-husky-hooks.sh
@@ -99,6 +99,20 @@ validate_environment() {
 
 # Create backup of hooks
 backup_hooks() {
+    # Check if any hook needs modification before creating backup
+    local needs_backup=false
+    for hook in "${HOOKS[@]}"; do
+        if [ -f "$HUSKY_DIR/$hook" ] && ! grep -q "=== BEGIN GIT LFS HOOK" "$HUSKY_DIR/$hook"; then
+            needs_backup=true
+            break
+        fi
+    done
+
+    if [ "$needs_backup" = false ]; then
+        echo "No backup needed - all hooks already configured"
+        return
+    fi
+
     echo "Creating backup of hooks in $BACKUP_DIR"
     mkdir -p "$BACKUP_DIR"
     for hook in "${HOOKS[@]}"; do

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,0 @@
-set -e
-
-# git-lfs hook
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/pre-push'.\n"; exit 2; }
-git lfs pre-push "$@"


### PR DESCRIPTION
## Problem

When starting the devcontainer, the setup fails due to a conflict between git-lfs and husky hooks:

```bash
Running the postCreateCommand from Feature 'ghcr.io/devcontainers/features/git-lfs:1'...
[16420 ms] Start: Run in container: /bin/sh -c /usr/local/share/pull-git-lfs-artifacts.sh
Fetching git lfs artifacts...
Hook already exists: pre-push
        #!/usr/bin/env sh
        . "$(dirname "$0")/h"
To resolve this, either:
  1: run `git lfs update --manual` for instructions on how to merge hooks.
  2: run `git lfs update --force` to overwrite your hook.
[16922 ms] postCreateCommand from Feature 'ghcr.io/devcontainers/features/git-lfs:1' failed with exit code 2.
```

## Root Cause Analysis

The issue occurs because:
1. **Husky runs first** during `npm install` and sets `core.hookspath` to `.husky/_`
2. **Git LFS feature runs later** and attempts to install its hooks, but finds existing husky hooks
3. The conflict causes the devcontainer setup to fail

**Note**: Reversing the execution order wouldn't solve the problem either. If git-lfs ran first and modified .git/hooks, husky would later change core.hookspath to .husky/_, effectively bypassing the git-lfs hooks and leaving git-lfs _silently_  improperly configured.


### Current Hook Structure
- Husky creates hooks in `.husky/_/` that source `.husky/_/h`
- The `h` script then calls any matching hook script in `.husky/` if it exists
- Git LFS needs to inject its own hook logic into this chain


## Solution

This PR implements a controlled merge of git-lfs hooks with husky's hook system:

1. **Let husky complete its setup** - maintains the existing hook infrastructure
2. **Delay git-lfs hook installation** - prevents the initial conflict
3. **Merge hooks in postCreateCommand** - combine git-lfs functionality with husky's hook chain

### Implementation Details

The solution adds a custom script that:
- Extracts git-lfs hook content
- Merges it with husky's template structure
- Ensures both git-lfs and husky hooks execute correctly


## Related Issues

- [[typicode/husky#1431](https://github.com/typicode/husky/issues/1431)](https://github.com/typicode/husky/issues/1431) - Similar conflict reported
- [[typicode/husky#1574](https://github.com/typicode/husky/issues/1574)](https://github.com/typicode/husky/issues/1574) - Discussion on core.hooksPath handling
- [[microsoft/vscode-copilot-chat#88](https://github.com/microsoft/vscode-copilot-chat/pull/88)](https://github.com/microsoft/vscode-copilot-chat/pull/88) - Previous attempt to improve devcontainer support
- [[typicode/husky#108](https://github.com/typicode/husky/issues/108)](https://github.com/typicode/husky/issues/108) - Git LFS and husky prepush hook compatibility
- [[mastodon/mastodon#24884](https://github.com/mastodon/mastodon/issues/24884)](https://github.com/mastodon/mastodon/issues/24884) - Husky clobbering git hooks with git-lfs
