### PR TITLE
Provide notebook contents on creation

### DIFF
--- a/src/platform/test/node/simulationWorkspace.ts
+++ b/src/platform/test/node/simulationWorkspace.ts
@@ -382,7 +382,7 @@ export class SimulationWorkspace {
 		this._notebooks.set(notebook.uri, notebook);
 	}
 
-	public getNotebook(filePathOrUri: string | vscode.Uri): ExtHostNotebookDocumentData {
+	public tryGetNotebook(filePathOrUri: string | vscode.Uri): ExtHostNotebookDocumentData | undefined {
 		const queryUri = typeof filePathOrUri === 'string' ? this.getUriFromFilePath(filePathOrUri) : filePathOrUri;
 		if (queryUri.scheme === Schemas.vscodeNotebookCell) {
 			// loop through notebooks to find the one matching the path
@@ -394,7 +394,11 @@ export class SimulationWorkspace {
 			}
 		}
 
-		const candidateFile = this._notebooks.get(queryUri);
+		return this._notebooks.get(queryUri);
+	}
+
+	public getNotebook(filePathOrUri: string | vscode.Uri): ExtHostNotebookDocumentData {
+		const candidateFile = this.tryGetNotebook(filePathOrUri);
 		if (!candidateFile) {
 			throw new Error(`Missing file ${JSON.stringify(filePathOrUri, null, '\t')}\n\nHave ${Array.from(this._docs.keys()).map(k => k.toString()).join('\n')}`);
 		}

--- a/test/simulation/baseline.json
+++ b/test/simulation/baseline.json
@@ -9172,23 +9172,23 @@
   {
     "name": "notebookEdits (bug reports - json) [panel] - Issue #13868",
     "contentFilterCount": 0,
-    "passCount": 0,
-    "failCount": 10,
-    "score": 0
+    "passCount": 10,
+    "failCount": 0,
+    "score": 1
   },
   {
     "name": "notebookEdits (bug reports - text) [panel] - Issue #13868",
     "contentFilterCount": 0,
-    "passCount": 0,
-    "failCount": 10,
-    "score": 0
+    "passCount": 10,
+    "failCount": 0,
+    "score": 1
   },
   {
     "name": "notebookEdits (bug reports - xml) [panel] - Issue #13868",
     "contentFilterCount": 0,
-    "passCount": 0,
-    "failCount": 10,
-    "score": 0
+    "passCount": 10,
+    "failCount": 0,
+    "score": 1
   },
   {
     "name": "notebookEdits (modification - json) [panel] [julia] - new julia code cells in empty notebook",

--- a/test/simulation/inlineChatSimulator.ts
+++ b/test/simulation/inlineChatSimulator.ts
@@ -518,13 +518,13 @@ export async function simulateEditingScenario(
 						outcomeFiles.push({
 							kind: 'relativeFile',
 							fileName: path.basename(uri.fsPath),
-							fileContents: workspace.getDocument(uri).getText()
+							fileContents: workspace.tryGetNotebook(uri)?.getText() ?? workspace.getDocument(uri).getText()
 						});
 					} else {
 						outcomeFiles.push({
 							kind: 'qualifiedFile',
 							uri: uri,
-							fileContents: workspace.getDocument(uri).getText()
+							fileContents: workspace.tryGetNotebook(uri)?.getText() ?? workspace.getDocument(uri).getText()
 						});
 					}
 					const offsetEdits = workingCopyDoc.appliedEdits;


### PR DESCRIPTION
Ensure that the contents of notebooks are accessible when a notebook is created, enhancing the handling of notebook documents.

Simulation test can fail to open notebooks after its created, here's the stack trace

```
vscode-notebook-cell:/Users/someone/Projects/proj01/tensorproduct_powers_issue.ipynb#d53ea8f6
    at SimulationWorkspace.getDocument (/agent/src/platform/test/node/simulationWorkspace.ts:360:10)
    at simulateEditingScenario (/agent/test/simulation/inlineChatSimulator.ts:521:32)
    at SimulationTest._runner (/agent/test/simulation/externalScenarios.ts:130:3)
    at executeTestOnce (/agent/test/testExecutor.ts:441:3)
    at CTask.execute (/agent/test/taskRunner.ts:20:19) 
```