### PR TITLE
Add execute_prompt and execute_task tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,26 @@
 				}
 			},
 			{
+				"name": "execute_prompt",
+				"toolReferenceName": "executePrompt",
+				"displayName": "Execute Prompt File",
+				"canBeReferencedInPrompt": true,
+				"modelDescription": "Use a separate agent loop to execute a user's chat prompt file. Provide a file path; the file contents will be treated as the user's chat message and run with full tool access and conversation history.",
+				"tags": [],
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"filePath": {
+							"type": "string",
+							"description": "Absolute path to the prompt file to execute."
+						}
+					},
+					"required": [
+						"filePath"
+					]
+				}
+			},
+			{
 				"name": "copilot_searchWorkspaceSymbols",
 				"toolReferenceName": "symbols",
 				"displayName": "%copilot.tools.searchWorkspaceSymbols.name%",

--- a/package.json
+++ b/package.json
@@ -164,18 +164,45 @@
 				}
 			},
 			{
+				"name": "execute_task",
+				"toolReferenceName": "executeTask",
+				"displayName": "Execute Task",
+				"when": "config.github.copilot.chat.advanced.taskTools.enabled",
+				"canBeReferencedInPrompt": true,
+				"modelDescription": "Launch a new agent to handle complex, multi-step tasks autonomously. This tool is good at researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries, use this agent to perform the search for you.\n\n- When the agent is done, it will return a single message back to you. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result.\n - Each agent invocation is stateless. You will not be able to send additional messages to the agent, nor will the agent be able to communicate with you outside of its final report. Therefore, your prompt should contain a highly detailed task description for the agent to perform autonomously and you should specify exactly what information the agent should return back to you in its final and only message to you.\n - The agent's outputs should generally be trusted\n - Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user's intent",
+				"tags": [],
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"prompt": {
+							"type": "string",
+							"description": "A detailed description of the task for the agent to perform"
+						},
+						"description": {
+							"type": "string",
+							"description": "A short (3-5 word) description of the task"
+						}
+					},
+					"required": [
+						"prompt",
+						"description"
+					]
+				}
+			},
+			{
 				"name": "execute_prompt",
 				"toolReferenceName": "executePrompt",
-				"displayName": "Execute Prompt File",
+				"displayName": "Execute Prompt",
+				"when": "config.github.copilot.chat.advanced.taskTools.enabled",
 				"canBeReferencedInPrompt": true,
-				"modelDescription": "Use a separate agent loop to execute a user's chat prompt file. Provide a file path; the file contents will be treated as the user's chat message and run with full tool access and conversation history.",
+				"modelDescription": "This tool can take a path to a user's prompt file as input, and execute it autonomously. If the user's prompt includes multiple references to .prompt.md files, then you should use this tool to execute those prompts in sequence.\n\n- When the agent is done, it will return a single message back to you. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result.\n - The agent's outputs should generally be trusted",
 				"tags": [],
 				"inputSchema": {
 					"type": "object",
 					"properties": {
 						"filePath": {
 							"type": "string",
-							"description": "Absolute path to the prompt file to execute."
+							"description": "The absolute path to the prompt file to execute"
 						}
 					},
 					"required": [

--- a/src/extension/intents/node/agentIntent.ts
+++ b/src/extension/intents/node/agentIntent.ts
@@ -49,7 +49,7 @@ import { addCacheBreakpoints } from './cacheBreakpoints';
 import { EditCodeIntent, EditCodeIntentInvocation, EditCodeIntentInvocationOptions, mergeMetadata, toNewChatReferences } from './editCodeIntent';
 import { getRequestedToolCallIterationLimit, IContinueOnErrorConfirmation } from './toolCallingLoop';
 
-const getTools = (instaService: IInstantiationService, request: vscode.ChatRequest) =>
+export const getAgentTools = (instaService: IInstantiationService, request: vscode.ChatRequest) =>
 	instaService.invokeFunction(async accessor => {
 		const toolsService = accessor.get<IToolsService>(IToolsService);
 		const testService = accessor.get<ITestProvider>(ITestProvider);
@@ -144,7 +144,7 @@ export class AgentIntent extends EditCodeIntent {
 	}
 
 	private async listTools(conversation: Conversation, request: vscode.ChatRequest, stream: vscode.ChatResponseStream, token: CancellationToken) {
-		const editingTools = await getTools(this.instantiationService, request);
+		const editingTools = await getAgentTools(this.instantiationService, request);
 		const grouping = this._toolGroupingService.create(conversation.sessionId, editingTools);
 		if (!grouping.isEnabled) {
 			stream.markdown(`Available tools: \n${editingTools.map(tool => `- ${tool.name}`).join('\n')}\n`);
@@ -226,7 +226,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation {
 	}
 
 	public override getAvailableTools(): Promise<vscode.LanguageModelToolInformation[]> {
-		return getTools(this.instantiationService, this.request);
+		return getAgentTools(this.instantiationService, this.request);
 	}
 
 	override async buildPrompt(

--- a/src/extension/prompt/node/executePromptToolCalling.ts
+++ b/src/extension/prompt/node/executePromptToolCalling.ts
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { randomUUID } from 'crypto';
+import type { CancellationToken, ChatRequest, LanguageModelToolInformation, Progress } from 'vscode';
+import { IAuthenticationChatUpgradeService } from '../../../platform/authentication/common/authenticationUpgrade';
+import { ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';
+import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { ILogService } from '../../../platform/log/common/logService';
+import { IRequestLogger } from '../../../platform/requestLogger/node/requestLogger';
+import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
+import { IThinkingDataService } from '../../../platform/thinking/node/thinkingDataService';
+import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { ChatResponseProgressPart, ChatResponseReferencePart } from '../../../vscodeTypes';
+import { IToolCallingLoopOptions, ToolCallingLoop, ToolCallingLoopFetchOptions } from '../../intents/node/toolCallingLoop';
+import { AgentPrompt } from '../../prompts/node/agent/agentPrompt';
+import { PromptRenderer } from '../../prompts/node/base/promptRenderer';
+import { ToolName } from '../../tools/common/toolNames';
+import { IToolsService } from '../../tools/common/toolsService';
+import { IBuildPromptContext } from '../common/intents';
+import { IBuildPromptResult } from './intents';
+
+export interface IExecutePromptToolCallingLoopOptions extends IToolCallingLoopOptions {
+	request: ChatRequest;
+	location: ChatLocation;
+	promptText: string;
+}
+
+export class ExecutePromptToolCallingLoop extends ToolCallingLoop<IExecutePromptToolCallingLoopOptions> {
+
+	public static readonly ID = 'executePromptTool';
+
+	constructor(
+		options: IExecutePromptToolCallingLoopOptions,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@ILogService logService: ILogService,
+		@IRequestLogger requestLogger: IRequestLogger,
+		@IEndpointProvider private readonly endpointProvider: IEndpointProvider,
+		@IToolsService private readonly toolsService: IToolsService,
+		@IAuthenticationChatUpgradeService authenticationChatUpgradeService: IAuthenticationChatUpgradeService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IThinkingDataService thinkingDataService: IThinkingDataService,
+	) {
+		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, thinkingDataService);
+	}
+
+	private async getEndpoint(request: ChatRequest) {
+		let endpoint = await this.endpointProvider.getChatEndpoint(this.options.request);
+		if (!endpoint.supportsToolCalls) {
+			endpoint = await this.endpointProvider.getChatEndpoint('gpt-4.1');
+		}
+		return endpoint;
+	}
+
+	protected async buildPrompt(buildPromptContext: IBuildPromptContext, progress: Progress<ChatResponseReferencePart | ChatResponseProgressPart>, token: CancellationToken): Promise<IBuildPromptResult> {
+		const endpoint = await this.getEndpoint(this.options.request);
+		const promptContext: IBuildPromptContext = {
+			...buildPromptContext,
+			query: this.options.promptText,
+			conversation: undefined
+		};
+		const renderer = PromptRenderer.create(
+			this.instantiationService,
+			endpoint,
+			AgentPrompt,
+			{
+				endpoint,
+				promptContext,
+				location: this.options.location,
+				enableCacheBreakpoints: false,
+			}
+		);
+		return await renderer.render(progress, token);
+	}
+
+	protected async getAvailableTools(): Promise<LanguageModelToolInformation[]> {
+		// Reuse the same set of enabled tools as the main agent loop
+		return this.toolsService.getEnabledTools(this.options.request, tool => {
+			if (tool.name === ToolName.ExecutePrompt) {
+				return false;
+			}
+		});
+	}
+
+	protected async fetch({ messages, finishedCb, requestOptions }: ToolCallingLoopFetchOptions, token: CancellationToken): Promise<ChatResponse> {
+		const endpoint = await this.getEndpoint(this.options.request);
+		return endpoint.makeChatRequest(
+			ExecutePromptToolCallingLoop.ID,
+			messages,
+			finishedCb,
+			token,
+			this.options.location,
+			undefined,
+			{
+				...requestOptions,
+				temperature: 0
+			},
+			// This loop is inside a tool called from another request, so never user initiated
+			false,
+			{
+				messageId: randomUUID(),
+				messageSource: ExecutePromptToolCallingLoop.ID
+			},
+		);
+	}
+}

--- a/src/extension/prompt/node/executePromptToolCalling.ts
+++ b/src/extension/prompt/node/executePromptToolCalling.ts
@@ -11,7 +11,6 @@ import { IEndpointProvider } from '../../../platform/endpoint/common/endpointPro
 import { ILogService } from '../../../platform/log/common/logService';
 import { IRequestLogger } from '../../../platform/requestLogger/node/requestLogger';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
-import { IThinkingDataService } from '../../../platform/thinking/node/thinkingDataService';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { ChatResponseProgressPart, ChatResponseReferencePart } from '../../../vscodeTypes';
 import { IToolCallingLoopOptions, ToolCallingLoop, ToolCallingLoopFetchOptions } from '../../intents/node/toolCallingLoop';
@@ -41,9 +40,8 @@ export class ExecutePromptToolCallingLoop extends ToolCallingLoop<IExecutePrompt
 		@IToolsService private readonly toolsService: IToolsService,
 		@IAuthenticationChatUpgradeService authenticationChatUpgradeService: IAuthenticationChatUpgradeService,
 		@ITelemetryService telemetryService: ITelemetryService,
-		@IThinkingDataService thinkingDataService: IThinkingDataService,
 	) {
-		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, thinkingDataService);
+		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService);
 	}
 
 	private async getEndpoint(request: ChatRequest) {

--- a/src/extension/tools/common/toolNames.ts
+++ b/src/extension/tools/common/toolNames.ts
@@ -8,6 +8,7 @@ import { cloneAndChange } from '../../../util/vs/base/common/objects';
 export enum ToolName {
 	ApplyPatch = 'apply_patch',
 	Codebase = 'semantic_search',
+	ExecutePrompt = 'execute_prompt',
 	VSCodeAPI = 'get_vscode_api',
 	TestFailure = 'test_failure',
 	RunTests = 'run_tests',
@@ -96,6 +97,8 @@ export enum ContributedToolName {
 	RunVscodeCmd = 'copilot_runVscodeCommand',
 	ToolReplay = 'copilot_toolReplay',
 	EditFilesPlaceholder = 'copilot_editFiles'
+	// Use non-reserved name for execute_prompt to satisfy schema validation
+	ExecutePrompt = 'execute_prompt',
 }
 
 const toolNameToContributedToolNames = new Map<ToolName, ContributedToolName>();

--- a/src/extension/tools/common/toolNames.ts
+++ b/src/extension/tools/common/toolNames.ts
@@ -96,7 +96,7 @@ export enum ContributedToolName {
 	CreateDirectory = 'copilot_createDirectory',
 	RunVscodeCmd = 'copilot_runVscodeCommand',
 	ToolReplay = 'copilot_toolReplay',
-	EditFilesPlaceholder = 'copilot_editFiles'
+	EditFilesPlaceholder = 'copilot_editFiles',
 	// Use non-reserved name for execute_prompt to satisfy schema validation
 	ExecutePrompt = 'execute_prompt',
 }

--- a/src/extension/tools/common/toolNames.ts
+++ b/src/extension/tools/common/toolNames.ts
@@ -8,7 +8,6 @@ import { cloneAndChange } from '../../../util/vs/base/common/objects';
 export enum ToolName {
 	ApplyPatch = 'apply_patch',
 	Codebase = 'semantic_search',
-	ExecutePrompt = 'execute_prompt',
 	VSCodeAPI = 'get_vscode_api',
 	TestFailure = 'test_failure',
 	RunTests = 'run_tests',
@@ -53,7 +52,9 @@ export enum ToolName {
 	CoreGetTaskOutput = 'get_task_output',
 	CoreRunTest = 'runTests',
 	ToolReplay = 'tool_replay',
-	EditFilesPlaceholder = 'edit_files'
+	EditFilesPlaceholder = 'edit_files',
+	ExecutePrompt = 'execute_prompt',
+	ExecuteTask = 'execute_task',
 }
 
 export enum ContributedToolName {
@@ -97,8 +98,8 @@ export enum ContributedToolName {
 	RunVscodeCmd = 'copilot_runVscodeCommand',
 	ToolReplay = 'copilot_toolReplay',
 	EditFilesPlaceholder = 'copilot_editFiles',
-	// Use non-reserved name for execute_prompt to satisfy schema validation
 	ExecutePrompt = 'execute_prompt',
+	ExecuteTask = 'execute_task',
 }
 
 const toolNameToContributedToolNames = new Map<ToolName, ContributedToolName>();

--- a/src/extension/tools/node/allTools.ts
+++ b/src/extension/tools/node/allTools.ts
@@ -9,6 +9,7 @@ import './createDirectoryTool';
 import './createFileTool';
 import './docTool';
 import './editNotebookTool';
+import './executePromptTool';
 import './findFilesTool';
 import './findTestsFilesTool';
 import './findTextInFilesTool';
@@ -38,4 +39,3 @@ import './userPreferencesTool';
 import './vscodeAPITool';
 import './vscodeCmdTool';
 import './toolReplayTool';
-

--- a/src/extension/tools/node/allTools.ts
+++ b/src/extension/tools/node/allTools.ts
@@ -10,6 +10,7 @@ import './createFileTool';
 import './docTool';
 import './editNotebookTool';
 import './executePromptTool';
+import './executeTaskTool';
 import './findFilesTool';
 import './findTestsFilesTool';
 import './findTextInFilesTool';

--- a/src/extension/tools/node/executePromptTool.tsx
+++ b/src/extension/tools/node/executePromptTool.tsx
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as l10n from '@vscode/l10n';
+import type * as vscode from 'vscode';
+import { IPromptPathRepresentationService } from '../../../platform/prompts/common/promptPathRepresentationService';
+import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
+import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { ExtendedLanguageModelToolResult, LanguageModelTextPart, MarkdownString } from '../../../vscodeTypes';
+import { IBuildPromptContext } from '../../prompt/common/intents';
+import { ExecutePromptToolCallingLoop } from '../../prompt/node/executePromptToolCalling';
+import { ToolName } from '../common/toolNames';
+import { CopilotToolMode, ICopilotTool, ToolRegistry } from '../common/toolsRegistry';
+import { assertFileOkForTool, formatUriForFileWidget, resolveToolInputPath } from './toolUtils';
+
+export interface IExecutePromptParams {
+	filePath: string;
+}
+
+class ExecutePromptTool implements ICopilotTool<IExecutePromptParams> {
+	public static readonly toolName = ToolName.ExecutePrompt;
+	private _inputContext: IBuildPromptContext | undefined;
+
+	constructor(
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IWorkspaceService private readonly workspaceService: IWorkspaceService,
+		@IPromptPathRepresentationService private readonly promptPathRepresentationService: IPromptPathRepresentationService,
+	) { }
+
+	async invoke(options: vscode.LanguageModelToolInvocationOptions<IExecutePromptParams>, token: vscode.CancellationToken) {
+		if (!options.input.filePath) {
+			throw new Error('Invalid input');
+		}
+
+		// Read the prompt file as text and include a reference
+		const uri = resolveToolInputPath(options.input.filePath, this.promptPathRepresentationService);
+		await this.instantiationService.invokeFunction(accessor => assertFileOkForTool(accessor, uri));
+		const doc = await this.workspaceService.openTextDocument(uri);
+		const promptText = doc.getText();
+
+		const loop = this.instantiationService.createInstance(ExecutePromptToolCallingLoop, {
+			toolCallLimit: 5,
+			conversation: this._inputContext!.conversation!,
+			request: this._inputContext!.request!,
+			location: this._inputContext!.request!.location,
+			promptText,
+		});
+
+		const loopResult = await loop.run(this._inputContext?.stream, token);
+		// Return the text of the last assistant response from the tool calling loop
+		const lastRoundResponse = loopResult.toolCallRounds.at(-1)?.response ?? loopResult.round.response ?? '';
+		const result = new ExtendedLanguageModelToolResult([new LanguageModelTextPart(lastRoundResponse)]);
+		return result;
+	}
+
+	prepareInvocation(options: vscode.LanguageModelToolInvocationPrepareOptions<IExecutePromptParams>, token: vscode.CancellationToken): vscode.ProviderResult<vscode.PreparedToolInvocation> {
+		const { input } = options;
+		if (!input.filePath) {
+			return;
+		}
+		try {
+			const uri = resolveToolInputPath(input.filePath, this.promptPathRepresentationService);
+			return {
+				invocationMessage: new MarkdownString(l10n.t`Executing prompt file ${formatUriForFileWidget(uri)}`),
+				pastTenseMessage: new MarkdownString(l10n.t`Executed prompt file ${formatUriForFileWidget(uri)}`),
+			};
+		} catch {
+			return;
+		}
+	}
+
+	async resolveInput(input: IExecutePromptParams, promptContext: IBuildPromptContext, mode: CopilotToolMode): Promise<IExecutePromptParams> {
+		this._inputContext = promptContext;
+		return input;
+	}
+}
+
+ToolRegistry.registerTool(ExecutePromptTool);

--- a/src/extension/tools/node/executePromptTool.tsx
+++ b/src/extension/tools/node/executePromptTool.tsx
@@ -5,8 +5,8 @@
 
 import * as l10n from '@vscode/l10n';
 import type * as vscode from 'vscode';
+import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
 import { IPromptPathRepresentationService } from '../../../platform/prompts/common/promptPathRepresentationService';
-import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { ExtendedLanguageModelToolResult, LanguageModelTextPart, MarkdownString } from '../../../vscodeTypes';
 import { IBuildPromptContext } from '../../prompt/common/intents';
@@ -25,7 +25,7 @@ class ExecutePromptTool implements ICopilotTool<IExecutePromptParams> {
 
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IWorkspaceService private readonly workspaceService: IWorkspaceService,
+		@IFileSystemService private readonly fileSystemService: IFileSystemService,
 		@IPromptPathRepresentationService private readonly promptPathRepresentationService: IPromptPathRepresentationService,
 	) { }
 
@@ -37,8 +37,7 @@ class ExecutePromptTool implements ICopilotTool<IExecutePromptParams> {
 		// Read the prompt file as text and include a reference
 		const uri = resolveToolInputPath(options.input.filePath, this.promptPathRepresentationService);
 		await this.instantiationService.invokeFunction(accessor => assertFileOkForTool(accessor, uri));
-		const doc = await this.workspaceService.openTextDocument(uri);
-		const promptText = doc.getText();
+		const promptText = (await this.fileSystemService.readFile(uri)).toString();
 
 		const loop = this.instantiationService.createInstance(ExecutePromptToolCallingLoop, {
 			toolCallLimit: 5,

--- a/src/extension/tools/node/executeTaskTool.ts
+++ b/src/extension/tools/node/executeTaskTool.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as vscode from 'vscode';
+import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { ChatResponseMarkdownPart, ExtendedLanguageModelToolResult, LanguageModelTextPart } from '../../../vscodeTypes';
+import { Conversation, Turn } from '../../prompt/common/conversation';
+import { IBuildPromptContext } from '../../prompt/common/intents';
+import { ExecutePromptToolCallingLoop } from '../../prompt/node/executePromptToolCalling';
+import { ToolName } from '../common/toolNames';
+import { CopilotToolMode, ICopilotTool, ToolRegistry } from '../common/toolsRegistry';
+import { ChatResponseStreamImpl } from '../../../util/common/chatResponseStreamImpl';
+
+export interface IExecuteTaskParams {
+	prompt: string;
+	description: string;
+}
+
+class ExecuteTaskTool implements ICopilotTool<IExecuteTaskParams> {
+	public static readonly toolName = ToolName.ExecuteTask;
+	private _inputContext: IBuildPromptContext | undefined;
+
+	constructor(
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+	) { }
+
+	async invoke(options: vscode.LanguageModelToolInvocationOptions<IExecuteTaskParams>, token: vscode.CancellationToken) {
+
+		const loop = this.instantiationService.createInstance(ExecutePromptToolCallingLoop, {
+			toolCallLimit: 25,
+			conversation: new Conversation('', [new Turn('', { type: 'user', message: options.input.prompt })]),
+			request: this._inputContext!.request!,
+			location: this._inputContext!.request!.location,
+			promptText: options.input.prompt,
+		});
+
+		// TODO This also prevents codeblock pills from being rendered
+		// I want to render this content as thinking blocks but couldn't get it to work
+		const stream = this._inputContext?.stream && ChatResponseStreamImpl.filter(
+			this._inputContext.stream,
+			part => !(part instanceof ChatResponseMarkdownPart)
+		);
+
+		const loopResult = await loop.run(stream, token);
+		// Return the text of the last assistant response from the tool calling loop
+		const lastRoundResponse = loopResult.toolCallRounds.at(-1)?.response ?? loopResult.round.response ?? '';
+		const result = new ExtendedLanguageModelToolResult([new LanguageModelTextPart(lastRoundResponse)]);
+		return result;
+	}
+
+	prepareInvocation(options: vscode.LanguageModelToolInvocationPrepareOptions<IExecuteTaskParams>, token: vscode.CancellationToken): vscode.ProviderResult<vscode.PreparedToolInvocation> {
+		const { input } = options;
+		try {
+			return {
+				invocationMessage: input.description,
+			};
+		} catch {
+			return;
+		}
+	}
+
+	async resolveInput(input: IExecuteTaskParams, promptContext: IBuildPromptContext, mode: CopilotToolMode): Promise<IExecuteTaskParams> {
+		this._inputContext = promptContext;
+		return input;
+	}
+}
+
+ToolRegistry.registerTool(ExecuteTaskTool);

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -730,6 +730,7 @@ export namespace ConfigKey {
 
 		export const EnableClaudeCodeAgent = defineSetting<boolean | string | undefined>('chat.advanced.claudeCode.enabled', false, INTERNAL);
 		export const ClaudeCodeDebugEnabled = defineSetting<boolean>('chat.advanced.claudeCode.debug', false, INTERNAL);
+		export const TaskToolsEnabled = defineSetting<boolean>('chat.advanced.taskTools.enabled', true);
 	}
 
 	export const AgentThinkingTool = defineSetting<boolean>('chat.agent.thinkingTool', false);

--- a/src/util/common/chatResponseStreamImpl.ts
+++ b/src/util/common/chatResponseStreamImpl.ts
@@ -51,6 +51,20 @@ export class ChatResponseStreamImpl implements FinalizableChatResponseStream {
 		});
 	}
 
+	public static map(stream: ChatResponseStream, callback: (part: ExtendedChatResponsePart) => ExtendedChatResponsePart | undefined, finalize?: () => void): ChatResponseStreamImpl {
+		return new ChatResponseStreamImpl((value) => {
+			const result = callback(value);
+			if (result) {
+				stream.push(result);
+			}
+		}, (reason) => {
+			stream.clearToPreviousToolInvocation(reason);
+		}, () => {
+			finalize?.();
+			return tryFinalizeResponseStream(stream);
+		});
+	}
+
 	constructor(
 		private readonly _push: (part: ExtendedChatResponsePart) => void,
 		private readonly _clearToPreviousToolInvocation: (reason: ChatResponseClearToPreviousToolInvocationReason) => void,


### PR DESCRIPTION
Introduce two new tools, `execute_prompt` and `execute_task`, to facilitate better planning and task execution in the AI development workflow. These tools enable users to execute prompts and manage complex, multi-step tasks autonomously. 

Towards microsoft/vscode#263917