### PR TITLE
Add telemetry for remote embeddings failures

### DIFF
--- a/src/extension/context/node/resolvers/extensionApi.tsx
+++ b/src/extension/context/node/resolvers/extensionApi.tsx
@@ -9,7 +9,7 @@ import { EmbeddingCacheType, IEmbeddingsCache, LocalEmbeddingsCache, RemoteCache
 import { IEnvService } from '../../../../platform/env/common/envService';
 import { Progress } from '../../../../platform/notification/common/notificationService';
 import { createFencedCodeBlock } from '../../../../util/common/markdown';
-import { CallTracker } from '../../../../util/common/telemetryCorrelationId';
+import { TelemetryCorrelationId } from '../../../../util/common/telemetryCorrelationId';
 import { sanitizeVSCodeVersion } from '../../../../util/common/vscodeVersion';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
 import { createDecorator, IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
@@ -92,7 +92,7 @@ export class VSCodeAPIContextElement extends PromptElement<VSCodeAPIContextProps
 	private async getSnippets(token: CancellationToken | undefined): Promise<string[]> {
 		await this.apiEmbeddingsIndex.updateIndex();
 
-		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [this.props.query], {}, new CallTracker('VSCodeAPIContextElement::getSnippets'), token);
+		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [this.props.query], {}, new TelemetryCorrelationId('VSCodeAPIContextElement::getSnippets'), token);
 		if (embeddingResult && embeddingResult.values.length > 0) {
 			return this.apiEmbeddingsIndex.nClosestValues(embeddingResult.values[0], 5);
 		}

--- a/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -25,7 +25,7 @@ import { IExperimentationService } from '../../../platform/telemetry/common/null
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
 import { IThinkingDataService } from '../../../platform/thinking/node/thinkingDataService';
 import { BaseTokensPerCompletion } from '../../../platform/tokenizer/node/tokenizer';
-import { CallTracker } from '../../../util/common/telemetryCorrelationId';
+import { TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
 import { Emitter } from '../../../util/vs/base/common/event';
 import { Disposable, MutableDisposable } from '../../../util/vs/base/common/lifecycle';
 import { isDefined, isNumber, isString, isStringArray } from '../../../util/vs/base/common/types';
@@ -226,7 +226,7 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 			dispo.clear();
 			dispo.value = vscode.lm.registerEmbeddingsProvider(`copilot.${model}`, new class implements vscode.EmbeddingsProvider {
 				async provideEmbeddings(input: string[], token: vscode.CancellationToken): Promise<vscode.Embedding[]> {
-					const result = await embeddingsComputer.computeEmbeddings(embeddingType, input, { parallelism: 2 }, new CallTracker('EmbeddingsProvider::provideEmbeddings'), token);
+					const result = await embeddingsComputer.computeEmbeddings(embeddingType, input, { parallelism: 2 }, new TelemetryCorrelationId('EmbeddingsProvider::provideEmbeddings'), token);
 					if (!result) {
 						throw new Error('Failed to compute embeddings');
 					}

--- a/src/extension/prompt/vscode-node/settingsEditorSearchServiceImpl.ts
+++ b/src/extension/prompt/vscode-node/settingsEditorSearchServiceImpl.ts
@@ -8,7 +8,7 @@ import { EmbeddingType, IEmbeddingsComputer } from '../../../platform/embeddings
 import { ICombinedEmbeddingIndex, SettingListItem } from '../../../platform/embeddings/common/vscodeIndex';
 import { ChatEndpointFamily, IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { ISettingsEditorSearchService } from '../../../platform/settingsEditor/common/settingsEditorSearchService';
-import { CallTracker } from '../../../util/common/telemetryCorrelationId';
+import { TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { SettingsEditorSearchResultsSelector } from '../node/settingsEditorSearchResultsSelector';
 
@@ -35,7 +35,7 @@ export class SettingsEditorSearchServiceImpl implements ISettingsEditorSearchSer
 			settings: []
 		};
 
-		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [query], {}, new CallTracker('SettingsEditorSearchServiceImpl::provideSettingsSearchResults'), token);
+		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [query], {}, new TelemetryCorrelationId('SettingsEditorSearchServiceImpl::provideSettingsSearchResults'), token);
 		if (token.isCancellationRequested) {
 			progress.report(canceledBundle);
 			return;

--- a/src/extension/relatedFiles/node/gitRelatedFilesProvider.ts
+++ b/src/extension/relatedFiles/node/gitRelatedFilesProvider.ts
@@ -11,7 +11,7 @@ import { IFileSystemService } from '../../../platform/filesystem/common/fileSyst
 import { IGitService } from '../../../platform/git/common/gitService';
 import { Commit } from '../../../platform/git/vscode/git';
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
-import { CallTracker } from '../../../util/common/telemetryCorrelationId';
+import { TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
 import { intersection, SetWithKey } from '../../../util/vs/base/common/collections';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { ResourceMap, ResourceSet } from '../../../util/vs/base/common/map';
@@ -153,7 +153,7 @@ export class GitRelatedFilesProvider extends Disposable implements vscode.ChatRe
 		// Calculate the embeddings for the commits we don't have cached embeddings for
 		const commitMessages = commitsToComputeEmbeddingsFor.map((commit) => commit.commit.message);
 		const text = prompt ? [prompt, ...commitMessages] : commitMessages;
-		const result = await this._embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, text, {}, new CallTracker('GitRelatedFilesProvider::computeCommitMessageEmbeddings'), token);
+		const result = await this._embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, text, {}, new TelemetryCorrelationId('GitRelatedFilesProvider::computeCommitMessageEmbeddings'), token);
 		if (!result) {
 			return undefined;
 		}

--- a/src/platform/embeddings/common/embeddingsComputer.ts
+++ b/src/platform/embeddings/common/embeddingsComputer.ts
@@ -5,7 +5,7 @@
 
 import type { CancellationToken } from 'vscode';
 import { createServiceIdentifier } from '../../../util/common/services';
-import { CallTracker } from '../../../util/common/telemetryCorrelationId';
+import { TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
 
 /**
  * Fully qualified type of the embedding.
@@ -109,7 +109,7 @@ export interface IEmbeddingsComputer {
 		type: EmbeddingType,
 		inputs: readonly string[],
 		options?: ComputeEmbeddingsOptions,
-		telemetryInfo?: CallTracker,
+		telemetryInfo?: TelemetryCorrelationId,
 		token?: CancellationToken,
 	): Promise<Embeddings | undefined>;
 }

--- a/src/platform/embeddings/common/vscodeIndex.ts
+++ b/src/platform/embeddings/common/vscodeIndex.ts
@@ -5,7 +5,7 @@
 
 import type { CancellationToken, CommandInformationResult, RelatedInformationProvider, RelatedInformationResult, SettingInformationResult } from 'vscode';
 import { createServiceIdentifier } from '../../../util/common/services';
-import { CallTracker } from '../../../util/common/telemetryCorrelationId';
+import { TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
 import { sanitizeVSCodeVersion } from '../../../util/common/vscodeVersion';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { IEnvService } from '../../env/common/envService';
@@ -108,7 +108,7 @@ abstract class RelatedInformationProviderEmbeddingsIndex<V extends { key: string
 			return [];
 		}
 		const startOfEmbeddingRequest = Date.now();
-		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [query], {}, new CallTracker('RelatedInformationProviderEmbeddingsIndex::provideRelatedInformation'), token);
+		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [query], {}, new TelemetryCorrelationId('RelatedInformationProviderEmbeddingsIndex::provideRelatedInformation'), token);
 		this._logService.debug(`Related Information: Remote similarly request took ${Date.now() - startOfEmbeddingRequest}ms`);
 		if (token.isCancellationRequested || !embeddingResult || !embeddingResult.values[0]) {
 			// return an array of 0s the same length as comparisons

--- a/src/platform/urlChunkSearch/node/urlChunkEmbeddingsIndex.ts
+++ b/src/platform/urlChunkSearch/node/urlChunkEmbeddingsIndex.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { createSha256Hash } from '../../../util/common/crypto';
-import { CallTracker } from '../../../util/common/telemetryCorrelationId';
+import { CallTracker, TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
 import { raceCancellationError } from '../../../util/vs/base/common/async';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
@@ -69,7 +69,7 @@ export class UrlChunkEmbeddingsIndex extends Disposable {
 	}
 
 	private async computeEmbeddings(str: string, token: CancellationToken): Promise<Embedding> {
-		const embeddings = await this._embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [str], {}, new CallTracker('UrlChunkEmbeddingsIndex::computeEmbeddings'), token);
+		const embeddings = await this._embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [str], {}, new TelemetryCorrelationId('UrlChunkEmbeddingsIndex::computeEmbeddings'), token);
 		if (!embeddings?.values.length) {
 			throw new Error('Timeout computing embeddings');
 		}

--- a/src/platform/workspaceChunkSearch/node/workspaceChunkSearchService.ts
+++ b/src/platform/workspaceChunkSearch/node/workspaceChunkSearchService.ts
@@ -8,7 +8,7 @@ import type * as vscode from 'vscode';
 import { createFencedCodeBlock, getLanguageId } from '../../../util/common/markdown';
 import { Result } from '../../../util/common/result';
 import { createServiceIdentifier } from '../../../util/common/services';
-import { CallTracker, TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
+import { TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
 import { TokenizerType } from '../../../util/common/tokenizer';
 import { coalesce } from '../../../util/vs/base/common/arrays';
 import { CancelablePromise, createCancelablePromise, raceCancellationError, raceTimeout } from '../../../util/vs/base/common/async';
@@ -142,6 +142,8 @@ export class WorkspaceChunkSearchService extends Disposable implements IWorkspac
 				this._logService.info(`WorkspaceChunkSearchService: using embedding type ${best}`);
 				this._impl = this._register(this._instantiationService.createInstance(WorkspaceChunkSearchServiceImpl, best));
 				this._register(this._impl.onDidChangeIndexState(() => this._onDidChangeIndexState.fire()));
+				this._onDidChangeIndexState.fire();
+
 				return this._impl;
 			}
 		} catch {
@@ -776,7 +778,7 @@ class WorkspaceChunkSearchServiceImpl extends Disposable implements IWorkspaceCh
 	}
 
 	private async computeEmbeddings(inputType: 'query' | 'document', strings: readonly string[], token: CancellationToken): Promise<Embeddings> {
-		const embeddings = await this._embeddingsComputer.computeEmbeddings(this._embeddingType, strings, { inputType }, new CallTracker('WorkspaceChunkSearchService::computeEmbeddings'), token);
+		const embeddings = await this._embeddingsComputer.computeEmbeddings(this._embeddingType, strings, { inputType }, new TelemetryCorrelationId('WorkspaceChunkSearchService::computeEmbeddings'), token);
 		if (!embeddings) {
 			throw new Error('Timeout computing embeddings');
 		}

--- a/test/base/cachingEmbeddingsFetcher.ts
+++ b/test/base/cachingEmbeddingsFetcher.ts
@@ -9,9 +9,10 @@ import { RemoteEmbeddingsComputer } from '../../src/platform/embeddings/common/r
 import { ICAPIClientService } from '../../src/platform/endpoint/common/capiClient';
 import { IDomainService } from '../../src/platform/endpoint/common/domainService';
 import { IEnvService } from '../../src/platform/env/common/envService';
+import { ILogService } from '../../src/platform/log/common/logService';
 import { IFetcherService } from '../../src/platform/networking/common/fetcherService';
 import { ITelemetryService } from '../../src/platform/telemetry/common/telemetry';
-import { CallTracker } from '../../src/util/common/telemetryCorrelationId';
+import { TelemetryCorrelationId } from '../../src/util/common/telemetryCorrelationId';
 import { computeSHA256 } from './hash';
 
 export class CacheableEmbeddingRequest {
@@ -45,19 +46,21 @@ export class CachingEmbeddingsComputer extends RemoteEmbeddingsComputer {
 	constructor(
 		private readonly cache: IEmbeddingsCache,
 		@IAuthenticationService authService: IAuthenticationService,
-		@ITelemetryService telemetryService: ITelemetryService,
-		@IDomainService domainService: IDomainService,
 		@ICAPIClientService capiClientService: ICAPIClientService,
+		@IDomainService domainService: IDomainService,
 		@IEnvService envService: IEnvService,
-		@IFetcherService fetcherService: IFetcherService
+		@IFetcherService fetcherService: IFetcherService,
+		@ILogService logService: ILogService,
+		@ITelemetryService telemetryService: ITelemetryService,
 	) {
 		super(
 			authService,
-			telemetryService,
-			domainService,
 			capiClientService,
+			domainService,
 			envService,
-			fetcherService
+			fetcherService,
+			logService,
+			telemetryService,
 		);
 	}
 
@@ -65,8 +68,8 @@ export class CachingEmbeddingsComputer extends RemoteEmbeddingsComputer {
 		type: EmbeddingType,
 		inputs: string[],
 		options: ComputeEmbeddingsOptions,
-		telemetryInfo: CallTracker,
-		token: CancellationToken | undefined,
+		telemetryInfo?: TelemetryCorrelationId,
+		token?: CancellationToken,
 	): Promise<Embeddings | undefined> {
 		const embeddingEntries = new Map<string, Embedding>();
 		const nonCached: string[] = [];


### PR DESCRIPTION
We'd like to track errors with the embedding service