### PR TITLE
Revert notebook toolset change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1134,16 +1134,16 @@
 				"tools": [
 					"createFile",
 					"createDirectory",
+					"editNotebook",
+					"newJupyterNotebook",
 					"editFiles"
 				]
 			},
 			{
-				"name": "notebooks",
-				"description": "%copilot.toolSet.notebooks.description%",
+				"name": "runNotebooks",
+				"description": "%copilot.toolSet.runNotebook.description%",
 				"icon": "$(notebook)",
 				"tools": [
-					"newJupyterNotebook",
-					"editNotebook",
 					"runCell",
 					"getNotebookSummary",
 					"readNotebookCellOutput"

--- a/package.nls.json
+++ b/package.nls.json
@@ -289,7 +289,7 @@
 	"github.copilot.config.customInstructionsInSystemMessage": "When enabled, custom instructions and mode instructions will be appended to the system message instead of a user message.",
 	"copilot.toolSet.editing.description": "Edit files in your workspace",
 	"copilot.toolSet.runCommand.description": "Run commands in the terminal",
-	"copilot.toolSet.notebooks.description": "Work with notebooks",
+	"copilot.toolSet.runNotebook.description": "Run notebook cells",
 	"copilot.toolSet.search.description": "Search and read files in your workspace",
 	"copilot.toolSet.new.description": "Scaffold a new workspace with VS Code-specific configurations to compile, debug and run new projects.",
 	"copilot.toolSet.runTasks.description": "Run tasks in your workspace"

--- a/src/extension/promptFileContext/vscode-node/promptFileContextService.ts
+++ b/src/extension/promptFileContext/vscode-node/promptFileContextService.ts
@@ -199,7 +199,7 @@ export class PromptFileContextContribution extends Disposable {
 	}
 
 	private getToolNames(): string[] {
-		return ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'notebooks', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI'];
+		return ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI'];
 	}
 
 


### PR DESCRIPTION
From #780
We need a way to do this that doesn't break based on how toolsets are referenced in prompt files and remembered in ui state