### PR TITLE
Add mode to conversation model messages

### DIFF
--- a/src/extension/prompt/node/chatParticipantTelemetry.ts
+++ b/src/extension/prompt/node/chatParticipantTelemetry.ts
@@ -358,7 +358,8 @@ export abstract class ChatTelemetry<C extends IDocumentContext | undefined = IDo
 				response,
 				this.telemetryMessageId, // That's the message id of the user message
 				this._documentContext?.document,
-				this._userTelemetry.extendedBy({ replyType: interactionOutcome.kind })
+				this._userTelemetry.extendedBy({ replyType: interactionOutcome.kind }),
+				this._getModeName()
 			);
 		}
 

--- a/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -392,10 +392,18 @@ export class DefaultIntentRequestHandler {
 			appliedText,
 			requestId,
 			this.documentContext?.document,
-			baseModelTelemetry
+			baseModelTelemetry,
+			this.getModeName()
 		);
 
 		return chatResult;
+	}
+
+	private getModeName(): string {
+		return this.request.modeInstructions ? 'custom' :
+			this.intent.id === 'editAgent' ? 'agent' :
+				(this.intent.id === 'edit' || this.intent.id === 'edit2') ? 'edit' :
+					'ask';
 	}
 
 	private processOffTopicFetchResult(baseModelTelemetry: ConversationalBaseTelemetryData): ChatResult {

--- a/src/extension/prompt/node/telemetry.ts
+++ b/src/extension/prompt/node/telemetry.ts
@@ -91,7 +91,8 @@ export function sendModelMessageTelemetry(
 	appliedText: string,
 	requestId: string,
 	doc: TextDocumentSnapshot | undefined,
-	baseTelemetry: ConversationalBaseTelemetryData
+	baseTelemetry: ConversationalBaseTelemetryData,
+	modeName: string,
 ): void {
 	// Get the languages of code blocks within the message
 	const codeBlockLanguages = getCodeBlocks(appliedText);
@@ -108,6 +109,7 @@ export function sendModelMessageTelemetry(
 			headerRequestId: requestId,
 			uiKind: ChatLocation.toString(location),
 			codeBlockLanguages: JSON.stringify({ ...codeBlockLanguages }),
+			mode: modeName,
 		},
 		{ messageCharLen: appliedText.length, numCodeBlocks: codeBlockLanguages.length },
 		baseTelemetry


### PR DESCRIPTION
This updates the conversation.message with source=model to include `mode` details in the telemetry