### PR TITLE
Add command executor abstraction, only run dotnet CLI tests on CI

### DIFF
--- a/src/extension/mcp/test/vscode-node/fixtures/snapshots/dotnet-package-search-does-not-exist.json
+++ b/src/extension/mcp/test/vscode-node/fixtures/snapshots/dotnet-package-search-does-not-exist.json
@@ -1,0 +1,10 @@
+{
+	"version": 2,
+	"problems": [],
+	"searchResult": [
+		{
+			"sourceName": "nuget.org",
+			"packages": []
+		}
+	]
+}

--- a/src/extension/mcp/test/vscode-node/fixtures/snapshots/dotnet-package-search-exists.json
+++ b/src/extension/mcp/test/vscode-node/fixtures/snapshots/dotnet-package-search-exists.json
@@ -1,0 +1,17 @@
+{
+	"version": 2,
+	"problems": [],
+	"searchResult": [
+		{
+			"sourceName": "nuget.org",
+			"packages": [
+				{
+					"id": "BaseTestPackage.DotnetTool",
+					"latestVersion": "1.0.0",
+					"totalDownloads": 1214,
+					"owners": "NuGetTestData"
+				}
+			]
+		}
+	]
+}

--- a/src/extension/mcp/test/vscode-node/fixtures/snapshots/nuget-readme.md
+++ b/src/extension/mcp/test/vscode-node/fixtures/snapshots/nuget-readme.md
@@ -1,0 +1,73 @@
+# NuGet MCP Server
+Contains an [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) server for NuGet, enabling advanced tooling and automation scenarios for NuGet package management.
+
+## Capabilities
+- Uses your configured NuGet feeds to get real time information about packages.
+- Provides the ability to update packages with known vulnerabilities, including transitive dependencies.
+- Provides advanced tooling for updating packages which provides the best updates based on a projects unique package graph and target frameworks.
+
+## Requirements
+To run the MCP server, you must have **[.NET 10 Preview 6 or later](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)** installed.
+This version of .NET adds a command, `dnx`, which is used to download, install, and run the MCP server from [nuget.org](https://nuget.org).
+
+To verify your .NET version, run the following command in your terminal:
+```bash
+dotnet --info
+```
+
+## Configuration
+To configure the MCP server for use with Visual Studio or VS Code, use the following snippet and include it in your `mcp.json`:
+
+```jsonc
+{
+  "servers": {
+    "nuget": {
+      "type": "stdio",
+      "command": "dnx",
+      "args": [
+        "NuGet.Mcp.Server",
+        "--source",
+        "https://api.nuget.org/v3/index.json",
+        "--prerelease",
+        "--yes"
+      ]
+    }
+  }
+}
+```
+
+**NOTE:** The `--prerelease` flag is required to use the MCP server from NuGet.org, as it is currently in preview and will cause new versions to be downloaded automatically.
+If you'd like to use a specific version of the MCP server, you can specify it with the `--version` argument, like so:
+```jsonc
+{
+  "servers": {
+    "nuget": {
+      "type": "stdio",
+      "command": "dnx",
+      "args": [
+        "NuGet.Mcp.Server",
+        "--source",
+        "https://api.nuget.org/v3/index.json",
+        "--version",
+        "0.1.0-preview",
+        "--yes"
+      ]
+    }
+  }
+}
+```
+
+When configured this way, you will need to update the version as new release become available.
+
+The format of the configuration file can differ for different environments. Below is a table with a link to documentation on how to configure it.
+
+| Environment | Documentation |
+|-------------|--------------|
+| Visual Studio | [File locations for automatic discovery of MCP configuration](https://learn.microsoft.com/visualstudio/ide/mcp-servers?view=vs-2022#file-locations-for-automatic-discovery-of-mcp-configuration) |
+| VS Code | [MCP configuration in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server) |
+| GitHub Copilot Coding Agent | [Setting up MCP servers in a repository](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent/extending-copilot-coding-agent-with-mcp#setting-up-mcp-servers-in-a-repository)
+
+## Support
+
+If you experience an issue with the NuGet MCP server or have any other feedback, please open an issue on the [NuGet GitHub repository](https://github.com/NuGet/Home/issues/new?template=MCPSERVER.yml).
+Please provide the requested information in the issue template so that we can better understand and address your issue or suggestion.

--- a/src/extension/mcp/test/vscode-node/fixtures/snapshots/nuget-service-index.json
+++ b/src/extension/mcp/test/vscode-node/fixtures/snapshots/nuget-service-index.json
@@ -1,0 +1,207 @@
+{
+	"version": "3.0.0",
+	"resources": [
+		{
+			"@id": "https://azuresearch-usnc.nuget.org/query",
+			"@type": "SearchQueryService",
+			"comment": "Query endpoint of NuGet Search service (primary)"
+		},
+		{
+			"@id": "https://azuresearch-ussc.nuget.org/query",
+			"@type": "SearchQueryService",
+			"comment": "Query endpoint of NuGet Search service (secondary)"
+		},
+		{
+			"@id": "https://azuresearch-usnc.nuget.org/autocomplete",
+			"@type": "SearchAutocompleteService",
+			"comment": "Autocomplete endpoint of NuGet Search service (primary)"
+		},
+		{
+			"@id": "https://azuresearch-ussc.nuget.org/autocomplete",
+			"@type": "SearchAutocompleteService",
+			"comment": "Autocomplete endpoint of NuGet Search service (secondary)"
+		},
+		{
+			"@id": "https://azuresearch-usnc.nuget.org/",
+			"@type": "SearchGalleryQueryService/3.0.0-rc",
+			"comment": "Azure Website based Search Service used by Gallery (primary)"
+		},
+		{
+			"@id": "https://azuresearch-ussc.nuget.org/",
+			"@type": "SearchGalleryQueryService/3.0.0-rc",
+			"comment": "Azure Website based Search Service used by Gallery (secondary)"
+		},
+		{
+			"@id": "https://api.nuget.org/v3/registration5-semver1/",
+			"@type": "RegistrationsBaseUrl",
+			"comment": "Base URL of Azure storage where NuGet package registration info is stored"
+		},
+		{
+			"@id": "https://api.nuget.org/v3-flatcontainer/",
+			"@type": "PackageBaseAddress/3.0.0",
+			"comment": "Base URL of where NuGet packages are stored, in the format https://api.nuget.org/v3-flatcontainer/{id-lower}/{version-lower}/{id-lower}.{version-lower}.nupkg"
+		},
+		{
+			"@id": "https://www.nuget.org/api/v2",
+			"@type": "LegacyGallery"
+		},
+		{
+			"@id": "https://www.nuget.org/api/v2",
+			"@type": "LegacyGallery/2.0.0"
+		},
+		{
+			"@id": "https://www.nuget.org/api/v2/package",
+			"@type": "PackagePublish/2.0.0"
+		},
+		{
+			"@id": "https://www.nuget.org/api/v2/symbolpackage",
+			"@type": "SymbolPackagePublish/4.9.0",
+			"comment": "The gallery symbol publish endpoint."
+		},
+		{
+			"@id": "https://azuresearch-usnc.nuget.org/query",
+			"@type": "SearchQueryService/3.0.0-rc",
+			"comment": "Query endpoint of NuGet Search service (primary) used by RC clients"
+		},
+		{
+			"@id": "https://azuresearch-ussc.nuget.org/query",
+			"@type": "SearchQueryService/3.0.0-rc",
+			"comment": "Query endpoint of NuGet Search service (secondary) used by RC clients"
+		},
+		{
+			"@id": "https://azuresearch-usnc.nuget.org/query",
+			"@type": "SearchQueryService/3.5.0",
+			"comment": "Query endpoint of NuGet Search service (primary) that supports package type filtering"
+		},
+		{
+			"@id": "https://azuresearch-ussc.nuget.org/query",
+			"@type": "SearchQueryService/3.5.0",
+			"comment": "Query endpoint of NuGet Search service (secondary) that supports package type filtering"
+		},
+		{
+			"@id": "https://azuresearch-usnc.nuget.org/autocomplete",
+			"@type": "SearchAutocompleteService/3.0.0-rc",
+			"comment": "Autocomplete endpoint of NuGet Search service (primary) used by RC clients"
+		},
+		{
+			"@id": "https://azuresearch-ussc.nuget.org/autocomplete",
+			"@type": "SearchAutocompleteService/3.0.0-rc",
+			"comment": "Autocomplete endpoint of NuGet Search service (secondary) used by RC clients"
+		},
+		{
+			"@id": "https://azuresearch-usnc.nuget.org/autocomplete",
+			"@type": "SearchAutocompleteService/3.5.0",
+			"comment": "Autocomplete endpoint of NuGet Search service (primary) that supports package type filtering"
+		},
+		{
+			"@id": "https://azuresearch-ussc.nuget.org/autocomplete",
+			"@type": "SearchAutocompleteService/3.5.0",
+			"comment": "Autocomplete endpoint of NuGet Search service (secondary) that supports package type filtering"
+		},
+		{
+			"@id": "https://api.nuget.org/v3/registration5-semver1/",
+			"@type": "RegistrationsBaseUrl/3.0.0-rc",
+			"comment": "Base URL of Azure storage where NuGet package registration info is stored used by RC clients. This base URL does not include SemVer 2.0.0 packages."
+		},
+		{
+			"@id": "https://www.nuget.org/packages/{id}/{version}/ReportAbuse",
+			"@type": "ReportAbuseUriTemplate/3.0.0-rc",
+			"comment": "URI template used by NuGet Client to construct Report Abuse URL for packages used by RC clients"
+		},
+		{
+			"@id": "https://api.nuget.org/v3/registration5-semver1/{id-lower}/index.json",
+			"@type": "PackageDisplayMetadataUriTemplate/3.0.0-rc",
+			"comment": "URI template used by NuGet Client to construct display metadata for Packages using ID"
+		},
+		{
+			"@id": "https://api.nuget.org/v3/registration5-semver1/{id-lower}/{version-lower}.json",
+			"@type": "PackageVersionDisplayMetadataUriTemplate/3.0.0-rc",
+			"comment": "URI template used by NuGet Client to construct display metadata for Packages using ID, Version"
+		},
+		{
+			"@id": "https://azuresearch-usnc.nuget.org/query",
+			"@type": "SearchQueryService/3.0.0-beta",
+			"comment": "Query endpoint of NuGet Search service (primary) used by beta clients"
+		},
+		{
+			"@id": "https://azuresearch-ussc.nuget.org/query",
+			"@type": "SearchQueryService/3.0.0-beta",
+			"comment": "Query endpoint of NuGet Search service (secondary) used by beta clients"
+		},
+		{
+			"@id": "https://azuresearch-usnc.nuget.org/autocomplete",
+			"@type": "SearchAutocompleteService/3.0.0-beta",
+			"comment": "Autocomplete endpoint of NuGet Search service (primary) used by beta clients"
+		},
+		{
+			"@id": "https://azuresearch-ussc.nuget.org/autocomplete",
+			"@type": "SearchAutocompleteService/3.0.0-beta",
+			"comment": "Autocomplete endpoint of NuGet Search service (secondary) used by beta clients"
+		},
+		{
+			"@id": "https://api.nuget.org/v3/registration5-semver1/",
+			"@type": "RegistrationsBaseUrl/3.0.0-beta",
+			"comment": "Base URL of Azure storage where NuGet package registration info is stored used by Beta clients. This base URL does not include SemVer 2.0.0 packages."
+		},
+		{
+			"@id": "https://www.nuget.org/packages/{id}/{version}/ReportAbuse",
+			"@type": "ReportAbuseUriTemplate/3.0.0-beta",
+			"comment": "URI template used by NuGet Client to construct Report Abuse URL for packages"
+		},
+		{
+			"@id": "https://www.nuget.org/packages/{id}/{version}?_src=template",
+			"@type": "PackageDetailsUriTemplate/5.1.0",
+			"comment": "URI template used by NuGet Client to construct details URL for packages"
+		},
+		{
+			"@id": "https://www.nuget.org/profiles/{owner}?_src=template",
+			"@type": "OwnerDetailsUriTemplate/6.11.0",
+			"comment": "URI template used by NuGet Client to construct owner URL for packages"
+		},
+		{
+			"@id": "https://api.nuget.org/v3/registration5-gz-semver1/",
+			"@type": "RegistrationsBaseUrl/3.4.0",
+			"comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL does not include SemVer 2.0.0 packages."
+		},
+		{
+			"@id": "https://api.nuget.org/v3/registration5-gz-semver2/",
+			"@type": "RegistrationsBaseUrl/3.6.0",
+			"comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
+		},
+		{
+			"@id": "https://api.nuget.org/v3/registration5-gz-semver2/",
+			"@type": "RegistrationsBaseUrl/Versioned",
+			"clientVersion": "4.3.0-alpha",
+			"comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
+		},
+		{
+			"@id": "https://api.nuget.org/v3-index/repository-signatures/4.7.0/index.json",
+			"@type": "RepositorySignatures/4.7.0",
+			"comment": "The endpoint for discovering information about this package source's repository signatures."
+		},
+		{
+			"@id": "https://api.nuget.org/v3-index/repository-signatures/5.0.0/index.json",
+			"@type": "RepositorySignatures/5.0.0",
+			"comment": "The endpoint for discovering information about this package source's repository signatures."
+		},
+		{
+			"@id": "https://api.nuget.org/v3/vulnerabilities/index.json",
+			"@type": "VulnerabilityInfo/6.7.0",
+			"comment": "The endpoint for discovering information about vulnerabilities of packages in this package source."
+		},
+		{
+			"@id": "https://api.nuget.org/v3/catalog0/index.json",
+			"@type": "Catalog/3.0.0",
+			"comment": "Index of the NuGet package catalog."
+		},
+		{
+			"@id": "https://api.nuget.org/v3-flatcontainer/{lower_id}/{lower_version}/readme",
+			"@type": "ReadmeUriTemplate/6.13.0",
+			"comment": "URI template used by NuGet Client to construct a URL for downloading a package's README."
+		}
+	],
+	"@context": {
+		"@vocab": "http://schema.nuget.org/services#",
+		"comment": "http://www.w3.org/2000/01/rdf-schema#comment"
+	}
+}

--- a/src/extension/mcp/test/vscode-node/nuget.integration.spec.ts
+++ b/src/extension/mcp/test/vscode-node/nuget.integration.spec.ts
@@ -6,22 +6,33 @@
 import path from 'path';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { ILogService } from '../../../../platform/log/common/logService';
+import { IFetcherService } from '../../../../platform/networking/common/fetcherService';
 import { ITestingServicesAccessor, TestingServiceCollection } from '../../../../platform/test/node/services';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
 import { NuGetMcpSetup } from '../../vscode-node/nuget';
+import { CommandExecutor, ICommandExecutor } from '../../vscode-node/util';
+import { FixtureFetcherService } from './util';
 
-describe.skip('get nuget MCP server info', { timeout: 30_000 }, () => {
-	let testingServiceCollection: TestingServiceCollection = createExtensionUnitTestingServices();
-	let accessor: ITestingServicesAccessor = testingServiceCollection.createTestingAccessor();
-	let logService: ILogService = accessor.get(ILogService);
+const RUN_DOTNET_CLI_TESTS = !!process.env['CI'] || !!process.env['BUILD_ARTIFACTSTAGINGDIRECTORY'];
+
+describe.runIf(RUN_DOTNET_CLI_TESTS)('get nuget MCP server info using dotnet CLI', { timeout: 30_000 }, () => {
+	let testingServiceCollection: TestingServiceCollection;
+	let accessor: ITestingServicesAccessor;
+	let logService: ILogService;
+	let fetcherService: IFetcherService;
+	let commandExecutor: ICommandExecutor;
 	let nuget: NuGetMcpSetup;
 
 	beforeEach(() => {
 		testingServiceCollection = createExtensionUnitTestingServices();
 		accessor = testingServiceCollection.createTestingAccessor();
 		logService = accessor.get(ILogService);
+		fetcherService = new FixtureFetcherService();
+		commandExecutor = new CommandExecutor();
 		nuget = new NuGetMcpSetup(
 			logService,
+			fetcherService,
+			commandExecutor,
 			{ command: 'dotnet', args: [] }, // allow dotnet command to be overridden for testing
 			path.join(__dirname, 'fixtures', 'nuget') // file based package source for testing
 		);

--- a/src/extension/mcp/test/vscode-node/nuget.stub.spec.ts
+++ b/src/extension/mcp/test/vscode-node/nuget.stub.spec.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ILogService } from '../../../../platform/log/common/logService';
+import { ITestingServicesAccessor, TestingServiceCollection } from '../../../../platform/test/node/services';
+import { createExtensionUnitTestingServices } from '../../../test/node/services';
+import { NuGetMcpSetup } from '../../vscode-node/nuget';
+import { FixtureCommandExecutor, FixtureFetcherService } from './util';
+
+describe('get nuget MCP server info using fake CLI', { timeout: 30_000 }, () => {
+	let testingServiceCollection: TestingServiceCollection;
+	let accessor: ITestingServicesAccessor;
+	let logService: ILogService;
+	let fetcherService: FixtureFetcherService;
+	let commandExecutor: FixtureCommandExecutor;
+	let nuget: NuGetMcpSetup;
+
+	beforeEach(() => {
+		testingServiceCollection = createExtensionUnitTestingServices();
+		accessor = testingServiceCollection.createTestingAccessor();
+		logService = accessor.get(ILogService);
+		fetcherService = new FixtureFetcherService(new Map([
+			['https://api.nuget.org/v3/index.json', { fileName: 'nuget-service-index.json', status: 200 }],
+			['https://api.nuget.org/v3-flatcontainer/basetestpackage.dotnettool/1.0.0/readme', { fileName: 'nuget-readme.md', status: 200 }],
+		]));
+		commandExecutor = new FixtureCommandExecutor(new Map([
+			['dotnet --version', { stdout: '10.0.100-preview.7.25358.102', exitCode: 0 }]
+		]));
+		nuget = new NuGetMcpSetup(logService, fetcherService, commandExecutor);
+	});
+
+	it('returns package metadata', async () => {
+		commandExecutor.fullCommandToResultMap.set(
+			'dotnet package search basetestpackage.DOTNETTOOL --source https://api.nuget.org/v3/index.json --prerelease --format json',
+			{ fileName: 'dotnet-package-search-exists.json', exitCode: 0 });
+		const result = await nuget.getNuGetPackageMetadata('basetestpackage.DOTNETTOOL');
+		expect(result.state).toBe('ok');
+		if (result.state === 'ok') {
+			expect(result.name).toBe('BaseTestPackage.DotnetTool');
+			expect(result.version).toBe('1.0.0');
+			expect(result.publisher).toBe('NuGetTestData');
+			await expect(result.readme).toMatchFileSnapshot('fixtures/snapshots/nuget-readme.md');
+		} else {
+			expect.fail();
+		}
+	});
+
+	it('handles missing package', async () => {
+		commandExecutor.fullCommandToResultMap.set(
+			'dotnet package search basetestpackage.dotnettool --source https://api.nuget.org/v3/index.json --prerelease --format json',
+			{ fileName: 'dotnet-package-search-does-not-exist.json', exitCode: 0 });
+		const result = await nuget.getNuGetPackageMetadata('basetestpackage.dotnettool');
+		expect(result.state).toBe('error');
+		if (result.state === 'error') {
+			expect(result.error).toBeDefined();
+			expect(result.errorType).toBe('NotFound');
+		} else {
+			expect.fail();
+		}
+	});
+});

--- a/src/extension/mcp/test/vscode-node/util.ts
+++ b/src/extension/mcp/test/vscode-node/util.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs/promises';
+import path from 'path';
+import { FetchOptions, IAbortController, IFetcherService, Response } from '../../../../platform/networking/common/fetcherService';
+import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
+import { ICommandExecutor } from '../../vscode-node/util';
+
+type CommandResult = { fileName?: string; stdout?: string; exitCode: number };
+
+export class FixtureCommandExecutor implements ICommandExecutor {
+	commands: Array<{ command: string; args: string[]; cwd: string }> = [];
+
+	constructor(public readonly fullCommandToResultMap: Map<string, CommandResult> = new Map()) { }
+
+	async executeWithTimeout(command: string, args: string[], cwd: string, timeoutMs?: number, expectZeroExitCode?: boolean, cancellationToken?: CancellationToken): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+		this.commands.push({ command, args, cwd });
+
+		let stdout: string = '';
+		let exitCode: number = 1;
+		if (this.fullCommandToResultMap) {
+			const fullCommand = `${command} ${args.join(' ')}`;
+			const result = this.fullCommandToResultMap.get(fullCommand);
+			if (result) {
+				exitCode = result.exitCode;
+				if (result.fileName) {
+					const filePath = path.join(__dirname, 'fixtures', 'snapshots', result.fileName);
+					stdout = await fs.readFile(filePath, 'utf-8');
+				} else if (result.stdout) {
+					stdout = result.stdout;
+				}
+			}
+		}
+
+		if (expectZeroExitCode && exitCode !== 0) {
+			return Promise.reject(new Error(`Expected zero exit code but got ${exitCode}`));
+		}
+
+		return Promise.resolve({
+			exitCode,
+			stdout,
+			stderr: '',
+		});
+	}
+}
+
+export class FixtureFetcherService implements IFetcherService {
+	urls: Array<string> = [];
+
+	constructor(readonly urlToFileNameMap: Map<string, { fileName: string; status: number }> = new Map()) { }
+
+	async fetch(url: string, options: FetchOptions): Promise<Response> {
+		this.urls.push(url);
+
+		const result = this.urlToFileNameMap?.get(url);
+		if (!result) {
+			return Promise.resolve({
+				ok: false,
+				status: 404,
+				json: async () => ({ message: 'Not Found' }),
+			} as Response);
+		} else {
+			const filePath = path.join(__dirname, 'fixtures', 'snapshots', result.fileName);
+			const content = await fs.readFile(filePath, 'utf-8');
+			return Promise.resolve({
+				ok: result.status === 200,
+				status: result.status,
+				text: async () => content,
+				json: async () => JSON.parse(content),
+			} as Response);
+		}
+	}
+
+	_serviceBrand: undefined;
+	getUserAgentLibrary(): string { throw new Error('Method not implemented.'); }
+	disconnectAll(): Promise<unknown> { throw new Error('Method not implemented.'); }
+	makeAbortController(): IAbortController { throw new Error('Method not implemented.'); }
+	isAbortError(e: any): boolean { throw new Error('Method not implemented.'); }
+	isInternetDisconnectedError(e: any): boolean { throw new Error('Method not implemented.'); }
+	isFetcherError(e: any): boolean { throw new Error('Method not implemented.'); }
+	getUserMessageForFetcherError(err: any): string { throw new Error('Method not implemented.'); }
+}

--- a/src/extension/mcp/vscode-node/commands.ts
+++ b/src/extension/mcp/vscode-node/commands.ts
@@ -301,10 +301,10 @@ Error: ${error}`);
 		this.pendingSetup = { cts, canPrompt, done, validateArgs, pendingArgs, stopwatch: sw };
 	}
 
-	public static async validatePackageRegistry(args: { type: PackageType; name: string }, logService: ILogService, fetcherServer: IFetcherService): Promise<ValidatePackageResult> {
+	public static async validatePackageRegistry(args: { type: PackageType; name: string }, logService: ILogService, fetcherService: IFetcherService): Promise<ValidatePackageResult> {
 		try {
 			if (args.type === 'npm') {
-				const response = await fetcherServer.fetch(`https://registry.npmjs.org/${encodeURIComponent(args.name)}`, { method: 'GET' });
+				const response = await fetcherService.fetch(`https://registry.npmjs.org/${encodeURIComponent(args.name)}`, { method: 'GET' });
 				if (!response.ok) {
 					return { state: 'error', errorType: ValidatePackageErrorType.NotFound, error: localize("mcp.setup.npmPackageNotFound", "Package {0} not found in npm registry", args.name) };
 				}
@@ -318,7 +318,7 @@ Error: ${error}`);
 					readme: data.readme,
 				};
 			} else if (args.type === 'pip') {
-				const response = await fetcherServer.fetch(`https://pypi.org/pypi/${encodeURIComponent(args.name)}/json`, { method: 'GET' });
+				const response = await fetcherService.fetch(`https://pypi.org/pypi/${encodeURIComponent(args.name)}/json`, { method: 'GET' });
 				if (!response.ok) {
 					return { state: 'error', errorType: ValidatePackageErrorType.NotFound, error: localize("mcp.setup.pythonPackageNotFound", "Package {0} not found in PyPI registry", args.name) };
 				}
@@ -334,7 +334,7 @@ Error: ${error}`);
 					readme: data.info?.description
 				};
 			} else if (args.type === 'nuget') {
-				const nuGetMcpSetup = new NuGetMcpSetup(logService);
+				const nuGetMcpSetup = new NuGetMcpSetup(logService, fetcherService);
 				return await nuGetMcpSetup.getNuGetPackageMetadata(args.name);
 			} else if (args.type === 'docker') {
 				// Docker Hub API uses namespace/repository format
@@ -343,7 +343,7 @@ Error: ${error}`);
 					? args.name.split('/', 2)
 					: ['library', args.name];
 
-				const response = await fetcherServer.fetch(`https://hub.docker.com/v2/repositories/${encodeURIComponent(namespace)}/${encodeURIComponent(repository)}`, { method: 'GET' });
+				const response = await fetcherService.fetch(`https://hub.docker.com/v2/repositories/${encodeURIComponent(namespace)}/${encodeURIComponent(repository)}`, { method: 'GET' });
 				if (!response.ok) {
 					return { state: 'error', errorType: ValidatePackageErrorType.NotFound, error: localize("mcp.setup.dockerRepositoryNotFound", "Docker image {0} not found in Docker Hub registry", args.name) };
 				}

--- a/src/extension/mcp/vscode-node/util.ts
+++ b/src/extension/mcp/vscode-node/util.ts
@@ -6,9 +6,39 @@
 import * as cp from 'child_process';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
 
+export interface ICommandExecutor {
+	executeWithTimeout(
+		command: string,
+		args: string[],
+		cwd: string,
+		timeoutMs?: number,
+		expectZeroExitCode?: boolean,
+		cancellationToken?: CancellationToken): Promise<{ stdout: string; stderr: string; exitCode: number }>;
+}
+
+export class CommandExecutor implements ICommandExecutor {
+	async executeWithTimeout(
+		command: string,
+		args: string[],
+		cwd: string,
+		timeoutMs?: number,
+		expectZeroExitCode?: boolean,
+		cancellationToken?: CancellationToken
+	): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+		return await executeWithTimeout(
+			command,
+			args,
+			cwd,
+			timeoutMs,
+			expectZeroExitCode,
+			cancellationToken
+		);
+	}
+}
+
 const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 10000;
 
-export async function executeWithTimeout(
+async function executeWithTimeout(
 	command: string,
 	args: string[],
 	cwd: string,


### PR DESCRIPTION
Address https://github.com/microsoft/vscode/issues/261524.
Uses CI + BUILD_ARTIFACTSTAGINGDIRECTORY similar to https://github.com/microsoft/vscode-copilot-chat/blob/e42aea64c5a9608c018c66aac9e6c784f3ff2517/src/util/vs/base/common/platform.ts#L82.