### PR TITLE
edits: implement file edit guards using standard confirmations

### DIFF
--- a/src/extension/tools/node/applyPatchTool.tsx
+++ b/src/extension/tools/node/applyPatchTool.tsx
@@ -43,10 +43,11 @@ import { ToolName } from '../common/toolNames';
 import { ICopilotTool, ToolRegistry } from '../common/toolsRegistry';
 import { IToolsService } from '../common/toolsService';
 import { PATCH_PREFIX, PATCH_SUFFIX } from './applyPatch/parseApplyPatch';
-import { ActionType, Commit, DiffError, FileChange, InvalidContextError, InvalidPatchFormatError, processPatch } from './applyPatch/parser';
+import { ActionType, Commit, DiffError, FileChange, identify_files_needed, InvalidContextError, InvalidPatchFormatError, processPatch } from './applyPatch/parser';
 import { EditFileResult, IEditedFile } from './editFileToolResult';
 import { sendEditNotebookTelemetry } from './editNotebookTool';
 import { assertFileOkForTool, resolveToolInputPath } from './toolUtils';
+import { createEditConfirmation } from './editFileToolUtils';
 
 export const applyPatchWithNotebookSupportDescription: vscode.LanguageModelToolInformation = {
 	name: ToolName.ApplyPatch,
@@ -575,9 +576,11 @@ export class ApplyPatchTool implements ICopilotTool<IApplyPatchToolParams> {
 	}
 
 	prepareInvocation(options: vscode.LanguageModelToolInvocationPrepareOptions<IApplyPatchToolParams>, token: vscode.CancellationToken): vscode.ProviderResult<vscode.PreparedToolInvocation> {
-		return {
-			presentation: 'hidden'
-		};
+		return this.instantiationService.invokeFunction(
+			createEditConfirmation,
+			identify_files_needed(options.input.input).map(f => URI.file(f)),
+			() => '```\n' + options.input.input + '\n```',
+		);
 	}
 }
 

--- a/src/extension/tools/node/createFileTool.tsx
+++ b/src/extension/tools/node/createFileTool.tsx
@@ -29,6 +29,7 @@ import { ICopilotTool, ToolRegistry } from '../common/toolsRegistry';
 import { IToolsService } from '../common/toolsService';
 import { ActionType } from './applyPatch/parser';
 import { EditFileResult } from './editFileToolResult';
+import { createEditConfirmation } from './editFileToolUtils';
 import { sendEditNotebookTelemetry } from './editNotebookTool';
 import { assertFileOkForTool, formatUriForFileWidget, resolveToolInputPath } from './toolUtils';
 
@@ -148,7 +149,13 @@ export class CreateFileTool implements ICopilotTool<ICreateFileParams> {
 
 	prepareInvocation(options: vscode.LanguageModelToolInvocationPrepareOptions<ICreateFileParams>, token: vscode.CancellationToken): vscode.ProviderResult<vscode.PreparedToolInvocation> {
 		const uri = resolveToolInputPath(options.input.filePath, this.promptPathRepresentationService);
+
 		return {
+			...this.instantiationService.invokeFunction(
+				createEditConfirmation,
+				[uri],
+				() => 'Contents:\n\n```\n' + options.input.content || '<empty>' + '\n```',
+			),
 			invocationMessage: new MarkdownString(l10n.t`Creating ${formatUriForFileWidget(uri)}`),
 			pastTenseMessage: new MarkdownString(l10n.t`Created ${formatUriForFileWidget(uri)}`)
 		};

--- a/src/extension/tools/node/multiReplaceStringTool.tsx
+++ b/src/extension/tools/node/multiReplaceStringTool.tsx
@@ -11,6 +11,7 @@ import { ToolName } from '../common/toolNames';
 import { ToolRegistry } from '../common/toolsRegistry';
 import { AbstractReplaceStringTool } from './abstractReplaceStringTool';
 import { IReplaceStringToolParams } from './replaceStringTool';
+import { resolveToolInputPath } from './toolUtils';
 
 export interface IMultiReplaceStringToolParams {
 	explanation: string;
@@ -19,6 +20,10 @@ export interface IMultiReplaceStringToolParams {
 
 export class MultiReplaceStringTool extends AbstractReplaceStringTool<IMultiReplaceStringToolParams> {
 	public static toolName = ToolName.MultiReplaceString;
+
+	protected override urisForInput(input: IMultiReplaceStringToolParams): readonly URI[] {
+		return input.replacements.map(r => resolveToolInputPath(r.filePath, this.promptPathRepresentationService));
+	}
 
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<IMultiReplaceStringToolParams>, token: vscode.CancellationToken) {
 		if (!options.input.replacements || !Array.isArray(options.input.replacements)) {

--- a/src/extension/tools/node/replaceStringTool.tsx
+++ b/src/extension/tools/node/replaceStringTool.tsx
@@ -4,9 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as vscode from 'vscode';
+import { URI } from '../../../util/vs/base/common/uri';
 import { ToolName } from '../common/toolNames';
 import { ToolRegistry } from '../common/toolsRegistry';
 import { AbstractReplaceStringTool } from './abstractReplaceStringTool';
+import { resolveToolInputPath } from './toolUtils';
 
 export interface IReplaceStringToolParams {
 	explanation: string;
@@ -17,6 +19,10 @@ export interface IReplaceStringToolParams {
 
 export class ReplaceStringTool extends AbstractReplaceStringTool<IReplaceStringToolParams> {
 	public static toolName = ToolName.ReplaceString;
+
+	protected override urisForInput(input: IReplaceStringToolParams): readonly URI[] {
+		return [resolveToolInputPath(input.filePath, this.promptPathRepresentationService)];
+	}
 
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<IReplaceStringToolParams>, token: vscode.CancellationToken) {
 		const prepared = await this.prepareEditsForFile(options, options.input, token);


### PR DESCRIPTION
After talking to Kai, we decided that the rare case of sensitive files edits should just use our standard confirmation UI instead of adding more variances to the base chat experience.