### PR TITLE
Adjust token usage for context window size and clean up types

### DIFF
--- a/src/extension/agents/vscode-node/adapters/anthropicAdapter.ts
+++ b/src/extension/agents/vscode-node/adapters/anthropicAdapter.ts
@@ -226,7 +226,7 @@ class AnthropicAdapter implements IProtocolAdapter {
 		}
 
 		// If we don't have endpoint info, return the unadjusted usage
-		if (!context.endpoint || context.modelId === 'gpt-4o-mini') {
+		if (context.endpoint.modelId === 'gpt-4o-mini') {
 			return usage;
 		}
 
@@ -261,7 +261,7 @@ class AnthropicAdapter implements IProtocolAdapter {
 				id: context.requestId,
 				type: 'message',
 				role: 'assistant',
-				model: context.modelId,
+				model: context.endpoint.modelId,
 				content: [],
 				stop_reason: null,
 				stop_sequence: null,

--- a/src/extension/agents/vscode-node/adapters/types.ts
+++ b/src/extension/agents/vscode-node/adapters/types.ts
@@ -78,8 +78,8 @@ export interface IProtocolAdapterFactory {
 
 export interface IStreamingContext {
 	requestId: string;
-	modelId: string;
-	endpoint?: {
+	endpoint: {
+		modelId: string;
 		modelMaxPromptTokens: number;
 	};
 }

--- a/src/extension/agents/vscode-node/langModelServer.ts
+++ b/src/extension/agents/vscode-node/langModelServer.ts
@@ -162,8 +162,8 @@ export class LanguageModelServer {
 				// Create streaming context with only essential shared data
 				const context: IStreamingContext = {
 					requestId: `req_${Math.random().toString(36).substr(2, 20)}`,
-					modelId: selectedEndpoint.model,
 					endpoint: {
+						modelId: selectedEndpoint.model,
 						modelMaxPromptTokens: selectedEndpoint.modelMaxPromptTokens
 					}
 				};


### PR DESCRIPTION
Claude code assumes it has 200k context window, this is smaller than what we actually have, so scale the reported token usage so that auto-compact will trigger properly