### PR TITLE
Only use Java imports in pre-release

### DIFF
--- a/src/extension/inlineEdits/vscode-node/features/diagnosticsBasedCompletions/importDiagnosticsCompletionProvider.ts
+++ b/src/extension/inlineEdits/vscode-node/features/diagnosticsBasedCompletions/importDiagnosticsCompletionProvider.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { isPreRelease } from '../../../../../platform/env/common/packagejson';
 import { IFileSystemService } from '../../../../../platform/filesystem/common/fileSystemService';
 import { CodeActionData } from '../../../../../platform/inlineEdits/common/dataTypes/codeActionData';
 import { DocumentId } from '../../../../../platform/inlineEdits/common/dataTypes/documentId';
@@ -205,8 +206,11 @@ export class ImportDiagnosticCompletionProvider implements IDiagnosticCompletion
 			['typescriptreact', javascriptImportHandler],
 			['javascriptreact', javascriptImportHandler],
 			['python', pythonImportHandler],
-			['java', javaImportHandler],
 		]);
+
+		if (isPreRelease) {
+			this._importHandlers.set('java', javaImportHandler);
+		}
 	}
 
 	public providesCompletionsForDiagnostic(workspaceDocument: IVSCodeObservableDocument, diagnostic: Diagnostic, language: LanguageId, pos: Position): boolean {


### PR DESCRIPTION
```Copilot Generated Description:``` Limit the addition of Java import handlers to pre-release versions only.

related https://github.com/microsoft/vscode-internalbacklog/issues/5781#issuecomment-3254517149