### PR TITLE
nes: fix: use target document ID of the edit for rejection collector & recently shown cache

### DIFF
--- a/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -247,7 +247,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			return nextEditResult;
 		}
 
-		if (this._rejectionCollector.isRejected(docId, edit) || currentDocument && this._nextEditCache.isRejectedNextEdit(docId, currentDocument, edit, nesConfigs)) {
+		if (this._rejectionCollector.isRejected(targetDocumentId, edit) || currentDocument && this._nextEditCache.isRejectedNextEdit(targetDocumentId, currentDocument, edit, nesConfigs)) {
 			tracer.trace('edit was previously rejected');
 			telemetryBuilder.setStatus('previouslyRejected');
 			telemetryBuilder.setWasPreviouslyRejected();
@@ -263,7 +263,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 
 		if (nesConfigs.isRecentlyShownCacheEnabled && !edit.isEmpty) {
 			tracer.trace('edit is not neutral');
-			this._recentlyShownCache.add(docId, currentDocument, [edit, req]);
+			this._recentlyShownCache.add(targetDocumentId, currentDocument, [edit, req]);
 		}
 
 		tracer.trace('returning next edit result');


### PR DESCRIPTION
cc @hediet since you seem to have authored this code