### PR TITLE
Add support for generic OAI endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -2812,6 +2812,11 @@
 									"type": "number",
 									"description": "Maximum number of output tokens supported by the model"
 								},
+								"requiresAPIKey": {
+									"type": "boolean",
+									"description": "Whether the model requires an API key for authentication",
+									"default": true
+								},
 								"thinking": {
 									"type": "boolean",
 									"default": false,
@@ -2824,7 +2829,8 @@
 								"toolCalling",
 								"vision",
 								"maxInputTokens",
-								"maxOutputTokens"
+								"maxOutputTokens",
+								"requiresAPIKey"
 							],
 							"additionalProperties": false
 						},

--- a/package.json
+++ b/package.json
@@ -1630,6 +1630,11 @@
 				"vendor": "openrouter",
 				"displayName": "OpenRouter",
 				"managementCommand": "github.copilot.chat.manageBYOK"
+			},
+			{
+				"vendor": "customoai",
+				"displayName": "Custom OpenAI Compatible Models",
+				"managementCommand": "github.copilot.chat.manageBYOK"
 			}
 		],
 		"interactiveSession": [
@@ -2773,6 +2778,57 @@
 							"additionalProperties": false
 						},
 						"markdownDescription": "Configure custom Azure OpenAI models. Each key should be a unique model ID, and the value should be an object with model configuration including name, url, toolCalling, vision, maxInputTokens, and maxOutputTokens properties."
+					},
+					"github.copilot.chat.customOAIModels": {
+						"type": "object",
+						"default": {},
+						"tags": [
+							"experimental"
+						],
+						"additionalProperties": {
+							"type": "object",
+							"properties": {
+								"name": {
+									"type": "string",
+									"description": "Display name of the custom OpenAI model"
+								},
+								"url": {
+									"type": "string",
+									"description": "URL endpoint for the custom OpenAI-compatible model"
+								},
+								"toolCalling": {
+									"type": "boolean",
+									"description": "Whether the model supports tool calling"
+								},
+								"vision": {
+									"type": "boolean",
+									"description": "Whether the model supports vision capabilities"
+								},
+								"maxInputTokens": {
+									"type": "number",
+									"description": "Maximum number of input tokens supported by the model"
+								},
+								"maxOutputTokens": {
+									"type": "number",
+									"description": "Maximum number of output tokens supported by the model"
+								},
+								"thinking": {
+									"type": "boolean",
+									"default": false,
+									"description": "Whether the model supports thinking capabilities"
+								}
+							},
+							"required": [
+								"name",
+								"url",
+								"toolCalling",
+								"vision",
+								"maxInputTokens",
+								"maxOutputTokens"
+							],
+							"additionalProperties": false
+						},
+						"markdownDescription": "Configure custom OpenAI-compatible models. Each key should be a unique model ID, and the value should be an object with model configuration including name, url, toolCalling, vision, maxInputTokens, and maxOutputTokens properties."
 					},
 					"github.copilot.chat.byok.responsesApi": {
 						"type": "boolean",

--- a/src/extension/byok/node/openAIEndpoint.ts
+++ b/src/extension/byok/node/openAIEndpoint.ts
@@ -12,6 +12,7 @@ import { IDomainService } from '../../../platform/endpoint/common/domainService'
 import { IChatModelInformation } from '../../../platform/endpoint/common/endpointProvider';
 import { ChatEndpoint } from '../../../platform/endpoint/node/chatEndpoint';
 import { IEnvService } from '../../../platform/env/common/envService';
+import { isOpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { IFetcherService } from '../../../platform/networking/common/fetcherService';
 import { IChatEndpoint, IEndpointBody, IMakeChatRequestOptions } from '../../../platform/networking/common/networking';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
@@ -94,6 +95,15 @@ export class OpenAIEndpoint extends ChatEndpoint {
 				return message;
 			});
 			body.messages = newMessages;
+		}
+
+		if (body?.tools) {
+			body.tools = body.tools.map(tool => {
+				if (isOpenAiFunctionTool(tool) && tool.function.parameters === undefined) {
+					tool.function.parameters = {};
+				}
+				return tool;
+			});
 		}
 
 		if (body) {

--- a/src/extension/byok/vscode-node/azureProvider.ts
+++ b/src/extension/byok/vscode-node/azureProvider.ts
@@ -3,17 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken, Event, LanguageModelChatInformation, LanguageModelChatMessage, LanguageModelChatMessage2, LanguageModelChatRequestHandleOptions, Progress, QuickPickItem, window } from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
-import { CopilotLanguageModelWrapper } from '../../conversation/vscode-node/languageModelAccess';
-import { BYOKAuthType, BYOKKnownModels, BYOKModelProvider, LMResponsePart, resolveModelInfo } from '../common/byokProvider';
-import { OpenAIEndpoint } from '../node/openAIEndpoint';
 import { IBYOKStorageService } from './byokStorageService';
-import { promptForAPIKey } from './byokUIService';
-
+import { CustomOAIBYOKModelProvider } from './customOAIProvider';
 
 export function resolveAzureUrl(modelId: string, url: string): string {
 	// The fully resolved url was already passed in
@@ -39,185 +34,32 @@ export function resolveAzureUrl(modelId: string, url: string): string {
 	}
 }
 
-interface AzureModelInfo extends LanguageModelChatInformation {
-	url: string;
-	thinking: boolean;
-}
+export class AzureBYOKModelProvider extends CustomOAIBYOKModelProvider {
+	static override readonly providerName = 'Azure';
 
-export class AzureBYOKModelProvider implements BYOKModelProvider<AzureModelInfo> {
-	private readonly _lmWrapper: CopilotLanguageModelWrapper;
-	static readonly providerName = 'Azure';
-	public readonly authType: BYOKAuthType = BYOKAuthType.PerModelDeployment;
 	constructor(
-		private readonly _byokStorageService: IBYOKStorageService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@ILogService private readonly _logService: ILogService,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IExperimentationService private readonly _experimentationService: IExperimentationService
+		byokStorageService: IBYOKStorageService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@ILogService logService: ILogService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IExperimentationService experimentationService: IExperimentationService
 	) {
-		this._lmWrapper = this._instantiationService.createInstance(CopilotLanguageModelWrapper);
+		super(
+			byokStorageService,
+			configurationService,
+			logService,
+			instantiationService,
+			experimentationService
+		);
+		// Override the instance properties
+		this.providerName = AzureBYOKModelProvider.providerName;
 	}
 
-	onDidChange?: Event<void> | undefined;
-
-	private async getAllModels(): Promise<BYOKKnownModels> {
-		const azureModelConfig = this._configurationService.getConfig(ConfigKey.AzureModels);
-		const models: BYOKKnownModels = {};
-		for (const [modelId, modelInfo] of Object.entries(azureModelConfig)) {
-			models[modelId] = {
-				name: modelInfo.name,
-				url: resolveAzureUrl(modelId, modelInfo.url),
-				toolCalling: modelInfo.toolCalling,
-				vision: modelInfo.vision,
-				maxInputTokens: modelInfo.maxInputTokens,
-				maxOutputTokens: modelInfo.maxOutputTokens,
-				thinking: modelInfo.thinking,
-			};
-		}
-		return models;
+	protected override getConfigKey() {
+		return ConfigKey.AzureModels;
 	}
 
-	private async getModelsWithAPIKeys(silent: boolean): Promise<BYOKKnownModels> {
-		const models = await this.getAllModels();
-		const modelsWithApiKeys: BYOKKnownModels = {};
-		for (const [modelId, modelInfo] of Object.entries(models)) {
-			let apiKey = await this._byokStorageService.getAPIKey(AzureBYOKModelProvider.providerName, modelId);
-			if (!silent && !apiKey) {
-				apiKey = await promptForAPIKey(`Azure - ${modelId}`, false);
-				if (apiKey) {
-					await this._byokStorageService.storeAPIKey(AzureBYOKModelProvider.providerName, apiKey, BYOKAuthType.PerModelDeployment, modelId);
-				}
-			}
-			if (apiKey) {
-				modelsWithApiKeys[modelId] = modelInfo;
-			}
-		}
-		return modelsWithApiKeys;
+	protected override resolveUrl(modelId: string, url: string): string {
+		return resolveAzureUrl(modelId, url);
 	}
-
-	async prepareLanguageModelChatInformation(options: { silent: boolean }, token: CancellationToken): Promise<AzureModelInfo[]> {
-		try {
-			const knownModels = await this.getModelsWithAPIKeys(options.silent);
-			return Object.entries(knownModels).map(([id, capabilities]) => {
-				return {
-					id,
-					url: capabilities.url || '',
-					name: capabilities.name,
-					cost: AzureBYOKModelProvider.providerName,
-					version: '1.0.0',
-					maxOutputTokens: capabilities.maxOutputTokens,
-					maxInputTokens: capabilities.maxInputTokens,
-					family: AzureBYOKModelProvider.providerName,
-					description: `${capabilities.name} is contributed via the ${AzureBYOKModelProvider.providerName} provider.`,
-					capabilities: {
-						toolCalling: capabilities.toolCalling,
-						vision: capabilities.vision
-					},
-					thinking: capabilities.thinking || false,
-				};
-			});
-		} catch {
-			return [];
-		}
-	}
-	async provideLanguageModelChatResponse(model: AzureModelInfo, messages: Array<LanguageModelChatMessage | LanguageModelChatMessage2>, options: LanguageModelChatRequestHandleOptions, progress: Progress<LMResponsePart>, token: CancellationToken): Promise<any> {
-		const apiKey = await this._byokStorageService.getAPIKey(AzureBYOKModelProvider.providerName, model.id);
-		if (!apiKey) {
-			this._logService.error(`No API key found for model ${model.id}`);
-			throw new Error(`No API key found for model ${model.id}`);
-		}
-		const modelInfo = resolveModelInfo(model.id, AzureBYOKModelProvider.providerName, undefined, {
-			maxInputTokens: model.maxInputTokens,
-			maxOutputTokens: model.maxOutputTokens,
-			toolCalling: !!model.capabilities?.toolCalling || false,
-			vision: !!model.capabilities?.vision || false,
-			name: model.name,
-			url: model.url,
-			thinking: model.thinking
-		});
-		modelInfo.capabilities.supports.statefulResponses = this._configurationService.getExperimentBasedConfig(ConfigKey.ByokResponsesApi, this._experimentationService);
-		const openAIChatEndpoint = this._instantiationService.createInstance(OpenAIEndpoint, modelInfo, apiKey, model.url);
-		return this._lmWrapper.provideLanguageModelResponse(openAIChatEndpoint, messages, options, options.extensionId, progress, token);
-	}
-	async provideTokenCount(model: AzureModelInfo, text: string | LanguageModelChatMessage | LanguageModelChatMessage2, token: CancellationToken): Promise<number> {
-		const apiKey = await this._byokStorageService.getAPIKey(AzureBYOKModelProvider.providerName, model.id);
-		if (!apiKey) {
-			this._logService.error(`No API key found for model ${model.id}`);
-			throw new Error(`No API key found for model ${model.id}`);
-		}
-		const modelInfo = resolveModelInfo(model.id, AzureBYOKModelProvider.providerName, undefined, {
-			maxInputTokens: model.maxInputTokens,
-			maxOutputTokens: model.maxOutputTokens,
-			toolCalling: !!model.capabilities?.toolCalling || false,
-			vision: !!model.capabilities?.vision || false,
-			name: model.name,
-			url: model.url,
-			thinking: model.thinking
-		});
-		const openAIChatEndpoint = this._instantiationService.createInstance(OpenAIEndpoint, modelInfo, apiKey, model.url);
-		return this._lmWrapper.provideTokenCount(openAIChatEndpoint, text);
-	}
-
-	public async updateAPIKey(): Promise<void> {
-		// Get all available models
-		const allModels = await this.getAllModels();
-
-		if (Object.keys(allModels).length === 0) {
-			await window.showInformationMessage('No Azure models are configured. Please configure models first.');
-			return;
-		}
-
-		// Create quick pick items for all models
-		interface ModelQuickPickItem extends QuickPickItem {
-			modelId: string;
-		}
-
-		const modelItems: ModelQuickPickItem[] = Object.entries(allModels).map(([modelId, modelInfo]) => ({
-			label: modelInfo.name || modelId,
-			description: modelId,
-			detail: `URL: ${modelInfo.url}`,
-			modelId: modelId
-		}));
-
-		// Show quick pick to select which model's API key to update
-		const quickPick = window.createQuickPick<ModelQuickPickItem>();
-		quickPick.title = 'Update Azure Model API Key';
-		quickPick.placeholder = 'Select a model to update its API key';
-		quickPick.items = modelItems;
-		quickPick.ignoreFocusOut = true;
-
-		const selectedModel = await new Promise<ModelQuickPickItem | undefined>((resolve) => {
-			quickPick.onDidAccept(() => {
-				const selected = quickPick.selectedItems[0];
-				quickPick.hide();
-				resolve(selected);
-			});
-
-			quickPick.onDidHide(() => {
-				resolve(undefined);
-			});
-
-			quickPick.show();
-		});
-
-		if (!selectedModel) {
-			return; // User cancelled
-		}
-
-		// Prompt for new API key
-		const newApiKey = await promptForAPIKey(`Azure - ${selectedModel.modelId}`, true);
-
-		if (newApiKey !== undefined) {
-			if (newApiKey.trim() === '') {
-				// Empty string means delete the API key
-				await this._byokStorageService.deleteAPIKey(AzureBYOKModelProvider.providerName, BYOKAuthType.PerModelDeployment, selectedModel.modelId);
-				await window.showInformationMessage(`API key for ${selectedModel.label} has been deleted.`);
-			} else {
-				// Store the new API key
-				await this._byokStorageService.storeAPIKey(AzureBYOKModelProvider.providerName, newApiKey, BYOKAuthType.PerModelDeployment, selectedModel.modelId);
-				await window.showInformationMessage(`API key for ${selectedModel.label} has been updated.`);
-			}
-		}
-	}
-
 }

--- a/src/extension/byok/vscode-node/byokContribution.ts
+++ b/src/extension/byok/vscode-node/byokContribution.ts
@@ -16,6 +16,7 @@ import { IExtensionContribution } from '../../common/contributions';
 import { AnthropicLMProvider } from './anthropicProvider';
 import { AzureBYOKModelProvider } from './azureProvider';
 import { BYOKStorageService, IBYOKStorageService } from './byokStorageService';
+import { CustomOAIBYOKModelProvider } from './customOAIProvider';
 import { GeminiBYOKLMProvider } from './geminiProvider';
 import { GroqBYOKLMProvider } from './groqProvider';
 import { OllamaLMProvider } from './ollamaProvider';
@@ -64,6 +65,7 @@ export class BYOKContrib extends Disposable implements IExtensionContribution {
 			this._providers.set(OAIBYOKLMProvider.providerName.toLowerCase(), instantiationService.createInstance(OAIBYOKLMProvider, knownModels[OAIBYOKLMProvider.providerName], this._byokStorageService));
 			this._providers.set(OpenRouterLMProvider.providerName.toLowerCase(), instantiationService.createInstance(OpenRouterLMProvider, this._byokStorageService));
 			this._providers.set(AzureBYOKModelProvider.providerName.toLowerCase(), instantiationService.createInstance(AzureBYOKModelProvider, this._byokStorageService));
+			this._providers.set(CustomOAIBYOKModelProvider.providerName.toLowerCase(), instantiationService.createInstance(CustomOAIBYOKModelProvider, this._byokStorageService));
 
 			for (const [providerName, provider] of this._providers) {
 				this._store.add(lm.registerLanguageModelChatProvider(providerName, provider));

--- a/src/extension/byok/vscode-node/customOAIProvider.ts
+++ b/src/extension/byok/vscode-node/customOAIProvider.ts
@@ -1,0 +1,232 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken, LanguageModelChatInformation, LanguageModelChatMessage, LanguageModelChatMessage2, LanguageModelChatRequestHandleOptions, Progress, QuickPickItem, window } from 'vscode';
+import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
+import { ILogService } from '../../../platform/log/common/logService';
+import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
+import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { CopilotLanguageModelWrapper } from '../../conversation/vscode-node/languageModelAccess';
+import { BYOKAuthType, BYOKKnownModels, BYOKModelProvider, LMResponsePart, resolveModelInfo } from '../common/byokProvider';
+import { OpenAIEndpoint } from '../node/openAIEndpoint';
+import { IBYOKStorageService } from './byokStorageService';
+import { promptForAPIKey } from './byokUIService';
+
+export function resolveCustomOAIUrl(modelId: string, url: string): string {
+	// The fully resolved url was already passed in
+	if (url.includes('/chat/completions')) {
+		return url;
+	}
+
+	// Remove the trailing slash
+	if (url.endsWith('/')) {
+		url = url.slice(0, -1);
+	}
+	// if url ends with `/v1` remove it
+	if (url.endsWith('/v1')) {
+		url = url.slice(0, -3);
+	}
+
+	// For standard OpenAI-compatible endpoints, just append the standard path
+	return `${url}/v1/chat/completions`;
+}
+
+interface CustomOAIModelInfo extends LanguageModelChatInformation {
+	url: string;
+	thinking: boolean;
+}
+
+export class CustomOAIBYOKModelProvider implements BYOKModelProvider<CustomOAIModelInfo> {
+	protected readonly _lmWrapper: CopilotLanguageModelWrapper;
+	public readonly authType: BYOKAuthType = BYOKAuthType.PerModelDeployment;
+
+	static readonly providerName: string = 'CustomOAI';
+	protected providerName: string = CustomOAIBYOKModelProvider.providerName;
+
+	constructor(
+		private readonly _byokStorageService: IBYOKStorageService,
+		@IConfigurationService protected readonly _configurationService: IConfigurationService,
+		@ILogService protected readonly _logService: ILogService,
+		@IInstantiationService protected readonly _instantiationService: IInstantiationService,
+		@IExperimentationService protected readonly _experimentationService: IExperimentationService
+	) {
+		this._lmWrapper = this._instantiationService.createInstance(CopilotLanguageModelWrapper);
+	}
+
+	protected getConfigKey() {
+		return ConfigKey.CustomOAIModels;
+	}
+
+	protected resolveUrl(modelId: string, url: string): string {
+		return resolveCustomOAIUrl(modelId, url);
+	}
+
+	private async getAllModels(): Promise<BYOKKnownModels> {
+		const modelConfig = this._configurationService.getConfig(this.getConfigKey()) as Record<string, { name: string; url: string; toolCalling: boolean; vision: boolean; maxInputTokens: number; maxOutputTokens: number; thinking?: boolean }>;
+		const models: BYOKKnownModels = {};
+		for (const [modelId, modelInfo] of Object.entries(modelConfig)) {
+			models[modelId] = {
+				name: modelInfo.name,
+				url: this.resolveUrl(modelId, modelInfo.url),
+				toolCalling: modelInfo.toolCalling,
+				vision: modelInfo.vision,
+				maxInputTokens: modelInfo.maxInputTokens,
+				maxOutputTokens: modelInfo.maxOutputTokens,
+				thinking: modelInfo.thinking,
+			};
+		}
+		return models;
+	}
+
+	private async getModelsWithAPIKeys(silent: boolean): Promise<BYOKKnownModels> {
+		const models = await this.getAllModels();
+		const modelsWithApiKeys: BYOKKnownModels = {};
+		for (const [modelId, modelInfo] of Object.entries(models)) {
+			let apiKey = await this._byokStorageService.getAPIKey(this.providerName, modelId);
+			if (!silent && !apiKey) {
+				apiKey = await promptForAPIKey(`${this.providerName} - ${modelId}`, false);
+				if (apiKey) {
+					await this._byokStorageService.storeAPIKey(this.providerName, apiKey, BYOKAuthType.PerModelDeployment, modelId);
+				}
+			}
+			if (apiKey) {
+				modelsWithApiKeys[modelId] = modelInfo;
+			}
+		}
+		return modelsWithApiKeys;
+	}
+
+	private createModelInfo(id: string, capabilities: BYOKKnownModels[string]): CustomOAIModelInfo {
+		const baseInfo: CustomOAIModelInfo = {
+			id,
+			url: capabilities.url || '',
+			name: capabilities.name,
+			detail: this.providerName,
+			version: '1.0.0',
+			maxOutputTokens: capabilities.maxOutputTokens,
+			maxInputTokens: capabilities.maxInputTokens,
+			family: this.providerName,
+			tooltip: `${capabilities.name} is contributed via the ${this.providerName} provider.`,
+			capabilities: {
+				toolCalling: capabilities.toolCalling,
+				vision: capabilities.vision
+			},
+			thinking: capabilities.thinking || false,
+		};
+		return baseInfo;
+	}
+
+	async prepareLanguageModelChatInformation(options: { silent: boolean }, token: CancellationToken): Promise<CustomOAIModelInfo[]> {
+		try {
+			const knownModels = await this.getModelsWithAPIKeys(options.silent);
+			return Object.entries(knownModels).map(([id, capabilities]) => {
+				return this.createModelInfo(id, capabilities);
+			});
+		} catch {
+			return [];
+		}
+	}
+
+	async provideLanguageModelChatResponse(model: CustomOAIModelInfo, messages: Array<LanguageModelChatMessage | LanguageModelChatMessage2>, options: LanguageModelChatRequestHandleOptions, progress: Progress<LMResponsePart>, token: CancellationToken): Promise<any> {
+		const apiKey = await this._byokStorageService.getAPIKey(this.providerName, model.id);
+		if (!apiKey) {
+			this._logService.error(`No API key found for model ${model.id}`);
+			throw new Error(`No API key found for model ${model.id}`);
+		}
+		const modelInfo = resolveModelInfo(model.id, this.providerName, undefined, {
+			maxInputTokens: model.maxInputTokens,
+			maxOutputTokens: model.maxOutputTokens,
+			toolCalling: !!model.capabilities?.toolCalling || false,
+			vision: !!model.capabilities?.vision || false,
+			name: model.name,
+			url: model.url,
+			thinking: model.thinking
+		});
+		modelInfo.capabilities.supports.statefulResponses = this._configurationService.getExperimentBasedConfig(ConfigKey.ByokResponsesApi, this._experimentationService);
+		const openAIChatEndpoint = this._instantiationService.createInstance(OpenAIEndpoint, modelInfo, apiKey, model.url);
+		return this._lmWrapper.provideLanguageModelResponse(openAIChatEndpoint, messages, options, options.extensionId, progress, token);
+	}
+
+	async provideTokenCount(model: CustomOAIModelInfo, text: string | LanguageModelChatMessage | LanguageModelChatMessage2, token: CancellationToken): Promise<number> {
+		const apiKey = await this._byokStorageService.getAPIKey(this.providerName, model.id);
+		if (!apiKey) {
+			this._logService.error(`No API key found for model ${model.id}`);
+			throw new Error(`No API key found for model ${model.id}`);
+		}
+		const modelInfo = resolveModelInfo(model.id, this.providerName, undefined, {
+			maxInputTokens: model.maxInputTokens,
+			maxOutputTokens: model.maxOutputTokens,
+			toolCalling: !!model.capabilities?.toolCalling || false,
+			vision: !!model.capabilities?.vision || false,
+			name: model.name,
+			url: model.url,
+			thinking: model.thinking
+		});
+		const openAIChatEndpoint = this._instantiationService.createInstance(OpenAIEndpoint, modelInfo, apiKey, model.url);
+		return this._lmWrapper.provideTokenCount(openAIChatEndpoint, text);
+	}
+
+	public async updateAPIKey(): Promise<void> {
+		// Get all available models
+		const allModels = await this.getAllModels();
+
+		if (Object.keys(allModels).length === 0) {
+			await window.showInformationMessage(`No ${this.providerName} models are configured. Please configure models first.`);
+			return;
+		}
+
+		// Create quick pick items for all models
+		interface ModelQuickPickItem extends QuickPickItem {
+			modelId: string;
+		}
+
+		const modelItems: ModelQuickPickItem[] = Object.entries(allModels).map(([modelId, modelInfo]) => ({
+			label: modelInfo.name || modelId,
+			description: modelId,
+			detail: `URL: ${modelInfo.url}`,
+			modelId: modelId
+		}));
+
+		// Show quick pick to select which model's API key to update
+		const quickPick = window.createQuickPick<ModelQuickPickItem>();
+		quickPick.title = `Update ${this.providerName} Model API Key`;
+		quickPick.placeholder = 'Select a model to update its API key';
+		quickPick.items = modelItems;
+		quickPick.ignoreFocusOut = true;
+
+		const selectedModel = await new Promise<ModelQuickPickItem | undefined>((resolve) => {
+			quickPick.onDidAccept(() => {
+				const selected = quickPick.selectedItems[0];
+				quickPick.hide();
+				resolve(selected);
+			});
+
+			quickPick.onDidHide(() => {
+				resolve(undefined);
+			});
+
+			quickPick.show();
+		});
+
+		if (!selectedModel) {
+			return; // User cancelled
+		}
+
+		// Prompt for new API key
+		const newApiKey = await promptForAPIKey(`${this.providerName} - ${selectedModel.modelId}`, true);
+
+		if (newApiKey !== undefined) {
+			if (newApiKey.trim() === '') {
+				// Empty string means delete the API key
+				await this._byokStorageService.deleteAPIKey(this.providerName, BYOKAuthType.PerModelDeployment, selectedModel.modelId);
+				await window.showInformationMessage(`API key for ${selectedModel.label} has been deleted.`);
+			} else {
+				// Store the new API key
+				await this._byokStorageService.storeAPIKey(this.providerName, newApiKey, BYOKAuthType.PerModelDeployment, selectedModel.modelId);
+				await window.showInformationMessage(`API key for ${selectedModel.label} has been updated.`);
+			}
+		}
+	}
+}

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -753,8 +753,8 @@ export namespace ConfigKey {
 	export const CurrentEditorAgentContext = defineSetting<boolean>('chat.agent.currentEditorContext.enabled', true);
 	/** BYOK  */
 	export const OllamaEndpoint = defineSetting<string>('chat.byok.ollamaEndpoint', 'http://localhost:11434');
-	export const AzureModels = defineSetting<Record<string, { name: string; url: string; toolCalling: boolean; vision: boolean; maxInputTokens: number; maxOutputTokens: number; thinking?: boolean }>>('chat.azureModels', {});
-	export const CustomOAIModels = defineSetting<Record<string, { name: string; url: string; toolCalling: boolean; vision: boolean; maxInputTokens: number; maxOutputTokens: number; requiresAPIKey: boolean; thinking?: boolean }>>('chat.customOAIModels', {});
+	export const AzureModels = defineSetting<Record<string, { name: string; url: string; toolCalling: boolean; vision: boolean; maxInputTokens: number; maxOutputTokens: number; requiresAPIKey?: boolean; thinking?: boolean }>>('chat.azureModels', {});
+	export const CustomOAIModels = defineSetting<Record<string, { name: string; url: string; toolCalling: boolean; vision: boolean; maxInputTokens: number; maxOutputTokens: number; requiresAPIKey?: boolean; thinking?: boolean }>>('chat.customOAIModels', {});
 	export const EditsCodeNewNotebookAgentEnabled = defineExpSetting<boolean>('chat.edits.newNotebook.enabled', true);
 	export const AutoFixDiagnostics = defineSetting<boolean>('chat.agent.autoFix', true);
 	export const NotebookFollowCellExecution = defineSetting<boolean>('chat.notebook.followCellExecution.enabled', false);

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -754,6 +754,7 @@ export namespace ConfigKey {
 	/** BYOK  */
 	export const OllamaEndpoint = defineSetting<string>('chat.byok.ollamaEndpoint', 'http://localhost:11434');
 	export const AzureModels = defineSetting<Record<string, { name: string; url: string; toolCalling: boolean; vision: boolean; maxInputTokens: number; maxOutputTokens: number; thinking?: boolean }>>('chat.azureModels', {});
+	export const CustomOAIModels = defineSetting<Record<string, { name: string; url: string; toolCalling: boolean; vision: boolean; maxInputTokens: number; maxOutputTokens: number; thinking?: boolean }>>('chat.customOAIModels', {});
 	export const EditsCodeNewNotebookAgentEnabled = defineExpSetting<boolean>('chat.edits.newNotebook.enabled', true);
 	export const AutoFixDiagnostics = defineSetting<boolean>('chat.agent.autoFix', true);
 	export const NotebookFollowCellExecution = defineSetting<boolean>('chat.notebook.followCellExecution.enabled', false);

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -754,7 +754,7 @@ export namespace ConfigKey {
 	/** BYOK  */
 	export const OllamaEndpoint = defineSetting<string>('chat.byok.ollamaEndpoint', 'http://localhost:11434');
 	export const AzureModels = defineSetting<Record<string, { name: string; url: string; toolCalling: boolean; vision: boolean; maxInputTokens: number; maxOutputTokens: number; thinking?: boolean }>>('chat.azureModels', {});
-	export const CustomOAIModels = defineSetting<Record<string, { name: string; url: string; toolCalling: boolean; vision: boolean; maxInputTokens: number; maxOutputTokens: number; thinking?: boolean }>>('chat.customOAIModels', {});
+	export const CustomOAIModels = defineSetting<Record<string, { name: string; url: string; toolCalling: boolean; vision: boolean; maxInputTokens: number; maxOutputTokens: number; requiresAPIKey: boolean; thinking?: boolean }>>('chat.customOAIModels', {});
 	export const EditsCodeNewNotebookAgentEnabled = defineExpSetting<boolean>('chat.edits.newNotebook.enabled', true);
 	export const AutoFixDiagnostics = defineSetting<boolean>('chat.agent.autoFix', true);
 	export const NotebookFollowCellExecution = defineSetting<boolean>('chat.notebook.followCellExecution.enabled', false);


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode-copilot-release/issues/7518

Here's an example config

```
  "github.copilot.chat.customOAIModels": {
    "gpt-4.1": {
      "name": "GPT-4.1 Custom",
      "maxInputTokens": 64768,
      "maxOutputTokens": 16192,
      "toolCalling": true,
      "url": "https://api.openai.com/v1/chat/completions",
      "vision": true,
      "requiresAPIKey": true
    },
    "openai/gpt-oss-20b": {
      "name": "GPT-OSS-20B",
      "maxInputTokens": 32768,
      "maxOutputTokens": 8192,
      "toolCalling": false,
      "url": "http://127.0.0.1:1234/v1/chat/completions",
      "vision": false,
      "requiresAPIKey": false
    }
  }
```