### PR TITLE
read notebook output should only be in one toolset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1078,7 +1078,6 @@
 					"fileSearch",
 					"textSearch",
 					"listDirectory",
-					"readNotebookCellOutput",
 					"readFile"
 				]
 			},


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/262577
fix https://github.com/microsoft/vscode/issues/258779