### PR TITLE
Set debounceDelayMs to 0

### DIFF
--- a/src/extension/inlineEdits/vscode-node/inlineEditProviderFeature.ts
+++ b/src/extension/inlineEdits/vscode-node/inlineEditProviderFeature.ts
@@ -133,6 +133,7 @@ export class InlineEditProviderFeature extends Disposable implements IExtensionC
 			reader.store.add(languages.registerInlineCompletionItemProvider('*', provider, {
 				displayName: provider.displayName,
 				yieldTo: this._yieldToCopilot.read(reader) ? ['github.copilot'] : undefined,
+				debounceDelayMs: 0, // set 0 debounce to ensure consistent delays/timings
 			}));
 
 			if (TRIGGER_INLINE_EDIT_ON_ACTIVE_EDITOR_CHANGE) {


### PR DESCRIPTION
Previously we did not set the `debounceDelayMs` value. This has lead to NES being called with different debounce values depending on other providers (inline completions extension). We are now setting the debounce to 0 to reliably be called with the same debounce (none). 

cc @hediet @ulugbekna 