### PR TITLE
fix: replace_string_in_file instructions for claude

### DIFF
--- a/src/extension/prompts/node/agent/agentInstructions.tsx
+++ b/src/extension/prompts/node/agent/agentInstructions.tsx
@@ -327,14 +327,14 @@ export class SweBenchAgentPrompt extends PromptElement<DefaultAgentPromptProps> 
 				Before using {ToolName.ReplaceString} tool, you must use {ToolName.ReadFile} tool to understand the file's contents and context you want to edit<br />
 				To make a file edit, provide the following:<br />
 				1. filePath: The absolute path to the file to modify (must be absolute, not relative)<br />
-				2. oldString: The text to replace (must be unique within the file, and must match the file contents exactly, including all whitespace, indentation, and existing escaping)<br />
+				2. oldString: The text to replace (must be unique within the file, and must match the file contents exactly, including all whitespace, indentation, existing escaping, and unicode characters)<br />
 				3. newString: The edited text to replace the oldString<br />
 				The tool will only replace ONE occurrence of oldString with newString in the specified file.<br />
 				CRITICAL REQUIREMENTS FOR USING THIS TOOL:<br />
 				1. UNIQUENESS: The oldString MUST uniquely identify the specific instance you want to change. This means:<br />
-				- Include AT LEAST 3-5 lines of context BEFORE the change point<br />
-				- Include AT LEAST 3-5 lines of context AFTER the change point<br />
-				- Include all whitespace, indentation, existing escaping, and surrounding code exactly as it appears in the file<br />
+				- Include AT LEAST 3-5 lines of exact current context BEFORE the change point<br />
+				- Include AT LEAST 3-5 lines of exact current context AFTER the change point<br />
+				- Include all whitespace, indentation, existing escaping, unicode characters, and surrounding code exactly as it appears in the file<br />
 				2. SINGLE INSTANCE: This tool can only change ONE instance at a time. If you need to change multiple instances:<br />
 				- Make separate calls to this tool for each instance<br />
 				- Each call must uniquely identify its specific instance using extensive context and exact lines from {ToolName.ReadFile}<br />
@@ -342,9 +342,11 @@ export class SweBenchAgentPrompt extends PromptElement<DefaultAgentPromptProps> 
 				- Check how many instances of the target text exist in the file<br />
 				- If multiple instances exist, gather enough context to uniquely identify each one<br />
 				- Plan separate tool calls for each instance<br />
+				WARNING: {ToolName.ReplaceString} calls will update the current content of the file.<br />
+				- Any subsequent overlapping {ToolName.ReplaceString} calls require {ToolName.ReadFile} tool call, otherwise the tool will fail<br />
 				WARNING: If you do not follow these requirements:<br />
 				- The tool will fail if oldString matches multiple locations<br />
-				- The tool will fail if oldString doesn't match exactly character for character (including whitespace, indentation, existing escaping)<br />
+				- The tool will fail if oldString doesn't match exactly the current content from the file character-for-character (including indentation, whitespace, existing escaping, exact same unicode characters)<br />
 				- The tool will fail if oldString matches newString exactly<br />
 				- You may change the wrong instance if you don't include enough context<br />
 				When making edits:<br />
@@ -491,6 +493,23 @@ class TodoListToolInstructions extends PromptElement<DefaultAgentPromptProps> {
 			4. Mark completed IMMEDIATELY<br />
 			5. Update the user with a very short evidence note<br />
 			6. Move to next todo<br />
+		</Tag>;
+	}
+}
+
+export class ReplaceStringInFileToolInstructions extends PromptElement {
+	render() {
+		return <Tag name='replaceStringInFileToolInstructions'>
+			When using the {ToolName.ReplaceString} tool:<br />
+			- Include 3-5 lines of the exact current content from the file, character-for-character (including indentation, whitespace, existing escaping, exact same unicode characters), before and after the string you want to replace, to make it unambiguous which part of the file should be edited.<br />
+			- Never construct or assume existing content, it must come from the file. You must use the {ToolName.ReadFile} tool to understand the file's existing content and content you want to edit.<br />
+			WARNING: {ToolName.ReplaceString} calls will update the current content of the file.<br />
+			- Any subsequent overlapping {ToolName.ReplaceString} calls require {ToolName.ReadFile} tool call, otherwise the tool will fail<br />
+			WARNING: If you do not follow these requirements:<br />
+			- The tool will fail if oldString matches multiple locations<br />
+			- The tool will fail if oldString doesn't match exactly the current content from the file character-for-character (including indentation, whitespace, existing escaping, exact same unicode characters)<br />
+			- The tool will fail if oldString matches newString exactly<br />
+			- You may change the wrong instance if you don't include enough context
 		</Tag>;
 	}
 }

--- a/src/extension/prompts/node/agent/agentPrompt.tsx
+++ b/src/extension/prompts/node/agent/agentPrompt.tsx
@@ -44,7 +44,7 @@ import { UserPreferences } from '../panel/preferences';
 import { ChatToolCalls } from '../panel/toolCalling';
 import { MultirootWorkspaceStructure } from '../panel/workspace/workspaceStructure';
 import { AgentConversationHistory } from './agentConversationHistory';
-import { DefaultAgentPrompt, SweBenchAgentPrompt } from './agentInstructions';
+import { DefaultAgentPrompt, ReplaceStringInFileToolInstructions, SweBenchAgentPrompt } from './agentInstructions';
 import { SummarizedConversationHistory } from './summarizedConversationHistory';
 
 export interface AgentPromptProps extends GenericBasePromptElementProps {
@@ -626,7 +626,7 @@ export function getEditingReminder(hasEditFileTool: boolean, hasReplaceStringToo
 		lines.push(<>When using the {ToolName.EditFile} tool, avoid repeating existing code, instead use a line comment with \`{EXISTING_CODE_MARKER}\` to represent regions of unchanged code.<br /></>);
 	}
 	if (hasReplaceStringTool) {
-		lines.push(<>When using the {ToolName.ReplaceString} tool, include 3-5 lines of unchanged exact content from the file (including indentation, whitespace, existing escaping), before and after the string you want to replace, to make it unambiguous which part of the file should be edited.<br /></>);
+		lines.push(<ReplaceStringInFileToolInstructions />);
 	}
 	if (hasEditFileTool && hasReplaceStringTool) {
 		if (useStrongReplaceStringHint) {

--- a/src/extension/prompts/node/agent/test/__snapshots__/agentPrompt.spec.tsx.snap
+++ b/src/extension/prompts/node/agent/test/__snapshots__/agentPrompt.spec.tsx.snap
@@ -256,7 +256,18 @@ copilot_cache_control: { type: 'ephemeral' }
 </context>
 <reminderInstructions>
 When using the insert_edit_into_file tool, avoid repeating existing code, instead use a line comment with /\`...existing code.../\` to represent regions of unchanged code.
-When using the replace_string_in_file tool, include 3-5 lines of unchanged code before and after the string you want to replace, to make it unambiguous which part of the file should be edited.
+<replaceStringInFileToolInstructions>
+When using the replace_string_in_file tool:
+- Include 3-5 lines of the exact current content from the file, character-for-character (including indentation, whitespace, existing escaping, exact same unicode characters), before and after the string you want to replace, to make it unambiguous which part of the file should be edited.
+- Never construct or assume existing content, it must come from the file. You must use the read_file tool to understand the file's existing content and content you want to edit.
+WARNING: replace_string_in_file calls will update the current content of the file.
+- Any subsequent overlapping replace_string_in_file calls require read_file tool call, otherwise the tool will fail
+WARNING: If you do not follow these requirements:
+- The tool will fail if oldString matches multiple locations
+- The tool will fail if oldString doesn't match exactly the current content from the file character-for-character (including indentation, whitespace, existing escaping, exact same unicode characters)
+- The tool will fail if oldString matches newString exactly
+- You may change the wrong instance if you don't include enough context
+</replaceStringInFileToolInstructions>
 It is much faster to edit using the replace_string_in_file tool. Prefer replace_string_in_file for making edits and only fall back to insert_edit_into_file if it fails.
 </reminderInstructions>
 <userRequest>


### PR DESCRIPTION
### Reminder Instructions

- Provides more detailed instructions to help Claude use the replace_string_in_file tool correctly.
  - Claude seems to struggle with:
    - Un-escape characters in original files
    - Mis-matched indentation and whitespace in original files
    - Making non-changing updates to existing code
    - Making updates to code that it modified previously.

### Notes:

- I avoided merging in these instructions into the SweBenchAgent instructions to avoid breaking the logic that exists specifically for SweBenchAgent. Instead, I made targeted adjustments to the existing instructions and merged similar instructions with the new `ReplaceStringInFileToolInstructions`.

## Details:

Claude attempting to make changes to a fairly large file, resulting in failed replace_string_in_file tool calls and healStringReplace calls:

<img width="970" height="2384" alt="image" src="https://github.com/user-attachments/assets/ca8735f2-2a4e-4244-8423-ecf0482186cb" />

### Updated Instructions

After these sorts of instructions (I forced them in my copilot-instructions.md file), Claude is much more successful at making its changes:

<img width="481" height="1261" alt="image" src="https://github.com/user-attachments/assets/7672598a-2bde-4d4c-8ef5-1e76bcd3bf55" />
