### PR TITLE
edits: remove gemini from multi edit tool models

### DIFF
--- a/src/extension/intents/node/agentIntent.ts
+++ b/src/extension/intents/node/agentIntent.ts
@@ -10,7 +10,7 @@ import { BudgetExceededError } from '@vscode/prompt-tsx/dist/base/materialized';
 import type * as vscode from 'vscode';
 import { ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
-import { modelCanUseReplaceStringExclusively, modelSupportsApplyPatch, modelSupportsReplaceString } from '../../../platform/endpoint/common/chatModelCapabilities';
+import { modelCanUseReplaceStringExclusively, modelSupportsApplyPatch, modelSupportsMultiReplaceString, modelSupportsReplaceString } from '../../../platform/endpoint/common/chatModelCapabilities';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { IEnvService } from '../../../platform/env/common/envService';
 import { ILogService } from '../../../platform/log/common/logService';
@@ -70,7 +70,7 @@ const getTools = (instaService: IInstantiationService, request: vscode.ChatReque
 		}
 
 		if (allowTools[ToolName.ReplaceString]) {
-			if (configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceString, experimentationService)) {
+			if (modelSupportsMultiReplaceString(model) && configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceString, experimentationService)) {
 				allowTools[ToolName.MultiReplaceString] = true;
 			}
 		}

--- a/src/extension/intents/node/editCodeIntent2.ts
+++ b/src/extension/intents/node/editCodeIntent2.ts
@@ -6,7 +6,7 @@
 import type * as vscode from 'vscode';
 import { ChatLocation } from '../../../platform/chat/common/commonTypes';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
-import { modelSupportsReplaceString } from '../../../platform/endpoint/common/chatModelCapabilities';
+import { modelSupportsMultiReplaceString, modelSupportsReplaceString } from '../../../platform/endpoint/common/chatModelCapabilities';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { IEnvService } from '../../../platform/env/common/envService';
 import { ILogService } from '../../../platform/log/common/logService';
@@ -50,7 +50,7 @@ const getTools = (instaService: IInstantiationService, request: vscode.ChatReque
 
 		if (modelSupportsReplaceString(model)) {
 			lookForTools.add(ToolName.ReplaceString);
-			if (configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceString, experimentationService)) {
+			if (modelSupportsMultiReplaceString(model) && configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceString, experimentationService)) {
 				lookForTools.add(ToolName.MultiReplaceString);
 			}
 		}

--- a/src/extension/intents/node/notebookEditorIntent.ts
+++ b/src/extension/intents/node/notebookEditorIntent.ts
@@ -33,7 +33,7 @@ import { IToolsService } from '../../tools/common/toolsService';
 import { EditCodeIntent, EditCodeIntentOptions } from './editCodeIntent';
 import { EditCode2IntentInvocation } from './editCodeIntent2';
 import { getRequestedToolCallIterationLimit } from './toolCallingLoop';
-import { modelSupportsReplaceString } from '../../../platform/endpoint/common/chatModelCapabilities';
+import { modelSupportsMultiReplaceString, modelSupportsReplaceString } from '../../../platform/endpoint/common/chatModelCapabilities';
 
 const getTools = (instaService: IInstantiationService, request: vscode.ChatRequest): Promise<vscode.LanguageModelToolInformation[]> =>
 	instaService.invokeFunction(async accessor => {
@@ -52,7 +52,7 @@ const getTools = (instaService: IInstantiationService, request: vscode.ChatReque
 
 		if (modelSupportsReplaceString(model)) {
 			lookForTools.add(ToolName.ReplaceString);
-			if (configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceString, experimentationService)) {
+			if (modelSupportsMultiReplaceString(model) && configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceString, experimentationService)) {
 				lookForTools.add(ToolName.MultiReplaceString);
 			}
 		}

--- a/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -57,6 +57,13 @@ export function modelSupportsReplaceString(model: LanguageModelChat | IChatEndpo
 }
 
 /**
+ * Model supports multi_replace_string_in_file as an edit tool.
+ */
+export function modelSupportsMultiReplaceString(model: LanguageModelChat | IChatEndpoint): boolean {
+	return modelSupportsReplaceString(model) && !model.family.includes('gemini');
+}
+
+/**
  * The model is capable of using replace_string_in_file exclusively,
  * without needing insert_edit_into_file.
  */


### PR DESCRIPTION
This reduces accuracy on Gemini and we're still root causing it. Remove it for now.