### PR TITLE
Fix OAI BYOK endpoint tool calling

### DIFF
--- a/src/extension/byok/node/openAIEndpoint.ts
+++ b/src/extension/byok/node/openAIEndpoint.ts
@@ -7,6 +7,7 @@ import type { CancellationToken } from 'vscode';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
 import { IChatMLFetcher } from '../../../platform/chat/common/chatMLFetcher';
 import { ChatFetchResponseType, ChatResponse } from '../../../platform/chat/common/commonTypes';
+import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { ICAPIClientService } from '../../../platform/endpoint/common/capiClient';
 import { IDomainService } from '../../../platform/endpoint/common/domainService';
 import { IChatModelInformation } from '../../../platform/endpoint/common/endpointProvider';
@@ -15,12 +16,11 @@ import { IEnvService } from '../../../platform/env/common/envService';
 import { isOpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { IFetcherService } from '../../../platform/networking/common/fetcherService';
 import { IChatEndpoint, IEndpointBody, IMakeChatRequestOptions } from '../../../platform/networking/common/networking';
+import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
 import { IThinkingDataService } from '../../../platform/thinking/node/thinkingDataService';
 import { ITokenizerProvider } from '../../../platform/tokenizer/node/tokenizer';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
-import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
-import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 
 function hydrateBYOKErrorMessages(response: ChatResponse): ChatResponse {
 	if (response.type === ChatFetchResponseType.Failed && response.streamError) {
@@ -106,7 +106,7 @@ export class OpenAIEndpoint extends ChatEndpoint {
 		if (body?.tools) {
 			body.tools = body.tools.map(tool => {
 				if (isOpenAiFunctionTool(tool) && tool.function.parameters === undefined) {
-					tool.function.parameters = {};
+					tool.function.parameters = { type: "object", properties: {} };
 				}
 				return tool;
 			});


### PR DESCRIPTION
It appears that every OAI provider does tool calling for empty params a bit differently.
1. Grok appears to require a minimum of `{}` instead of undefined
2. LM Studio seems to require either `undefined` or the full `{ type: "object", properties: {} }`. But passing undefined isn't an option because then Grok fails.

I know OpenRouter also had to recently fix a bug on their end for similar oddities with translation of tool calls. OAI seems to allow undefined and even document undefined, but discussion posts mention previously they required this verbosity which is why some providers might not handle undefined well.

Should we be doing this everywhere or just in BYOK cc @roblourens and @connor4312