### PR TITLE
Add better support for new embeddings model

### DIFF
--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -530,7 +530,8 @@ export const enum CHAT_MODEL {
 // WARNING
 // These values are used in the request and are case sensitive. Do not change them unless advised by CAPI.
 export const enum EMBEDDING_MODEL {
-	TEXT3SMALL = "text-embedding-3-small"
+	TEXT3SMALL = 'text-embedding-3-small',
+	Metis_1024_I16_Binary = 'metis-1024-I16-Binary',
 }
 
 export enum AuthProviderId {

--- a/src/platform/endpoint/common/endpointProvider.ts
+++ b/src/platform/endpoint/common/endpointProvider.ts
@@ -78,10 +78,11 @@ export function isEmbeddingModelInformation(model: IModelAPIResponse): model is 
 }
 
 export type ChatEndpointFamily = 'gpt-4.1' | 'gpt-4o-mini' | 'copilot-base';
-export type EmbeddingsEndpointFamily = 'text3small';
+export type EmbeddingsEndpointFamily = 'text3small' | 'metis';
 
 export interface IEndpointProvider {
 	readonly _serviceBrand: undefined;
+
 	/**
 	 * Get the embedding endpoint information
 	 */

--- a/src/platform/workspaceChunkSearch/test/node/packEmbedding.spec.ts
+++ b/src/platform/workspaceChunkSearch/test/node/packEmbedding.spec.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test } from 'vitest';
+import { Embedding, EmbeddingType } from '../../../embeddings/common/embeddingsComputer';
+import { packEmbedding, unpackEmbedding } from '../../node/workspaceChunkAndEmbeddingCache';
+
+suite('Pack Embedding', () => {
+	test('Text3small should pack and unpack to same values', () => {
+		const embedding: Embedding = {
+			type: EmbeddingType.text3small_512,
+			// Start with float32 array so that we don't check for the very small rounding
+			// that can happen when going from js number -> float32
+			value: Array.from(Float32Array.from({ length: 512 }, () => Math.random())),
+		};
+
+		const serialized = packEmbedding(embedding);
+		const deserialized = unpackEmbedding(EmbeddingType.text3small_512, serialized);
+		assert.deepStrictEqual(deserialized.value.length, embedding.value.length);
+		assert.deepStrictEqual(deserialized.value, embedding.value);
+	});
+
+	test('Metis should use binary storage', () => {
+		const embedding: Embedding = {
+			type: EmbeddingType.metis_1024_I16_Binary,
+			value: Array.from({ length: 1024 }, () => Math.random() < 0.5 ? 0.03125 : -0.03125)
+		};
+
+		const serialized = packEmbedding(embedding);
+		assert.strictEqual(serialized.length, 1024 / 8);
+
+		const deserialized = unpackEmbedding(EmbeddingType.metis_1024_I16_Binary, serialized);
+		assert.deepStrictEqual(deserialized.value.length, embedding.value.length);
+		assert.deepStrictEqual(deserialized.value, embedding.value);
+	});
+
+	test('Unpack should work with buffer offsets', () => {
+		const embedding: Embedding = {
+			type: EmbeddingType.metis_1024_I16_Binary,
+			value: Array.from({ length: 1024 }, () => Math.random() < 0.5 ? 0.03125 : -0.03125)
+		};
+
+		const serialized = packEmbedding(embedding);
+
+		// Now create a new buffer and write the serialized data to it at an offset
+		const prefixAndSuffixSize = 512;
+		const buffer = new Uint8Array(serialized.length + prefixAndSuffixSize * 2);
+		for (let i = 0; i < serialized.length; i++) {
+			buffer[i + prefixAndSuffixSize] = serialized[i];
+		}
+
+		const serializedCopy = new Uint8Array(buffer.buffer, prefixAndSuffixSize, serialized.length);
+
+		const deserialized = unpackEmbedding(EmbeddingType.metis_1024_I16_Binary, serializedCopy);
+		assert.deepStrictEqual(deserialized.value.length, embedding.value.length);
+		assert.deepStrictEqual(deserialized.value, embedding.value);
+	});
+});


### PR DESCRIPTION
New model uses binary so it should be 6% of the storage size 