### PR TITLE
Add telemetry flag for API type

### DIFF
--- a/src/extension/prompt/node/chatMLFetcher.ts
+++ b/src/extension/prompt/node/chatMLFetcher.ts
@@ -255,6 +255,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 						source: telemetryProperties.messageSource ?? 'unknown',
 						requestId: ourRequestId,
 						model: chatEndpoint.model,
+						apiType: chatEndpoint.apiType,
 						...(telemetryProperties.retryAfterFilterCategory ? { retryAfterFilterCategory: telemetryProperties.retryAfterFilterCategory } : {}),
 					}, {
 						totalTokenMax: chatEndpoint.modelMaxPromptTokens ?? -1,
@@ -282,6 +283,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 					source: telemetryProperties.messageSource ?? 'unknown',
 					requestId: ourRequestId,
 					model: chatEndpoint.model,
+					apiType: chatEndpoint.apiType
 				}, {
 					totalTokenMax: chatEndpoint.modelMaxPromptTokens ?? -1,
 					promptTokenCount: tokenCount,
@@ -304,10 +306,12 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			source,
 			requestId,
 			model,
+			apiType
 		}: {
 			source: string;
 			requestId: string;
 			model: string;
+			apiType: string | undefined;
 		},
 		{
 			totalTokenMax,
@@ -332,6 +336,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 				"owner": "digitarald",
 				"comment": "Report canceled service responses for quality.",
 				"model": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Model selection for the response" },
+				"apiType": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "API type for the response- chat completions or responses" },
 				"source": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Source for why the request was made" },
 				"requestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the request" },
 				"totalTokenMax": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Maximum total token window", "isMeasurement": true },
@@ -345,6 +350,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			}
 		*/
 		this._telemetryService.sendTelemetryEvent('response.cancelled', { github: true, microsoft: true }, {
+			apiType,
 			source,
 			requestId,
 			model,
@@ -376,6 +382,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 				"type": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Type of issue" },
 				"reason": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Reason of issue" },
 				"model": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Model selection for the response" },
+				"apiType": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "API type for the response- chat completions or responses" },
 				"source": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Source for why the request was made" },
 				"requestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the request" },
 				"totalTokenMax": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Maximum total token window", "isMeasurement": true },
@@ -393,6 +400,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			source: telemetryProperties?.messageSource ?? 'unknown',
 			requestId: ourRequestId,
 			model: chatEndpointInfo.model,
+			apiType: chatEndpointInfo.apiType,
 			...(telemetryProperties?.retryAfterFilterCategory ? { retryAfterFilterCategory: telemetryProperties.retryAfterFilterCategory } : {})
 		}, {
 			totalTokenMax: chatEndpointInfo.modelMaxPromptTokens ?? -1,
@@ -428,6 +436,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 					"source": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Source of the initial request" },
 					"initiatorType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the request was initiated by a user or an agent" },
 					"model": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Model selection for the response" },
+					"apiType": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "API type for the response- chat completions or responses" },
 					"requestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the current turn request" },
 					"totalTokenMax": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Maximum total token window", "isMeasurement": true },
 					"clientPromptTokenCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of prompt tokens, locally counted", "isMeasurement": true },
@@ -451,6 +460,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 				source: baseTelemetry?.properties.messageSource ?? 'unknown',
 				initiatorType: userInitiatedRequest ? 'user' : 'agent',
 				model: chatEndpointInfo?.model,
+				apiType: chatEndpointInfo?.apiType,
 				requestId,
 				...(baseTelemetry?.properties.retryAfterFilterCategory ? { retryAfterFilterCategory: baseTelemetry.properties.retryAfterFilterCategory } : {}),
 			}, {

--- a/src/extension/prompt/node/chatParticipantTelemetry.ts
+++ b/src/extension/prompt/node/chatParticipantTelemetry.ts
@@ -33,6 +33,7 @@ type ResponseInternalTelemetryProperties = {
 	request: string;
 	response: string;
 	baseModel: string;
+	apiType: string | undefined;
 };
 
 // EVENT: interactiveSessionResponse
@@ -85,6 +86,7 @@ type RequestInternalPanelTelemetryProperties = {
 	sessionId: string;
 	requestId: string;
 	baseModel: string;
+	apiType: string | undefined;
 	intent: string;
 	isParticipantDetected: string;
 	detectedIntent: string;
@@ -102,6 +104,7 @@ type RequestInternalInlineTelemetryProperties = {
 	language: string;
 	prompt: string;
 	model: string;
+	apiType: string | undefined;
 };
 
 type RequestInternalInlineTelemetryMeasurements = {
@@ -126,6 +129,7 @@ type RequestTelemetryProperties = {
 	responseType: string;
 	languageId: string | undefined;
 	model: string;
+	apiType: string | undefined;
 };
 
 type RequestPanelTelemetryProperties = RequestTelemetryProperties & {
@@ -523,6 +527,7 @@ export class PanelChatTelemetry extends ChatTelemetry<IDocumentContext | undefin
 			sessionId: this._sessionId,
 			requestId: this.telemetryMessageId,
 			baseModel: this._endpoint.model,
+			apiType: this._endpoint.apiType,
 			intent: this._intent.id,
 			isParticipantDetected: String(this._request.isParticipantDetected),
 			detectedIntent: this._request.enableCommandDetection ? this._intent?.id : 'none',
@@ -576,6 +581,7 @@ export class PanelChatTelemetry extends ChatTelemetry<IDocumentContext | undefin
 				"languageId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The language of the active editor." },
 				"codeBlocks": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Code block languages in the response." },
 				"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model that is used in the endpoint." },
+				"apiType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The API type used in the endpoint- responses or chatCompletions" },
 				"turn": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many turns have been made in the conversation." },
 				"round": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "The current round index of the turn." },
 				"textBlocks": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "For text-only responses (no code), how many paragraphs were in the response." },
@@ -611,6 +617,7 @@ export class PanelChatTelemetry extends ChatTelemetry<IDocumentContext | undefin
 			languageId: this._documentContext?.document.languageId,
 			codeBlocks: codeBlockLanguages.join(','),
 			model: this._endpoint.model,
+			apiType: this._endpoint.apiType,
 			isParticipantDetected: String(this._request.isParticipantDetected),
 			toolCounts: JSON.stringify(toolCounts),
 		} satisfies RequestPanelTelemetryProperties, {
@@ -682,6 +689,7 @@ export class PanelChatTelemetry extends ChatTelemetry<IDocumentContext | undefin
 			request: this._request.prompt,
 			response: response ?? '',
 			baseModel: this._endpoint.model,
+			apiType: this._endpoint.apiType,
 
 			// shareable but NOT
 			isParticipantDetected: String(this._request.isParticipantDetected),
@@ -752,7 +760,8 @@ export class InlineChatTelemetry extends ChatTelemetry<IDocumentContext> {
 			intent: this._intent.id,
 			language: this._documentContext.document.languageId,
 			prompt: this._messages.map(m => `${roleToString(m.role).toUpperCase()}:\n${m.content}`).join('\n---\n'),
-			model: this._endpoint.model
+			model: this._endpoint.model,
+			apiType: this._endpoint.apiType
 		} satisfies RequestInternalInlineTelemetryProperties, {
 			isNotebook: this._isNotebookDocument,
 			turnNumber: this._conversation.turns.length,
@@ -776,6 +785,7 @@ export class InlineChatTelemetry extends ChatTelemetry<IDocumentContext> {
 				"responseType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The result type of the response." },
 				"replyType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "How response is shown in the interface." },
 				"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model that is used in the endpoint." },
+				"apiType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The API type used in the endpoint- responses or chatCompletions" },
 				"diagnosticsProvider": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The diagnostics provider." },
 				"diagnosticCodes": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The diagnostics codes in the file." },
 				"selectionDiagnosticCodes": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The selected diagnostics codes." },
@@ -818,6 +828,7 @@ export class InlineChatTelemetry extends ChatTelemetry<IDocumentContext> {
 			responseType: responseType,
 			replyType: interactionOutcome.kind,
 			model: this._endpoint.model,
+			apiType: this._endpoint.apiType,
 			diagnosticsProvider: this._diagnosticsTelemetryData.diagnosticsProvider,
 			diagnosticCodes: this._diagnosticsTelemetryData.fileDiagnosticsTelemetry.diagnosticCodes,
 			selectionDiagnosticCodes: this._diagnosticsTelemetryData.selectionDiagnosticsTelemetry.diagnosticCodes,
@@ -858,6 +869,7 @@ export class InlineChatTelemetry extends ChatTelemetry<IDocumentContext> {
 			conversationId: this._sessionId,
 			requestId: this.telemetryMessageId,
 			baseModel: this._endpoint.model,
+			apiType: this._endpoint.apiType,
 			responseType,
 			problems: this._diagnosticsTelemetryData.fileDiagnosticsTelemetry.problems,
 			selectionProblems: this._diagnosticsTelemetryData.selectionDiagnosticsTelemetry.problems,

--- a/src/extension/prompt/node/test/__snapshots__/defaultIntentRequestHandler.spec.ts.snap
+++ b/src/extension/prompt/node/test/__snapshots__/defaultIntentRequestHandler.spec.ts.snap
@@ -137,6 +137,7 @@ exports[`defaultIntentRequestHandler > avoids requests when handler return is nu
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "contextTypes": "none",
@@ -590,6 +591,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "contextTypes": "none",
@@ -750,6 +752,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "userPromptCount": 1,
       },
       "properties": {
+        "apiType": undefined,
         "codeBlocks": "",
         "command": "test",
         "contextTypes": "none",
@@ -806,6 +809,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "intent": "test",
@@ -823,6 +827,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "contextTypes": "none",
@@ -983,6 +988,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "userPromptCount": 1,
       },
       "properties": {
+        "apiType": undefined,
         "codeBlocks": "",
         "command": "test",
         "contextTypes": "none",
@@ -1039,6 +1045,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "intent": "test",
@@ -1056,6 +1063,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "contextTypes": "none",
@@ -1216,6 +1224,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "userPromptCount": 1,
       },
       "properties": {
+        "apiType": undefined,
         "codeBlocks": "",
         "command": "test",
         "contextTypes": "none",
@@ -1272,6 +1281,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "intent": "test",
@@ -1289,6 +1299,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "contextTypes": "none",
@@ -1449,6 +1460,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "userPromptCount": 1,
       },
       "properties": {
+        "apiType": undefined,
         "codeBlocks": "",
         "command": "test",
         "contextTypes": "none",
@@ -1505,6 +1517,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "intent": "test",
@@ -1572,6 +1585,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "contextTypes": "none",
@@ -1732,6 +1746,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "userPromptCount": 1,
       },
       "properties": {
+        "apiType": undefined,
         "codeBlocks": "",
         "command": "test",
         "contextTypes": "none",
@@ -1788,6 +1803,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "intent": "test",
@@ -1805,6 +1821,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "contextTypes": "none",
@@ -1965,6 +1982,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "userPromptCount": 1,
       },
       "properties": {
+        "apiType": undefined,
         "codeBlocks": "",
         "command": "test",
         "contextTypes": "none",
@@ -2021,6 +2039,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "intent": "test",
@@ -2038,6 +2057,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "contextTypes": "none",
@@ -2198,6 +2218,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "userPromptCount": 1,
       },
       "properties": {
+        "apiType": undefined,
         "codeBlocks": "",
         "command": "test",
         "contextTypes": "none",
@@ -2254,6 +2275,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "intent": "test",
@@ -2271,6 +2293,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "contextTypes": "none",
@@ -2431,6 +2454,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "userPromptCount": 1,
       },
       "properties": {
+        "apiType": undefined,
         "codeBlocks": "",
         "command": "test",
         "contextTypes": "none",
@@ -2487,6 +2511,7 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "intent": "test",
@@ -2582,6 +2607,7 @@ exports[`defaultIntentRequestHandler > makes a successful request with a single 
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "contextTypes": "none",
@@ -2742,6 +2768,7 @@ exports[`defaultIntentRequestHandler > makes a successful request with a single 
         "userPromptCount": 1,
       },
       "properties": {
+        "apiType": undefined,
         "codeBlocks": "",
         "command": "test",
         "contextTypes": "none",
@@ -2798,6 +2825,7 @@ exports[`defaultIntentRequestHandler > makes a successful request with a single 
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "intent": "test",
@@ -2916,6 +2944,7 @@ exports[`defaultIntentRequestHandler > makes a tool call turn 2`] = `
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "contextTypes": "none",
@@ -3076,6 +3105,7 @@ exports[`defaultIntentRequestHandler > makes a tool call turn 2`] = `
         "userPromptCount": 1,
       },
       "properties": {
+        "apiType": undefined,
         "codeBlocks": "",
         "command": "test",
         "contextTypes": "none",
@@ -3132,6 +3162,7 @@ exports[`defaultIntentRequestHandler > makes a tool call turn 2`] = `
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "intent": "test",
@@ -3149,6 +3180,7 @@ exports[`defaultIntentRequestHandler > makes a tool call turn 2`] = `
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "contextTypes": "none",
@@ -3309,6 +3341,7 @@ exports[`defaultIntentRequestHandler > makes a tool call turn 2`] = `
         "userPromptCount": 1,
       },
       "properties": {
+        "apiType": undefined,
         "codeBlocks": "",
         "command": "test",
         "contextTypes": "none",
@@ -3365,6 +3398,7 @@ exports[`defaultIntentRequestHandler > makes a tool call turn 2`] = `
         "turnNumber": 1,
       },
       "properties": {
+        "apiType": undefined,
         "baseModel": "gpt-4.1-2025-04-14",
         "chatLocation": "panel",
         "intent": "test",

--- a/src/platform/endpoint/node/chatEndpoint.ts
+++ b/src/platform/endpoint/node/chatEndpoint.ts
@@ -225,6 +225,10 @@ export class ChatEndpoint implements IChatEndpoint {
 		return { terms: this._policyDetails.terms ?? 'Unknown policy terms' };
 	}
 
+	public get apiType(): string {
+		return this.useResponsesApi ? 'responses' : 'chatCompletions';
+	}
+
 	interceptBody(body: IEndpointBody | undefined): void {
 		// Remove tool calls from requests that don't support them
 		// We really shouldn't make requests to models that don't support tool calls with tools though

--- a/src/platform/networking/common/networking.ts
+++ b/src/platform/networking/common/networking.ts
@@ -154,6 +154,7 @@ export interface IChatEndpoint extends IEndpoint {
 	readonly maxOutputTokens: number;
 	/** The model ID- this may change and will be `copilot-base` for the base model. Use `family` to switch behavior based on model type. */
 	readonly model: string;
+	readonly apiType?: string;
 	readonly supportsToolCalls: boolean;
 	readonly supportsVision: boolean;
 	readonly supportsPrediction: boolean;


### PR DESCRIPTION
Introduce a flag in telemetry to differentiate between responses and completions API, enhancing tracking capabilities. 