### PR TITLE
Remove the message copilot_cache_control field from a context where there is no understanding of it

### DIFF
--- a/src/platform/endpoint/test/node/openaiCompatibleEndpoint.ts
+++ b/src/platform/endpoint/test/node/openaiCompatibleEndpoint.ts
@@ -164,6 +164,14 @@ export class OpenAICompatibleTestEndpoint extends ChatEndpoint {
 			delete body.tools;
 		}
 
+		if (body?.messages && this.modelConfig.name && this.modelConfig.name.trim() !== '') {
+			body.messages.forEach((message: any) => {
+				if (message.copilot_cache_control) {
+					delete message.copilot_cache_control;
+				}
+			});
+		}
+
 		if (body) {
 			if (this.modelConfig.overrides.snippy === null) {
 				delete body.snippy;

--- a/src/platform/endpoint/test/node/openaiCompatibleEndpoint.ts
+++ b/src/platform/endpoint/test/node/openaiCompatibleEndpoint.ts
@@ -164,7 +164,7 @@ export class OpenAICompatibleTestEndpoint extends ChatEndpoint {
 			delete body.tools;
 		}
 
-		if (body?.messages && this.modelConfig.name && this.modelConfig.name.trim() !== '') {
+		if (body?.messages) {
 			body.messages.forEach((message: any) => {
 				if (message.copilot_cache_control) {
 					delete message.copilot_cache_control;


### PR DESCRIPTION
Remove the message copilot_cache_control field if it exists when calling an OpenAI compatible endpoint where it might not be understood. The result of not understanding the field can be benign or result in a rejection.