### PR TITLE
Parallelize some of the initial copilot token fetch

### DIFF
--- a/src/platform/authentication/test/node/copilotToken.spec.ts
+++ b/src/platform/authentication/test/node/copilotToken.spec.ts
@@ -73,7 +73,7 @@ describe('Copilot token unit tests', function () {
 		accessor = disposables.add(testingServiceCollection.createTestingAccessor());
 
 		const tokenManager = disposables.add(accessor.get(IInstantiationService).createInstance(RefreshFakeCopilotTokenManager, 1));
-		await tokenManager.authFromGitHubToken('fake-token');
+		await tokenManager.authFromGitHubToken('fake-token', 'fake-user');
 
 		expect(fetcher.requests.size).toBe(2);
 	});
@@ -103,7 +103,7 @@ describe('Copilot token unit tests', function () {
 		testingServiceCollection.define(IFetcherService, fetcher);
 		accessor = disposables.add(testingServiceCollection.createTestingAccessor());
 
-		const tokenManager = accessor.get(IInstantiationService).createInstance(CopilotTokenManagerFromGitHubToken, 'invalid');
+		const tokenManager = accessor.get(IInstantiationService).createInstance(CopilotTokenManagerFromGitHubToken, 'invalid', 'invalid-user');
 		const result = await tokenManager.checkCopilotToken();
 		expect(result).toEqual({
 			kind: 'failure',
@@ -121,7 +121,7 @@ describe('Copilot token unit tests', function () {
 		testingServiceCollection.define(IFetcherService, new ErrorFetcherService(expectedError));
 		accessor = disposables.add(testingServiceCollection.createTestingAccessor());
 
-		const tokenManager = accessor.get(IInstantiationService).createInstance(CopilotTokenManagerFromGitHubToken, 'invalid');
+		const tokenManager = accessor.get(IInstantiationService).createInstance(CopilotTokenManagerFromGitHubToken, 'invalid', 'invalid-user');
 		try {
 			await tokenManager.checkCopilotToken();
 		} catch (err: any) {
@@ -172,7 +172,7 @@ describe('Copilot token unit tests', function () {
 		accessor = disposables.add(testingServiceCollection.createTestingAccessor());
 
 		const tokenManager = disposables.add(accessor.get(IInstantiationService).createInstance(RefreshFakeCopilotTokenManager, 1));
-		await tokenManager.authFromGitHubToken('fake-token');
+		await tokenManager.authFromGitHubToken('fake-token', 'invalid-user');
 
 		expect(fetcher.requests.size).toBe(2);
 	});

--- a/src/platform/authentication/vscode-node/copilotTokenManager.ts
+++ b/src/platform/authentication/vscode-node/copilotTokenManager.ts
@@ -66,7 +66,7 @@ export class VSCodeCopilotTokenManager extends BaseCopilotTokenManager {
 		}
 		// Log the steps by default, but only log actual token values when the log level is set to debug.
 		this._logService.info(`Logged in as ${session.account.label}`);
-		const tokenResult = await this.authFromGitHubToken(session.accessToken);
+		const tokenResult = await this.authFromGitHubToken(session.accessToken, session.account.label);
 		if (tokenResult.kind === 'success') {
 			this._logService.info(`Got Copilot token for ${session.account.label}`);
 		}


### PR DESCRIPTION
This is a good start to speeding up the time to model list resolution.

I see it go from ~1000ms to 600ms with just this change. We parallelize the copilot info request and remove the request for the username as that is already present on the auth session received from VS Code