### PR TITLE
fix: update apply_patch format instructions to be consistent and include required space

### DIFF
--- a/src/extension/prompts/node/agent/agentInstructions.tsx
+++ b/src/extension/prompts/node/agent/agentInstructions.tsx
@@ -400,12 +400,15 @@ export class ApplyPatchFormatInstructions extends PromptElement {
 	render() {
 		return <>
 			*** Update File: [file_path]<br />
-			[context_before] -&gt; See below for further instructions on context.<br />
+			&nbsp;[context_before] -&gt; See below for further instructions on context.<br />
 			-[old_code] -&gt; Precede each line in the old code with a minus sign.<br />
 			+[new_code] -&gt; Precede each line in the new, replacement code with a plus sign.<br />
-			[context_after] -&gt; See below for further instructions on context.<br />
+			&nbsp;[context_after] -&gt; See below for further instructions on context.<br />
 			<br />
+			Prefix each line of old code with exactly one minus (-) before its original first character; keep the original indentation after it.<br />
+			Prefix each line of new code with exactly one plus (+), the remainder of the line after the plus is the full new line content.<br />
 			For instructions on [context_before] and [context_after]:<br />
+			- Prefix each unchanged context line with exactly one ASCII space (U+0020) before its original first character; keep the original indentation after it.<br />
 			- By default, show 3 lines of code immediately above and 3 lines immediately below each change. If a change is within 3 lines of a previous change, do NOT duplicate the first change's [context_after] lines in the second change's [context_before] lines.<br />
 			- If 3 lines of context is insufficient to uniquely identify the snippet of code within the file, use the @@ operator to indicate the class or function to which the snippet belongs.<br />
 			- If a code block is repeated so many times in a class or function such that even a single @@ statement and 3 lines of context cannot uniquely identify the snippet of code, you can use multiple `@@` statements to jump to the right context.
@@ -413,17 +416,18 @@ export class ApplyPatchFormatInstructions extends PromptElement {
 			You must use the same indentation style as the original code. If the original code uses tabs, you must use tabs. If the original code uses spaces, you must use spaces. Be sure to use a proper UNESCAPED tab character.<br />
 			<br />
 			See below for an example of the patch format. If you propose changes to multiple regions in the same file, you should repeat the *** Update File header for each snippet of code to change:<br />
-			<br />
-			*** Begin Patch<br />
-			*** Update File: /Users/someone/pygorithm/searching/binary_search.py<br />
-			@@ class BaseClass<br />
-			@@   def method():<br />
-			[3 lines of pre-context]<br />
-			-[old_code]<br />
-			+[new_code]<br />
-			+[new_code]<br />
-			[3 lines of post-context]<br />
-			*** End Patch<br />
+			<Tag name='applyPatchExample'>
+				*** Begin Patch<br />
+				*** Update File: /Users/someone/pygorithm/searching/binary_search.py<br />
+				@@ class BaseClass<br />
+				@@   def method():<br />
+				&nbsp;[3 lines of pre-context]<br />
+				-[old_code]<br />
+				+[new_code]<br />
+				+[new_code]<br />
+				&nbsp;[3 lines of post-context]<br />
+				*** End Patch<br />
+			</Tag>
 		</>;
 	}
 }
@@ -433,7 +437,9 @@ class ApplyPatchInstructions extends PromptElement<DefaultAgentPromptProps> {
 		const isGpt5 = this.props.modelFamily === 'gpt-5';
 		return <Tag name='applyPatchInstructions'>
 			To edit files in the workspace, use the {ToolName.ApplyPatch} tool. If you have issues with it, you should first try to fix your patch and continue using {ToolName.ApplyPatch}. If you are stuck, you can fall back on the {ToolName.EditFile} tool. But {ToolName.ApplyPatch} is much faster and is the preferred tool.<br />
-			{isGpt5 && <>Prefer the smallest set of changes needed to satisfy the task. Avoid reformatting unrelated code; preserve existing style and public APIs unless the task requires changes. When practical, complete all edits for a file within a single message.<br /></>}
+			{isGpt5 && <>
+				Never use {ToolName.ApplyPatch} for creating files.<br />
+				Prefer the smallest set of changes needed to satisfy the task. Avoid reformatting unrelated code; preserve existing style and public APIs unless the task requires changes. When practical, complete all edits for a file within a single message.<br /></>}
 			The input for this tool is a string representing the patch to apply, following a special format. For each snippet of code that needs to be changed, repeat the following:<br />
 			<ApplyPatchFormatInstructions /><br />
 			NEVER print this out to the user, instead call the tool and the edits will be applied and shown to the user.<br />

--- a/src/extension/prompts/node/agent/test/__snapshots__/agentPrompt.spec.tsx.snap
+++ b/src/extension/prompts/node/agent/test/__snapshots__/agentPrompt.spec.tsx.snap
@@ -42,29 +42,34 @@ Tools can be disabled by the user. You may see tools used previously in the conv
 To edit files in the workspace, use the apply_patch tool. If you have issues with it, you should first try to fix your patch and continue using apply_patch. If you are stuck, you can fall back on the insert_edit_into_file tool. But apply_patch is much faster and is the preferred tool.
 The input for this tool is a string representing the patch to apply, following a special format. For each snippet of code that needs to be changed, repeat the following:
 *** Update File: [file_path]
-[context_before] -> See below for further instructions on context.
+ [context_before] -> See below for further instructions on context.
 -[old_code] -> Precede each line in the old code with a minus sign.
 +[new_code] -> Precede each line in the new, replacement code with a plus sign.
-[context_after] -> See below for further instructions on context.
+ [context_after] -> See below for further instructions on context.
 
+Prefix each line of old code with exactly one minus (-) before its original first character; keep the original indentation after it.
+Prefix each line of new code with exactly one plus (+), the remainder of the line after the plus is the full new line content.
 For instructions on [context_before] and [context_after]:
+- Prefix each unchanged context line with exactly one ASCII space (U+0020) before its original first character; keep the original indentation after it.
 - By default, show 3 lines of code immediately above and 3 lines immediately below each change. If a change is within 3 lines of a previous change, do NOT duplicate the first change's [context_after] lines in the second change's [context_before] lines.
 - If 3 lines of context is insufficient to uniquely identify the snippet of code within the file, use the @@ operator to indicate the class or function to which the snippet belongs.
 - If a code block is repeated so many times in a class or function such that even a single @@ statement and 3 lines of context cannot uniquely identify the snippet of code, you can use multiple \`@@\` statements to jump to the right context.
 You must use the same indentation style as the original code. If the original code uses tabs, you must use tabs. If the original code uses spaces, you must use spaces. Be sure to use a proper UNESCAPED tab character.
 
 See below for an example of the patch format. If you propose changes to multiple regions in the same file, you should repeat the *** Update File header for each snippet of code to change:
-
+<applyPatchExample>
 *** Begin Patch
 *** Update File: /Users/someone/pygorithm/searching/binary_search.py
 @@ class BaseClass
 @@   def method():
-[3 lines of pre-context]
+ [3 lines of pre-context]
 -[old_code]
 +[new_code]
 +[new_code]
-[3 lines of post-context]
+ [3 lines of post-context]
 *** End Patch
+
+</applyPatchExample>
 
 NEVER print this out to the user, instead call the tool and the edits will be applied and shown to the user.
 Follow best practices when editing files. If a popular external library exists to solve a problem, use it and properly install the package e.g. creating a "requirements.txt".


### PR DESCRIPTION
### ApplyPatchFormatInstructions

- Made sure the model knows to always have a space before `[context_before]` and `[context_after]`
- Made sure the model knows to always have a `-` before original old code lines
- Made sure the model knows to always have a `+` after new code lines

### ApplyPatchInstructions
- Explicitly tell GPT-5 to not use ApplyPatch for create file (*GPT-5 would try and create a file with apply_patch then fail over and over until eventually using the create_file tool*)

## Details

The apply_patch instructions and description would sometimes confuse the models and produce patches that where either missing an additional space infront of unchanging context lines, or it would consider `-` characters from the original text as old code lines.