### PR TITLE
Bubble up embeddings endpoint errors

### DIFF
--- a/src/extension/context/node/resolvers/extensionApi.tsx
+++ b/src/extension/context/node/resolvers/extensionApi.tsx
@@ -91,13 +91,12 @@ export class VSCodeAPIContextElement extends PromptElement<VSCodeAPIContextProps
 
 	private async getSnippets(token: CancellationToken | undefined): Promise<string[]> {
 		await this.apiEmbeddingsIndex.updateIndex();
-
-		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [this.props.query], {}, new TelemetryCorrelationId('VSCodeAPIContextElement::getSnippets'), token);
-		if (embeddingResult && embeddingResult.values.length > 0) {
-			return this.apiEmbeddingsIndex.nClosestValues(embeddingResult.values[0], 5);
+		if (token?.isCancellationRequested) {
+			return [];
 		}
 
-		return [];
+		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [this.props.query], {}, new TelemetryCorrelationId('VSCodeAPIContextElement::getSnippets'), token);
+		return this.apiEmbeddingsIndex.nClosestValues(embeddingResult.values[0], 5);
 	}
 
 	override async render(state: undefined, sizing: PromptSizing, progress?: Progress<ChatResponsePart>, token?: CancellationToken): Promise<PromptPiece<any, any> | undefined> {

--- a/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -226,9 +226,6 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 			dispo.value = vscode.lm.registerEmbeddingsProvider(`copilot.${model}`, new class implements vscode.EmbeddingsProvider {
 				async provideEmbeddings(input: string[], token: vscode.CancellationToken): Promise<vscode.Embedding[]> {
 					const result = await embeddingsComputer.computeEmbeddings(embeddingType, input, { parallelism: 2 }, new TelemetryCorrelationId('EmbeddingsProvider::provideEmbeddings'), token);
-					if (!result) {
-						throw new Error('Failed to compute embeddings');
-					}
 					return result.values.map(embedding => ({ values: embedding.value.slice(0) }));
 				}
 			});

--- a/src/extension/prompt/vscode-node/settingsEditorSearchServiceImpl.ts
+++ b/src/extension/prompt/vscode-node/settingsEditorSearchServiceImpl.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { CancellationToken, Progress, SettingsSearchProviderOptions, SettingsSearchResult, SettingsSearchResultKind } from 'vscode';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
-import { EmbeddingType, IEmbeddingsComputer } from '../../../platform/embeddings/common/embeddingsComputer';
+import { Embeddings, EmbeddingType, IEmbeddingsComputer } from '../../../platform/embeddings/common/embeddingsComputer';
 import { ICombinedEmbeddingIndex, SettingListItem } from '../../../platform/embeddings/common/vscodeIndex';
 import { ChatEndpointFamily, IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { ISettingsEditorSearchService } from '../../../platform/settingsEditor/common/settingsEditorSearchService';
@@ -35,12 +35,15 @@ export class SettingsEditorSearchServiceImpl implements ISettingsEditorSearchSer
 			settings: []
 		};
 
-		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [query], {}, new TelemetryCorrelationId('SettingsEditorSearchServiceImpl::provideSettingsSearchResults'), token);
-		if (token.isCancellationRequested) {
-			progress.report(canceledBundle);
-			return;
-		}
-		if (!embeddingResult || embeddingResult.values.length === 0) {
+		let embeddingResult: Embeddings;
+		try {
+			embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [query], {}, new TelemetryCorrelationId('SettingsEditorSearchServiceImpl::provideSettingsSearchResults'), token);
+		} catch {
+			if (token.isCancellationRequested) {
+				progress.report(canceledBundle);
+				return;
+			}
+
 			progress.report({
 				query,
 				kind: SettingsSearchResultKind.EMBEDDED,
@@ -53,6 +56,11 @@ export class SettingsEditorSearchServiceImpl implements ISettingsEditorSearchSer
 					settings: []
 				});
 			}
+			return;
+		}
+
+		if (token.isCancellationRequested) {
+			progress.report(canceledBundle);
 			return;
 		}
 

--- a/src/extension/prompts/node/panel/newWorkspace/newWorkspace.tsx
+++ b/src/extension/prompts/node/panel/newWorkspace/newWorkspace.tsx
@@ -106,29 +106,27 @@ export class NewWorkspacePrompt extends PromptElement<NewWorkspacePromptProps, N
 			else if (instruction.intent === 'Project') {
 				if (this.props.useTemplates) {
 					const result = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [instruction.question], {}, undefined);
-					if (result && result.values.length > 0) {
-						progress.report(new ChatResponseProgressPart(l10n.t('Searching project template index...')));
-						const similarProjects = await this.projectTemplatesIndex.nClosestValues(result.values[0], 1);
-						if (similarProjects.length > 0) {
-							const content = similarProjects[0]?.split(':');
-							const org = content[0].trim();
-							const repo = content[1].trim();
-							const repoPath = content[2].trim() === '' ? '.' : content[2].trim();
+					progress.report(new ChatResponseProgressPart(l10n.t('Searching project template index...')));
+					const similarProjects = await this.projectTemplatesIndex.nClosestValues(result.values[0], 1);
+					if (similarProjects.length > 0) {
+						const content = similarProjects[0]?.split(':');
+						const org = content[0].trim();
+						const repo = content[1].trim();
+						const repoPath = content[2].trim() === '' ? '.' : content[2].trim();
 
-							if (org && repo && repoPath) {
-								const items = await reportProgressOnSlowPromise(progress, new ChatResponseProgressPart(l10n.t('Fetching project contents...')), this.repositoryService.getRepositoryItems(org, repo, repoPath), 500);
-								if (items.length > 0) {
-									let url: string;
-									if (repoPath === '.') {
-										url = `httpx://github.com/${org}/${repo}`;
-									} else {
-										url = path.dirname(items[0].html_url);
-									}
-
-									this._metadata = new NewWorkspaceGithubContentMetadata(org, repo, repoPath, items);
-									return { url: url };
-
+						if (org && repo && repoPath) {
+							const items = await reportProgressOnSlowPromise(progress, new ChatResponseProgressPart(l10n.t('Fetching project contents...')), this.repositoryService.getRepositoryItems(org, repo, repoPath), 500);
+							if (items.length > 0) {
+								let url: string;
+								if (repoPath === '.') {
+									url = `httpx://github.com/${org}/${repo}`;
+								} else {
+									url = path.dirname(items[0].html_url);
 								}
+
+								this._metadata = new NewWorkspaceGithubContentMetadata(org, repo, repoPath, items);
+								return { url: url };
+
 							}
 						}
 					}

--- a/src/extension/prompts/node/panel/vscode.tsx
+++ b/src/extension/prompts/node/panel/vscode.tsx
@@ -122,10 +122,6 @@ export class VscodePrompt extends PromptElement<VscodePromptProps, VscodePromptS
 			return { settings: [], commands: [], releaseNotes: '', query: userQuery };
 		}
 
-		if (!embeddingResult) {
-			return { settings: [], commands: [], query: userQuery };
-		}
-
 		const nClosestValuesPromise = progress
 			? reportProgressOnSlowPromise(progress, new ChatResponseProgressPart(l10n.t("Searching command and setting index....")), this.combinedEmbeddingIndex.nClosestValues(embeddingResult.values[0], shouldIncludeDocsSearch ? 5 : 25), 500)
 			: this.combinedEmbeddingIndex.nClosestValues(embeddingResult.values[0], shouldIncludeDocsSearch ? 5 : 25);

--- a/src/extension/relatedFiles/node/gitRelatedFilesProvider.ts
+++ b/src/extension/relatedFiles/node/gitRelatedFilesProvider.ts
@@ -154,9 +154,6 @@ export class GitRelatedFilesProvider extends Disposable implements vscode.ChatRe
 		const commitMessages = commitsToComputeEmbeddingsFor.map((commit) => commit.commit.message);
 		const text = prompt ? [prompt, ...commitMessages] : commitMessages;
 		const result = await this._embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, text, {}, new TelemetryCorrelationId('GitRelatedFilesProvider::computeCommitMessageEmbeddings'), token);
-		if (!result) {
-			return undefined;
-		}
 
 		const embeddings = result.values;
 		const promptEmbedding = prompt ? embeddings[0] : undefined;

--- a/src/platform/embeddings/common/embeddingsComputer.ts
+++ b/src/platform/embeddings/common/embeddingsComputer.ts
@@ -111,7 +111,7 @@ export interface IEmbeddingsComputer {
 		options?: ComputeEmbeddingsOptions,
 		telemetryInfo?: TelemetryCorrelationId,
 		token?: CancellationToken,
-	): Promise<Embeddings | undefined>;
+	): Promise<Embeddings>;
 }
 
 function dotProduct(a: EmbeddingVector, b: EmbeddingVector): number {

--- a/src/platform/embeddings/common/vscodeIndex.ts
+++ b/src/platform/embeddings/common/vscodeIndex.ts
@@ -110,7 +110,7 @@ abstract class RelatedInformationProviderEmbeddingsIndex<V extends { key: string
 		const startOfEmbeddingRequest = Date.now();
 		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [query], {}, new TelemetryCorrelationId('RelatedInformationProviderEmbeddingsIndex::provideRelatedInformation'), token);
 		this._logService.debug(`Related Information: Remote similarly request took ${Date.now() - startOfEmbeddingRequest}ms`);
-		if (token.isCancellationRequested || !embeddingResult || !embeddingResult.values[0]) {
+		if (token.isCancellationRequested) {
 			// return an array of 0s the same length as comparisons
 			this._logService.debug(`Related Information: Request cancelled or no embeddings computed, returning ${Date.now() - similarityStart}ms`);
 			return [];

--- a/src/platform/urlChunkSearch/node/urlChunkEmbeddingsIndex.ts
+++ b/src/platform/urlChunkSearch/node/urlChunkEmbeddingsIndex.ts
@@ -70,10 +70,6 @@ export class UrlChunkEmbeddingsIndex extends Disposable {
 
 	private async computeEmbeddings(str: string, token: CancellationToken): Promise<Embedding> {
 		const embeddings = await this._embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [str], {}, new TelemetryCorrelationId('UrlChunkEmbeddingsIndex::computeEmbeddings'), token);
-		if (!embeddings?.values.length) {
-			throw new Error('Timeout computing embeddings');
-		}
-
 		return embeddings.values[0];
 	}
 

--- a/src/platform/workspaceChunkSearch/node/workspaceChunkSearchService.ts
+++ b/src/platform/workspaceChunkSearch/node/workspaceChunkSearchService.ts
@@ -779,13 +779,8 @@ class WorkspaceChunkSearchServiceImpl extends Disposable implements IWorkspaceCh
 		});
 	}
 
-	private async computeEmbeddings(inputType: 'query' | 'document', strings: readonly string[], token: CancellationToken): Promise<Embeddings> {
-		const embeddings = await this._embeddingsComputer.computeEmbeddings(this._embeddingType, strings, { inputType }, new TelemetryCorrelationId('WorkspaceChunkSearchService::computeEmbeddings'), token);
-		if (!embeddings) {
-			throw new Error('Timeout computing embeddings');
-		}
-
-		return embeddings;
+	private computeEmbeddings(inputType: 'query' | 'document', strings: readonly string[], token: CancellationToken): Promise<Embeddings> {
+		return this._embeddingsComputer.computeEmbeddings(this._embeddingType, strings, { inputType }, new TelemetryCorrelationId('WorkspaceChunkSearchService::computeEmbeddings'), token);
 	}
 
 	/**

--- a/test/base/cachingEmbeddingsFetcher.ts
+++ b/test/base/cachingEmbeddingsFetcher.ts
@@ -70,7 +70,7 @@ export class CachingEmbeddingsComputer extends RemoteEmbeddingsComputer {
 		options: ComputeEmbeddingsOptions,
 		telemetryInfo?: TelemetryCorrelationId,
 		token?: CancellationToken,
-	): Promise<Embeddings | undefined> {
+	): Promise<Embeddings> {
 		const embeddingEntries = new Map<string, Embedding>();
 		const nonCached: string[] = [];
 
@@ -91,9 +91,6 @@ export class CachingEmbeddingsComputer extends RemoteEmbeddingsComputer {
 
 		if (nonCached.length) {
 			const embeddingsResult = await super.computeEmbeddings(type, nonCached, options, telemetryInfo, token);
-			if (!embeddingsResult) {
-				return undefined;
-			}
 
 			// Update the cache with the newest entries
 			for (let i = 0; i < nonCached.length; i++) {
@@ -108,10 +105,9 @@ export class CachingEmbeddingsComputer extends RemoteEmbeddingsComputer {
 		const out: Embedding[] = [];
 		for (const input of inputs) {
 			const embedding = embeddingEntries.get(input);
-			if (!embedding) {
-				return undefined;
+			if (embedding) {
+				out.push(embedding);
 			}
-			out.push(embedding);
 		}
 		return { type, values: out };
 	}


### PR DESCRIPTION
Right now we return `undefined` when computing embeddings fails. I think it makes more sense to throw exceptions with the  details of why this failed so we can track these