### PR TITLE
Update default JSON formatter in settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,7 @@
 		}
 	},
 	"[json]": {
-		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.defaultFormatter": "vscode.json-language-features",
 		"editor.formatOnSave": true,
 		"files.insertFinalNewline": false
 	},


### PR DESCRIPTION
```Copilot Generated Description:``` Change the default formatter for JSON files from Prettier to the built-in JSON language features.

closes https://github.com/microsoft/vscode/issues/265832