### PR TITLE
add sku data to github telemetry

### DIFF
--- a/src/platform/telemetry/common/baseTelemetryService.ts
+++ b/src/platform/telemetry/common/baseTelemetryService.ts
@@ -62,7 +62,13 @@ export class BaseTelemetryService implements ITelemetryService {
 	}
 
 	sendGHTelemetryEvent(eventName: string, properties?: TelemetryEventProperties | undefined, measurements?: TelemetryEventMeasurements | undefined): void {
-		this.sendTelemetryEvent(eventName, { github: true, microsoft: false }, properties, measurements);
+		// Add SKU to GitHub telemetry events specifically
+		const sku = this._tokenStore.copilotToken?.sku;
+		const enrichedProperties = {
+			...properties,
+			sku: sku ?? ''
+		};
+		this.sendTelemetryEvent(eventName, { github: true, microsoft: false }, enrichedProperties, measurements);
 	}
 
 	sendGHTelemetryErrorEvent(eventName: string, properties?: TelemetryEventProperties | undefined, measurements?: TelemetryEventMeasurements | undefined): void {


### PR DESCRIPTION
Add SKU information to events sent to `copilot_v0_copilot_events` in the hydro telemetry database.