### PR TITLE
fix: referencing wrong edit tool with no string_replace

### DIFF
--- a/src/extension/prompts/node/agent/agentInstructions.tsx
+++ b/src/extension/prompts/node/agent/agentInstructions.tsx
@@ -149,14 +149,14 @@ export class DefaultAgentPrompt extends PromptElement<DefaultAgentPromptProps> {
 						{isGpt5 && <>Make the smallest set of edits needed and avoid reformatting or moving unrelated code. Preserve existing style and conventions, and keep imports, exports, and public APIs stable unless the task requires changes. Prefer completing all edits for a file within a single message when practical.<br /></>}
 						NEVER show the changes to the user, just call the tool, and the edits will be applied and shown to the user.<br />
 						NEVER print a codeblock that represents a change to a file, use {ToolName.ReplaceString} or {ToolName.EditFile} instead.<br />
-						For each file, give a short description of what needs to be changed, then use the {ToolName.ReplaceString} or {ToolName.EditFile} tools. You can use any tool multiple times in a response, and you can keep writing text after using a tool.<br /></> :
-					<>
+						For each file, give a short description of what needs to be changed, then use the {ToolName.ReplaceString} or {ToolName.EditFile} tools. You can use any tool multiple times in a response, and you can keep writing text after using a tool.<br /></>
+					: <>
 						Don't try to edit an existing file without reading it first, so you can make changes properly.<br />
-						Use the {ToolName.ReplaceString} tool to edit files. When editing files, group your changes by file.<br />
+						Use the {ToolName.EditFile} tool to edit files. When editing files, group your changes by file.<br />
 						{isGpt5 && <>Make the smallest set of edits needed and avoid reformatting or moving unrelated code. Preserve existing style and conventions, and keep imports, exports, and public APIs stable unless the task requires changes. Prefer completing all edits for a file within a single message when practical.<br /></>}
 						NEVER show the changes to the user, just call the tool, and the edits will be applied and shown to the user.<br />
-						NEVER print a codeblock that represents a change to a file, use {ToolName.ReplaceString} instead.<br />
-						For each file, give a short description of what needs to be changed, then use the {ToolName.ReplaceString} tool. You can use any tool multiple times in a response, and you can keep writing text after using a tool.<br />
+						NEVER print a codeblock that represents a change to a file, use {ToolName.EditFile} instead.<br />
+						For each file, give a short description of what needs to be changed, then use the {ToolName.EditFile} tool. You can use any tool multiple times in a response, and you can keep writing text after using a tool.<br />
 					</>}
 				<GenericEditingTips {...this.props} />
 				The {ToolName.EditFile} tool is very smart and can understand how to apply your edits to the user's files, you just need to provide minimal hints.<br />


### PR DESCRIPTION
No model actually uses this config currently, but fix the instructions nevertheless

Closes https://github.com/microsoft/vscode/issues/258888