### PR TITLE
Fix bad ordering of thinking and tool prep chat response parts

### DIFF
--- a/src/extension/linkify/common/responseStreamWithLinkification.ts
+++ b/src/extension/linkify/common/responseStreamWithLinkification.ts
@@ -6,7 +6,7 @@ import type { ChatResponseClearToPreviousToolInvocationReason, ChatResponseFileT
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
 import { FinalizableChatResponseStream } from '../../../util/common/chatResponseStreamImpl';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
-import { ChatResponseAnchorPart, ChatResponseCommandButtonPart, ChatResponseConfirmationPart, ChatResponseFileTreePart, ChatResponseMarkdownPart, MarkdownString } from '../../../vscodeTypes';
+import { ChatPrepareToolInvocationPart, ChatResponseAnchorPart, ChatResponseCommandButtonPart, ChatResponseConfirmationPart, ChatResponseFileTreePart, ChatResponseMarkdownPart, ChatResponseThinkingProgressPart, MarkdownString } from '../../../vscodeTypes';
 import { LinkifiedText, LinkifySymbolAnchor } from './linkifiedText';
 import { IContributedLinkifierFactory, ILinkifier, ILinkifyService, LinkifierContext } from './linkifyService';
 
@@ -105,7 +105,9 @@ export class ResponseStreamWithLinkification implements FinalizableChatResponseS
 	private isBlockPart(part: ChatResponsePart): boolean {
 		return part instanceof ChatResponseFileTreePart
 			|| part instanceof ChatResponseCommandButtonPart
-			|| part instanceof ChatResponseConfirmationPart;
+			|| part instanceof ChatResponseConfirmationPart
+			|| part instanceof ChatPrepareToolInvocationPart
+			|| part instanceof ChatResponseThinkingProgressPart;
 	}
 
 	textEdit(target: Uri, editsOrDone: TextEdit | TextEdit[] | true): ChatResponseStream {


### PR DESCRIPTION
Fixes an issue causing the chat to be rendered like this due to a response part being sent out of order before the last markdown part.

<img width="1088" height="264" alt="image" src="https://github.com/user-attachments/assets/f9cdb90e-a796-4e1b-a4fb-1c6d67abe012" />

I don't really understand the `isBlockPart`, why don't we flush before every non-md part? Do you know @mjbvz? 