### PR TITLE
Support per language language context provider enablement

### DIFF
--- a/src/extension/xtab/common/promptCrafting.ts
+++ b/src/extension/xtab/common/promptCrafting.ts
@@ -9,7 +9,7 @@ import { LanguageContextResponse } from '../../../platform/inlineEdits/common/da
 import { CurrentFileOptions, DiffHistoryOptions, PromptingStrategy, PromptOptions } from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { StatelessNextEditRequest } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { IXtabHistoryEditEntry, IXtabHistoryEntry } from '../../../platform/inlineEdits/common/workspaceEditTracker/nesXtabHistoryTracker';
-import { ContextKind } from '../../../platform/languageServer/common/languageContextService';
+import { ContextKind, TraitContext } from '../../../platform/languageServer/common/languageContextService';
 import { range } from '../../../util/vs/base/common/arrays';
 import { illegalArgument } from '../../../util/vs/base/common/errors';
 import { Schemas } from '../../../util/vs/base/common/network';
@@ -141,6 +141,8 @@ export function getUserPrompt(request: StatelessNextEditRequest, currentFileCont
 
 	const editDiffHistory = getEditDiffHistory(request, docsInPrompt, computeTokens, opts.diffHistory);
 
+	const relatedInformation = getRelatedInformation(langCtx);
+
 	const currentFilePath = toUniquePath(activeDoc.id, activeDoc.workspaceRoot?.path);
 
 	const postScript = getPostScript(opts.promptingStrategy, currentFilePath);
@@ -162,7 +164,7 @@ ${areaAroundCodeToEdit}`;
 
 	const includeBackticks = opts.promptingStrategy !== PromptingStrategy.Nes41Miniv3 && opts.promptingStrategy !== PromptingStrategy.Codexv21NesUnified;
 
-	const prompt = (includeBackticks ? wrapInBackticks(mainPrompt) : mainPrompt) + postScript;
+	const prompt = relatedInformation + (includeBackticks ? wrapInBackticks(mainPrompt) : mainPrompt) + postScript;
 
 	const trimmedPrompt = prompt.trim();
 
@@ -201,6 +203,28 @@ they would have made next. Provide the revised code that was between the \`${COD
 
 	const formattedPostScript = postScript === undefined ? '' : `\n\n${postScript}`;
 	return formattedPostScript;
+}
+
+function getRelatedInformation(langCtx: LanguageContextResponse | undefined): string {
+	if (langCtx === undefined) {
+		return '';
+	}
+
+	const traits = langCtx.items
+		.filter(ctx => ctx.context.kind === ContextKind.Trait)
+		.filter(t => !t.onTimeout)
+		.map(t => t.context) as TraitContext[];
+
+	if (traits.length === 0) {
+		return '';
+	}
+
+	const relatedInformation: string[] = [];
+	for (const trait of traits) {
+		relatedInformation.push(`${trait.name}: ${trait.value}`);
+	}
+
+	return `Consider this related information:\n${relatedInformation.join('\n')}\n\n`;
 }
 
 function getEditDiffHistory(

--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -13,7 +13,9 @@ import { createProxyXtabEndpoint } from '../../../platform/endpoint/node/proxyXt
 import { IIgnoreService } from '../../../platform/ignore/common/ignoreService';
 import { Copilot } from '../../../platform/inlineCompletions/common/api';
 import { LanguageContextEntry, LanguageContextResponse } from '../../../platform/inlineEdits/common/dataTypes/languageContext';
+import { LanguageId } from '../../../platform/inlineEdits/common/dataTypes/languageId';
 import * as xtabPromptOptions from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
+import { LanguageContextLanguages, LanguageContextOptions } from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { InlineEditRequestLogContext } from '../../../platform/inlineEdits/common/inlineEditLogContext';
 import { ResponseProcessor } from '../../../platform/inlineEdits/common/responseProcessor';
 import { NoNextEditReason, PushEdit, ShowNextEditPreference, StatelessNextEditDocument, StatelessNextEditRequest, StatelessNextEditResult, StatelessNextEditTelemetryBuilder } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
@@ -241,10 +243,11 @@ export class XtabProvider extends ChainedStatelessNextEditProvider {
 					maxTokens: this.configService.getExperimentBasedConfig(ConfigKey.Internal.InlineEditsXtabRecentlyViewedDocumentsMaxTokens, this.expService),
 					includeViewedFiles: this.configService.getExperimentBasedConfig(ConfigKey.Internal.InlineEditsXtabIncludeViewedFiles, this.expService),
 				},
-				languageContext: {
+				languageContext: this.determineLanguageContextOptions(activeDocument.languageId, {
 					enabled: this.configService.getExperimentBasedConfig(ConfigKey.Internal.InlineEditsXtabLanguageContextEnabled, this.expService),
+					enabledLanguages: this.configService.getConfig(ConfigKey.Internal.InlineEditsXtabLanguageContextEnabledLanguages),
 					maxTokens: this.configService.getExperimentBasedConfig(ConfigKey.Internal.InlineEditsXtabLanguageContextMaxTokens, this.expService),
-				},
+				}),
 				diffHistory: {
 					nEntries: this.configService.getExperimentBasedConfig(ConfigKey.Internal.InlineEditsXtabDiffNEntries, this.expService),
 					maxTokens: this.configService.getExperimentBasedConfig(ConfigKey.Internal.InlineEditsXtabDiffMaxTokens, this.expService),
@@ -846,6 +849,15 @@ export class XtabProvider extends ChainedStatelessNextEditProvider {
 			default:
 				return systemPromptTemplate;
 		}
+	}
+
+	private determineLanguageContextOptions(languageId: LanguageId, { enabled, enabledLanguages, maxTokens }: { enabled: boolean; enabledLanguages: LanguageContextLanguages; maxTokens: number }): LanguageContextOptions {
+		// Some languages are
+		if (languageId in enabledLanguages) {
+			return { enabled: enabledLanguages[languageId], maxTokens };
+		}
+
+		return { enabled, maxTokens };
 	}
 
 	private getEndpoint() {

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -15,6 +15,7 @@ import * as types from '../../../util/vs/base/common/types';
 import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStore';
 import { isPreRelease, packageJson } from '../../env/common/packagejson';
 import * as xtabPromptOptions from '../../inlineEdits/common/dataTypes/xtabPromptOptions';
+import { LANGUAGE_CONTEXT_ENABLED_LANGUAGES, LanguageContextLanguages } from '../../inlineEdits/common/dataTypes/xtabPromptOptions';
 import { ResponseProcessor } from '../../inlineEdits/common/responseProcessor';
 import { AlternativeNotebookFormat } from '../../notebook/common/alternativeContentFormat';
 import { IExperimentationService } from '../../telemetry/common/nullExperimentationService';
@@ -661,6 +662,7 @@ export namespace ConfigKey {
 		export const InlineEditsXtabNNonSignificantLinesToConverge = defineExpSetting<number>('chat.advanced.inlineEdits.xtabProvider.nNonSignificantLinesToConverge', ResponseProcessor.DEFAULT_DIFF_PARAMS.nLinesToConverge, INTERNAL_RESTRICTED);
 		export const InlineEditsXtabNSignificantLinesToConverge = defineExpSetting<number>('chat.advanced.inlineEdits.xtabProvider.nSignificantLinesToConverge', ResponseProcessor.DEFAULT_DIFF_PARAMS.nSignificantLinesToConverge, INTERNAL_RESTRICTED);
 		export const InlineEditsXtabLanguageContextEnabled = defineExpSetting<boolean>('chat.advanced.inlineEdits.xtabProvider.languageContext.enabled', xtabPromptOptions.DEFAULT_OPTIONS.languageContext.enabled, INTERNAL_RESTRICTED);
+		export const InlineEditsXtabLanguageContextEnabledLanguages = defineSetting<LanguageContextLanguages>('chat.advanced.inlineEdits.xtabProvider.languageContext.enabledLanguages', LANGUAGE_CONTEXT_ENABLED_LANGUAGES, INTERNAL_RESTRICTED);
 		export const InlineEditsXtabLanguageContextMaxTokens = defineExpSetting<number>('chat.advanced.inlineEdits.xtabProvider.languageContext.maxTokens', xtabPromptOptions.DEFAULT_OPTIONS.languageContext.maxTokens, INTERNAL_RESTRICTED);
 		export const InlineEditsXtabUseUnifiedModel = defineExpSetting<boolean>('chat.advanced.inlineEdits.xtabProvider.useUnifiedModel', false, INTERNAL_RESTRICTED);
 		export const InlineEditsXtabProviderUseSimplifiedPrompt = defineExpSetting<boolean>('chat.advanced.inlineEdits.xtabProvider.simplifiedPrompt', false, INTERNAL_RESTRICTED);

--- a/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
+++ b/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
@@ -9,6 +9,8 @@ export type RecentlyViewedDocumentsOptions = {
 	readonly includeViewedFiles: boolean;
 }
 
+export type LanguageContextLanguages = { [languageId: string]: boolean };
+
 export type LanguageContextOptions = {
 	readonly enabled: boolean;
 	readonly maxTokens: number;
@@ -77,4 +79,11 @@ export const DEFAULT_OPTIONS: PromptOptions = {
 		onlyForDocsInPrompt: false,
 		useRelativePaths: false,
 	},
+};
+
+// TODO: consider a better per language setting/experiment approach
+export const LANGUAGE_CONTEXT_ENABLED_LANGUAGES: LanguageContextLanguages = {
+	'prompt': true,
+	'instructions': true,
+	'chatmode': true,
 };


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce functionality to enable language context providers on a per-language basis, allowing for more tailored responses based on the active document's language. This includes updates to configuration settings and the addition of related information in prompts.

cc @aeschli 

FYI @ulugbekna I've also introduced adding trait context to the prompt. I'm using the same format as completions are. It seems reasonable to use it as a prefix to the main prompt and to not include any `<><\>`. We currently only use language context for prompt files. We should reconsider the format when we use language context from programming languages
