### PR TITLE
eng: disable nuget mcp tests for now

### DIFF
--- a/src/extension/mcp/test/vscode-node/nuget.spec.ts
+++ b/src/extension/mcp/test/vscode-node/nuget.spec.ts
@@ -10,7 +10,7 @@ import { ITestingServicesAccessor, TestingServiceCollection } from '../../../../
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
 import { NuGetMcpSetup } from '../../vscode-node/nuget';
 
-describe('get nuget MCP server info', { timeout: 30_000 }, () => {
+describe.skip('get nuget MCP server info', { timeout: 30_000 }, () => {
 	let testingServiceCollection: TestingServiceCollection = createExtensionUnitTestingServices();
 	let accessor: ITestingServicesAccessor = testingServiceCollection.createTestingAccessor();
 	let logService: ILogService = accessor.get(ILogService);


### PR DESCRIPTION
These depend on .net being installed the machine which is not a requirement for vscode chat developers.

Ref: https://github.com/microsoft/vscode/issues/261524