### PR TITLE
add build task info to custom instructions for `vscode-copilot-chat`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,8 +28,8 @@ This is the **GitHub Copilot Chat** extension for Visual Studio Code - a VS Code
 You MUST check compilation output before running ANY script or declaring work complete!
 
 1. **ALWAYS** check the `start-watch-tasks` watch task output for compilation errors
-3. **NEVER** use the `compile` task to to make sure everything is working properly
-4. **FIX** all compilation errors before moving forward
+2. **NEVER** use the `compile` task as a way to check if everything is working properly
+3. **FIX** all compilation errors before moving forward
 
 ### TypeScript compilation steps
 - Monitor the `start-watch-tasks` task outputs for real-time compilation errors as you make changes

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,19 @@ This is the **GitHub Copilot Chat** extension for Visual Studio Code - a VS Code
 - **Vitest**: Unit testing framework
 - **Python**: For notebooks integration and ML evaluation scripts
 
+## Validating changes
+
+You MUST check compilation output before running ANY script or declaring work complete!
+
+1. **ALWAYS** check the `start-watch-tasks` watch task output for compilation errors
+3. **NEVER** use the `compile` task to to make sure everything is working properly
+4. **FIX** all compilation errors before moving forward
+
+### TypeScript compilation steps
+- Monitor the `start-watch-tasks` task outputs for real-time compilation errors as you make changes
+- This task runs `npm: watch:tsc-extension`,`npm: watch:tsc-extension-web`, `npm: watch:tsc-simulation-workbench`, and `npm: watch:esbuild` to incrementally compile the project
+- Start the task if it's not already running in the background
+
 ## Project Architecture
 
 ### Top-Level Directory Structure


### PR DESCRIPTION
fix #264387

Mirrors the ones added to the `vscode` repo:

https://github.com/microsoft/vscode/blob/e2f7d168d01b96cf8797d8553360210e5ccc118c/.github/copilot-instructions.md#L48-L62

cc @roblourens 