### PR TITLE
Support related extensions filters and completions experiment flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"version": "0.31.0",
 	"build": "1",
 	"internalAIKey": "1058ec22-3c95-4951-8443-f26c1f325911",
-	"completionsCore": "0b22c32a66a5941f625ad16fa2ab00bf30916703",
+	"completionsCore": "ce32ae8eff163a71f510c813d5885591ced877dc",
 	"completionsCoreVersion": "1.363.1764",
 	"internalLargeStorageAriaKey": "ec712b3202c5462fb6877acae7f1f9d7-c19ad55e-3e3c-4f99-984b-827f6d95bd9e-6917",
 	"ariaKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",

--- a/src/extension/completions/vscode-node/completionsCoreContribution.ts.txt
+++ b/src/extension/completions/vscode-node/completionsCoreContribution.ts.txt
@@ -27,6 +27,7 @@ export class CompletionsCoreContribution extends Disposable {
 			const ctx = instantiationService.invokeFunction(createContext);
 			reader.store.add(setup(ctx));
 			const provider = new CopilotInlineCompletionItemProvider(ctx);
+			reader.store.add(provider);
 			reader.store.add(languages.registerInlineCompletionItemProvider({ pattern: '**' }, provider, { debounceDelayMs: 0, excludes: ['github.copilot'], groupId: 'completions' }));
 		}));
 	}

--- a/src/platform/telemetry/common/nullExperimentationService.ts
+++ b/src/platform/telemetry/common/nullExperimentationService.ts
@@ -46,6 +46,13 @@ export interface IExperimentationService {
 	 * @param name name of the treatment variable.
 	 */
 	getTreatmentVariable<T extends boolean | number | string>(name: string): T | undefined;
+
+	/**
+	 * Sets the filters for the completions experiments.
+	 * @param filters Map of filter names to their values.
+	 * @deprecated This will be removed once we have fully migrated to the new completions implementation.
+	 */
+	setCompletionsFilters(filters: Map<string, string>): void;
 }
 
 export const IExperimentationService = createServiceIdentifier<IExperimentationService>('IExperimentationService');
@@ -61,4 +68,6 @@ export class NullExperimentationService implements IExperimentationService {
 	getTreatmentVariable<T extends boolean | number | string>(_name: string): T | undefined {
 		return undefined;
 	}
+
+	async setCompletionsFilters(filters: Map<string, string>): Promise<void> { }
 }

--- a/src/platform/telemetry/node/baseExperimentationService.ts
+++ b/src/platform/telemetry/node/baseExperimentationService.ts
@@ -147,4 +147,39 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 		this._previouslyReadTreatments.set(name, result);
 		return result;
 	}
+
+	// Note: This is only temporarily until we have fully migrated to the new completions implementation.
+	// At that point, we can remove this method and the related code.
+	private _completionsFilters: Map<string, string> = new Map<string, string>();
+	async setCompletionsFilters(filters: Map<string, string>): Promise<void> {
+		if (equalMap(this._completionsFilters, filters)) {
+			return;
+		}
+
+		this._completionsFilters.clear();
+		for (const [key, value] of filters) {
+			this._completionsFilters.set(key, value);
+		}
+
+		await this._delegate.initialFetch;
+		await this._delegate.getTreatmentVariableAsync('vscode', 'refresh');
+	}
+
+	protected getCompletionsFilters(): Map<string, string> {
+		return this._completionsFilters;
+	}
+}
+
+function equalMap(map1: Map<string, string>, map2: Map<string, string>): boolean {
+	if (map1.size !== map2.size) {
+		return false;
+	}
+
+	for (const [key, value] of map1) {
+		if (map2.get(key) !== value) {
+			return false;
+		}
+	}
+
+	return true;
 }

--- a/src/platform/telemetry/vscode-node/microsoftExperimentationService.ts
+++ b/src/platform/telemetry/vscode-node/microsoftExperimentationService.ts
@@ -22,6 +22,72 @@ function getTargetPopulation(isPreRelease: boolean): TargetPopulation {
 	return TargetPopulation.Public;
 }
 
+function trimVersionSuffix(version: string): string {
+	return version.split('-')[0];
+}
+
+const CopilotRelatedPluginVersionPrefix = 'X-Copilot-RelatedPluginVersion-';
+
+export enum RelatedExtensionsFilter {
+	CopilotRelatedPluginVersionCppTools = CopilotRelatedPluginVersionPrefix + 'msvscodecpptools',
+	CopilotRelatedPluginVersionCMakeTools = CopilotRelatedPluginVersionPrefix + 'msvscodecmaketools',
+	CopilotRelatedPluginVersionMakefileTools = CopilotRelatedPluginVersionPrefix + 'msvscodemakefiletools',
+	CopilotRelatedPluginVersionCSharpDevKit = CopilotRelatedPluginVersionPrefix + 'msdotnettoolscsdevkit',
+	CopilotRelatedPluginVersionPython = CopilotRelatedPluginVersionPrefix + 'mspythonpython',
+	CopilotRelatedPluginVersionPylance = CopilotRelatedPluginVersionPrefix + 'mspythonvscodepylance',
+	CopilotRelatedPluginVersionJavaPack = CopilotRelatedPluginVersionPrefix + 'vscjavavscodejavapack',
+	CopilotRelatedPluginVersionTypescript = CopilotRelatedPluginVersionPrefix + 'vscodetypescriptlanguagefeatures',
+	CopilotRelatedPluginVersionTypescriptNext = CopilotRelatedPluginVersionPrefix + 'msvscodevscodetypescriptnext',
+	CopilotRelatedPluginVersionCSharp = CopilotRelatedPluginVersionPrefix + 'msdotnettoolscsharp',
+	// Copilot related plugins
+	CopilotRelatedPluginVersionCopilot = CopilotRelatedPluginVersionPrefix + 'githubcopilot',
+	CopilotRelatedPluginVersionCopilotChat = CopilotRelatedPluginVersionPrefix + 'githubcopilotchat',
+}
+
+class RelatedExtensionsFilterProvider implements IExperimentationFilterProvider {
+	constructor(private _logService: ILogService) { }
+
+	private _getRelatedExtensions(): { name: string; version: string }[] {
+		return [
+			'ms-vscode.cpptools',
+			'ms-vscode.cmake-tools',
+			'ms-vscode.makefile-tools',
+			'ms-dotnettools.csdevkit',
+			'ms-python.python',
+			'ms-python.vscode-pylance',
+			'vscjava.vscode-java-pack',
+			'vscode.typescript-language-features',
+			'ms-vscode.vscode-typescript-next',
+			'ms-dotnettools.csharp',
+		]
+			.map(name => {
+				const extpj = vscode.extensions.getExtension(name)?.packageJSON as unknown;
+				if (extpj && typeof extpj === 'object' && 'version' in extpj && typeof extpj.version === 'string') {
+					return { name, version: extpj.version };
+				}
+			})
+			.filter(plugin => plugin !== undefined);
+	}
+
+	getFilters(): Map<string, any> {
+		this._logService.trace(`[RelatedExtensionsFilterProvider]::getFilters looking up related extensions`);
+		const filters = new Map<string, any>();
+
+		for (const extension of this._getRelatedExtensions()) {
+			const filterName = CopilotRelatedPluginVersionPrefix + extension.name.replace(/[^A-Za-z]/g, '').toLowerCase();
+			if (!Object.values<string>(RelatedExtensionsFilter).includes(filterName)) {
+				this._logService.warn(`[RelatedExtensionsFilterProvider]::getFilters A filter could not be registered for the unrecognized related plugin "${extension.name}".`);
+				continue;
+			}
+			filters.set(filterName, trimVersionSuffix(extension.version));
+		}
+
+		this._logService.trace(`[RelatedExtensionsFilterProvider]::getFilters Filters: ${JSON.stringify(Array.from(filters.entries()))}`);
+
+		return filters;
+	}
+}
+
 class CopilotExtensionsFilterProvider implements IExperimentationFilterProvider {
 	constructor(private _logService: ILogService) { }
 
@@ -32,8 +98,8 @@ class CopilotExtensionsFilterProvider implements IExperimentationFilterProvider 
 
 		this._logService.trace(`[CopilotExtensionsFilterProvider]::getFilters Copilot Extension Version: ${copilotExtensionversion}, Copilot Chat Extension Version: ${copilotChatExtensionVersion}, Completions Core Version: ${completionsCoreVersion}`);
 		const filters = new Map<string, any>();
-		filters.set('X-Copilot-RelatedPluginVersion-githubcopilot', copilotExtensionversion);
-		filters.set('X-Copilot-RelatedPluginVersion-githubcopilotchat', copilotChatExtensionVersion);
+		filters.set(RelatedExtensionsFilter.CopilotRelatedPluginVersionCopilot, copilotExtensionversion);
+		filters.set(RelatedExtensionsFilter.CopilotRelatedPluginVersionCopilotChat, copilotChatExtensionVersion);
 		filters.set('X-VSCode-CompletionsInChatExtensionVersion', completionsCoreVersion);
 		return filters;
 	}
@@ -66,7 +132,7 @@ export class MicrosoftExperimentationService extends BaseExperimentationService 
 		const version = context.extension.packageJSON['version'];
 		const targetPopulation = getTargetPopulation(envService.isPreRelease());
 		const delegateFn = (globalState: any, userInfoStore: UserInfoStore) => {
-			return getExperimentationService(id, version, targetPopulation, telemetryService, globalState, new GithubAccountFilterProvider(userInfoStore, logService), new CopilotExtensionsFilterProvider(logService));
+			return getExperimentationService(id, version, targetPopulation, telemetryService, globalState, new GithubAccountFilterProvider(userInfoStore, logService), new RelatedExtensionsFilterProvider(logService), new CopilotExtensionsFilterProvider(logService));
 		};
 
 		super(delegateFn, context, copilotTokenStore, configurationService, logService);

--- a/src/platform/telemetry/vscode-node/microsoftExperimentationService.ts
+++ b/src/platform/telemetry/vscode-node/microsoftExperimentationService.ts
@@ -105,6 +105,19 @@ class CopilotExtensionsFilterProvider implements IExperimentationFilterProvider 
 	}
 }
 
+class CopilotCompletionsFilterProvider implements IExperimentationFilterProvider {
+	constructor(private _getCompletionsFilters: () => Map<string, string>, private _logService: ILogService) { }
+
+	getFilters(): Map<string, any> {
+		const filters = new Map<string, any>();
+		for (const [key, value] of this._getCompletionsFilters()) {
+			filters.set(key, value);
+		}
+		this._logService.trace(`[CopilotCompletionsFilterProvider]::getFilters Filters: ${JSON.stringify(Array.from(filters.entries()))}`);
+		return filters;
+	}
+}
+
 class GithubAccountFilterProvider implements IExperimentationFilterProvider {
 	constructor(private _userInfoStore: UserInfoStore, private _logService: ILogService) { }
 
@@ -132,7 +145,7 @@ export class MicrosoftExperimentationService extends BaseExperimentationService 
 		const version = context.extension.packageJSON['version'];
 		const targetPopulation = getTargetPopulation(envService.isPreRelease());
 		const delegateFn = (globalState: any, userInfoStore: UserInfoStore) => {
-			return getExperimentationService(id, version, targetPopulation, telemetryService, globalState, new GithubAccountFilterProvider(userInfoStore, logService), new RelatedExtensionsFilterProvider(logService), new CopilotExtensionsFilterProvider(logService));
+			return getExperimentationService(id, version, targetPopulation, telemetryService, globalState, new GithubAccountFilterProvider(userInfoStore, logService), new RelatedExtensionsFilterProvider(logService), new CopilotExtensionsFilterProvider(logService), new CopilotCompletionsFilterProvider(() => this.getCompletionsFilters(), logService));
 		};
 
 		super(delegateFn, context, copilotTokenStore, configurationService, logService);


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce filters for related extensions and support for completions experiment flags. Update the completions port to accommodate these changes.

related https://github.com/microsoft/vscode-internalbacklog/issues/5806