### PR TITLE
Add session ID and tracking ID to GitHub telemetry

### DIFF
--- a/src/platform/telemetry/node/azureInsights.ts
+++ b/src/platform/telemetry/node/azureInsights.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from '../../../util/vs/base/common/lifecycle';
+import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStore';
 import { ICAPIClientService } from '../../endpoint/common/capiClient';
 import { IEnvService } from '../../env/common/envService';
 import { IGHTelemetryService } from '../common/telemetry';
@@ -17,6 +18,7 @@ export async function setupGHTelemetry(
 	telemetryService: IGHTelemetryService,
 	capiClientService: ICAPIClientService,
 	envService: IEnvService,
+	tokenStore: ICopilotTokenStore,
 	telemetryNamespace: string,
 	telemetryEnabled: boolean
 ): Promise<IDisposable | undefined> {
@@ -26,8 +28,8 @@ export async function setupGHTelemetry(
 		return;
 	}
 
-	const reporter = new AzureInsightReporter(capiClientService, envService, telemetryNamespace, APP_INSIGHTS_KEY_STANDARD);
-	const reporterSecure = new AzureInsightReporter(capiClientService, envService, telemetryNamespace, APP_INSIGHTS_KEY_ENHANCED);
+	const reporter = new AzureInsightReporter(capiClientService, envService, tokenStore, telemetryNamespace, APP_INSIGHTS_KEY_STANDARD);
+	const reporterSecure = new AzureInsightReporter(capiClientService, envService, tokenStore, telemetryNamespace, APP_INSIGHTS_KEY_ENHANCED);
 
 	container.setReporter(reporter);
 	container.setSecureReporter(reporterSecure);

--- a/src/platform/telemetry/vscode-node/githubTelemetrySender.ts
+++ b/src/platform/telemetry/vscode-node/githubTelemetrySender.ts
@@ -27,9 +27,9 @@ export class GitHubTelemetrySender extends BaseGHTelemetrySender {
 	) {
 		const telemeryLoggerFactory = (enhanced: boolean) => {
 			if (enhanced) {
-				return env.createTelemetryLogger(new AzureInsightReporter(capiClientService, envService, extensionName, enhancedTelemetryAIKey), { ignoreBuiltInCommonProperties: true, ignoreUnhandledErrors: true });
+				return env.createTelemetryLogger(new AzureInsightReporter(capiClientService, envService, tokenStore, extensionName, enhancedTelemetryAIKey), { ignoreBuiltInCommonProperties: true, ignoreUnhandledErrors: true });
 			} else {
-				return env.createTelemetryLogger(new AzureInsightReporter(capiClientService, envService, extensionName, standardTelemetryAIKey), { ignoreBuiltInCommonProperties: true, ignoreUnhandledErrors: true });
+				return env.createTelemetryLogger(new AzureInsightReporter(capiClientService, envService, tokenStore, extensionName, standardTelemetryAIKey), { ignoreBuiltInCommonProperties: true, ignoreUnhandledErrors: true });
 			}
 		};
 		super(tokenStore, telemeryLoggerFactory, configService, telemetryConfig, envService, domainService);

--- a/src/platform/test/node/telemetry.ts
+++ b/src/platform/test/node/telemetry.ts
@@ -14,6 +14,7 @@ import { ITelemetryUserConfig } from '../../telemetry/common/telemetry';
 import { APP_INSIGHTS_KEY_ENHANCED, APP_INSIGHTS_KEY_STANDARD, setupGHTelemetry } from '../../telemetry/node/azureInsights';
 import { ITestingServicesAccessor, TestingServiceCollection } from './services';
 import { startFakeTelemetryServerIfNecessary } from './telemetryFake';
+import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStore';
 
 export type EventData = {
 	baseType: 'EventData';
@@ -155,7 +156,7 @@ async function _withTelemetryCapture<T>(
 	const ghTelemetry = new GHTelemetryService(true, accessor.get(IConfigurationService), accessor.get(IEnvService), accessor.get(ITelemetryUserConfig));
 	await ghTelemetry.enablePromiseTracking(true);
 
-	await setupGHTelemetry(ghTelemetry, accessor.get(ICAPIClientService), accessor.get(IEnvService), extensionId, forceTelemetry);
+	await setupGHTelemetry(ghTelemetry, accessor.get(ICAPIClientService), accessor.get(IEnvService), accessor.get(ICopilotTokenStore), extensionId, forceTelemetry);
 
 	try {
 		const result = await work(accessor);


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce session ID and tracking ID to enhance telemetry reporting by integrating the copilot token store into the Azure Insight Reporter. This change modifies the telemetry setup to include these identifiers in the event tracking.

fixes https://github.com/microsoft/vscode/issues/265831