### PR TITLE
Fix responses API

### DIFF
--- a/src/platform/openai/node/fetch.ts
+++ b/src/platform/openai/node/fetch.ts
@@ -564,7 +564,7 @@ async function fetchWithInstrumentation(
 			throw error;
 		})
 		.finally(() => {
-			sendEngineMessagesTelemetry(telemetryService, request.messages!, telemetryData, false, logService);
+			sendEngineMessagesTelemetry(telemetryService, request.messages ?? [], telemetryData, false, logService);
 		});
 }
 


### PR DESCRIPTION
A telemetry change came in which fails due to this old `!`.
Will need to fix these telemetry events for this API later