### PR TITLE
edits: adjust confirmations for system files and outside the workspace

### DIFF
--- a/src/extension/tools/node/abstractReplaceStringTool.tsx
+++ b/src/extension/tools/node/abstractReplaceStringTool.tsx
@@ -37,7 +37,7 @@ import { CorrectedEditResult, healReplaceStringParams } from './editFileHealing'
 import { EditFileResult, IEditedFile } from './editFileToolResult';
 import { EditError, NoChangeError, NoMatchError, applyEdit, createEditConfirmation } from './editFileToolUtils';
 import { sendEditNotebookTelemetry } from './editNotebookTool';
-import { assertFileOkForTool, resolveToolInputPath } from './toolUtils';
+import { assertFileNotContentExcluded, resolveToolInputPath } from './toolUtils';
 
 export interface IAbstractReplaceStringInput {
 	filePath: string;
@@ -83,7 +83,7 @@ export abstract class AbstractReplaceStringTool<T extends { explanation: string 
 	protected async prepareEditsForFile(options: vscode.LanguageModelToolInvocationOptions<T>, input: IAbstractReplaceStringInput, token: vscode.CancellationToken): Promise<IPrepareEdit> {
 		const uri = resolveToolInputPath(input.filePath, this.promptPathRepresentationService);
 		try {
-			await this.instantiationService.invokeFunction(accessor => assertFileOkForTool(accessor, uri));
+			await this.instantiationService.invokeFunction(accessor => assertFileNotContentExcluded(accessor, uri));
 		} catch (error) {
 			this.sendReplaceTelemetry('invalidFile', options, input, undefined, undefined, undefined);
 			throw error;

--- a/src/extension/tools/node/applyPatchTool.tsx
+++ b/src/extension/tools/node/applyPatchTool.tsx
@@ -45,7 +45,7 @@ import { ActionType, Commit, DiffError, FileChange, identify_files_needed, Inval
 import { EditFileResult, IEditedFile } from './editFileToolResult';
 import { createEditConfirmation } from './editFileToolUtils';
 import { sendEditNotebookTelemetry } from './editNotebookTool';
-import { assertFileOkForTool, resolveToolInputPath } from './toolUtils';
+import { assertFileNotContentExcluded, resolveToolInputPath } from './toolUtils';
 
 export interface IApplyPatchToolParams {
 	input: string;
@@ -244,7 +244,7 @@ export class ApplyPatchTool implements ICopilotTool<IApplyPatchToolParams> {
 			const notebookEdits = new ResourceMap<(vscode.NotebookEdit | [vscode.Uri, vscode.TextEdit[]])[]>();
 			for (const [file, changes] of Object.entries(commit.changes)) {
 				let path = resolveToolInputPath(file, this.promptPathRepresentationService);
-				await this.instantiationService.invokeFunction(accessor => assertFileOkForTool(accessor, path));
+				await this.instantiationService.invokeFunction(accessor => assertFileNotContentExcluded(accessor, path));
 
 				switch (changes.type) {
 					case ActionType.ADD: {

--- a/src/extension/tools/node/createFileTool.tsx
+++ b/src/extension/tools/node/createFileTool.tsx
@@ -31,7 +31,7 @@ import { ActionType } from './applyPatch/parser';
 import { EditFileResult } from './editFileToolResult';
 import { createEditConfirmation } from './editFileToolUtils';
 import { sendEditNotebookTelemetry } from './editNotebookTool';
-import { assertFileOkForTool, formatUriForFileWidget, resolveToolInputPath } from './toolUtils';
+import { assertFileNotContentExcluded, formatUriForFileWidget, resolveToolInputPath } from './toolUtils';
 
 export interface ICreateFileParams {
 	filePath: string;
@@ -63,7 +63,7 @@ export class CreateFileTool implements ICopilotTool<ICreateFileParams> {
 			throw new Error(`Invalid file path`);
 		}
 
-		await this.instantiationService.invokeFunction(accessor => assertFileOkForTool(accessor, uri));
+		await this.instantiationService.invokeFunction(accessor => assertFileNotContentExcluded(accessor, uri));
 
 		if (!this._promptContext?.stream) {
 			throw new Error('Invalid stream');

--- a/src/extension/tools/node/insertEditTool.tsx
+++ b/src/extension/tools/node/insertEditTool.tsx
@@ -23,7 +23,7 @@ import { ActionType } from './applyPatch/parser';
 import { EditFileResult } from './editFileToolResult';
 import { createEditConfirmation } from './editFileToolUtils';
 import { sendEditNotebookTelemetry } from './editNotebookTool';
-import { assertFileOkForTool } from './toolUtils';
+import { assertFileNotContentExcluded } from './toolUtils';
 
 export interface IEditFileParams {
 	explanation: string;
@@ -54,7 +54,7 @@ export class EditFileTool implements ICopilotTool<IEditFileParams> {
 			throw new Error(`Invalid file path`);
 		}
 
-		await this.instantiationService.invokeFunction(accessor => assertFileOkForTool(accessor, uri));
+		await this.instantiationService.invokeFunction(accessor => assertFileNotContentExcluded(accessor, uri));
 
 		const existingDiagnostics = this.languageDiagnosticsService.getDiagnostics(uri);
 

--- a/src/extension/tools/node/toolUtils.ts
+++ b/src/extension/tools/node/toolUtils.ts
@@ -93,9 +93,10 @@ export async function isFileOkForTool(accessor: ServicesAccessor, uri: URI): Pro
 export async function assertFileOkForTool(accessor: ServicesAccessor, uri: URI): Promise<void> {
 	const workspaceService = accessor.get(IWorkspaceService);
 	const tabsAndEditorsService = accessor.get(ITabsAndEditorsService);
-	const ignoreService = accessor.get(IIgnoreService);
 	const promptPathRepresentationService = accessor.get(IPromptPathRepresentationService);
 	const customInstructionsService = accessor.get(ICustomInstructionsService);
+
+	await assertFileNotContentExcluded(accessor, uri);
 
 	if (!workspaceService.getWorkspaceFolder(normalizePath(uri)) && !customInstructionsService.isExternalInstructionsFile(uri)) {
 		const fileOpenInSomeTab = tabsAndEditorsService.tabs.some(tab => isEqual(tab.uri, uri));
@@ -103,6 +104,11 @@ export async function assertFileOkForTool(accessor: ServicesAccessor, uri: URI):
 			throw new Error(`File ${promptPathRepresentationService.getFilePath(uri)} is outside of the workspace, and not open in an editor, and can't be read`);
 		}
 	}
+}
+
+export async function assertFileNotContentExcluded(accessor: ServicesAccessor, uri: URI): Promise<void> {
+	const ignoreService = accessor.get(IIgnoreService);
+	const promptPathRepresentationService = accessor.get(IPromptPathRepresentationService);
 
 	if (await ignoreService.isCopilotIgnored(uri)) {
 		throw new Error(`File ${promptPathRepresentationService.getFilePath(uri)} is configured to be ignored by Copilot`);


### PR DESCRIPTION
- Don't block edits to files outside the workspace, but allow them with
  confirmations.
- Always confirm on certain files (dotfiles/folders in the home
  directory and appdatas on Windows)