### PR TITLE
Add CAPI text-3-small endpoint support for embeddings

### DIFF
--- a/src/extension/context/node/resolvers/extensionApi.tsx
+++ b/src/extension/context/node/resolvers/extensionApi.tsx
@@ -95,7 +95,7 @@ export class VSCodeAPIContextElement extends PromptElement<VSCodeAPIContextProps
 			return [];
 		}
 
-		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [this.props.query], {}, new TelemetryCorrelationId('VSCodeAPIContextElement::getSnippets'), token);
+		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [this.props.query], { endpointType: 'capi' }, new TelemetryCorrelationId('VSCodeAPIContextElement::getSnippets'), token);
 		return this.apiEmbeddingsIndex.nClosestValues(embeddingResult.values[0], 5);
 	}
 

--- a/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -9,15 +9,16 @@ import { ConfigKey, IConfigurationService } from '../../../platform/configuratio
 import { AutoChatEndpoint } from '../../../platform/endpoint/common/autoChatEndpoint';
 import { IAutomodeService } from '../../../platform/endpoint/common/automodeService';
 import { ICAPIClientService } from '../../../platform/endpoint/common/capiClient';
-import { ChatEndpointFamily, IChatModelInformation, ICompletionModelInformation, IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { ChatEndpointFamily, IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation, IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { CopilotChatEndpoint } from '../../../platform/endpoint/node/copilotChatEndpoint';
+import { EmbeddingEndpoint } from '../../../platform/endpoint/node/embeddingsEndpoint';
 import { IModelMetadataFetcher, ModelMetadataFetcher } from '../../../platform/endpoint/node/modelMetadataFetcher';
 import { applyExperimentModifications, ExperimentConfig, getCustomDefaultModelExperimentConfig, ProxyExperimentEndpoint } from '../../../platform/endpoint/node/proxyExperimentEndpoint';
 import { ExtensionContributedChatEndpoint } from '../../../platform/endpoint/vscode-node/extChatEndpoint';
 import { IEnvService } from '../../../platform/env/common/envService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IFetcherService } from '../../../platform/networking/common/fetcherService';
-import { IChatEndpoint } from '../../../platform/networking/common/networking';
+import { IChatEndpoint, IEmbeddingsEndpoint } from '../../../platform/networking/common/networking';
 import { IRequestLogger } from '../../../platform/requestLogger/node/requestLogger';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
@@ -30,6 +31,7 @@ export class ProductionEndpointProvider implements IEndpointProvider {
 	declare readonly _serviceBrand: undefined;
 
 	private _chatEndpoints: Map<string, IChatEndpoint> = new Map();
+	private _embeddingEndpoints: Map<string, IEmbeddingsEndpoint> = new Map();
 	private readonly _modelFetcher: IModelMetadataFetcher;
 
 	constructor(
@@ -142,6 +144,24 @@ export class ProductionEndpointProvider implements IEndpointProvider {
 
 		this._logService.trace(`Resolved chat model`);
 		return endpoint;
+	}
+
+	async getEmbeddingsEndpoint(): Promise<IEmbeddingsEndpoint> {
+		this._logService.trace(`Resolving embedding model`);
+		const modelMetadata = await this._modelFetcher.getEmbeddingsModel('text-embedding-3-small');
+		const model = await this.getOrCreateEmbeddingEndpointInstance(modelMetadata);
+		this._logService.trace(`Resolved embedding model`);
+		return model;
+	}
+
+	private async getOrCreateEmbeddingEndpointInstance(modelMetadata: IEmbeddingModelInformation): Promise<IEmbeddingsEndpoint> {
+		const modelId = 'text-embedding-3-small';
+		let embeddingEndpoint = this._embeddingEndpoints.get(modelId);
+		if (!embeddingEndpoint) {
+			embeddingEndpoint = this._instantiationService.createInstance(EmbeddingEndpoint, modelMetadata);
+			this._embeddingEndpoints.set(modelId, embeddingEndpoint);
+		}
+		return embeddingEndpoint;
 	}
 
 	async getAllCompletionModels(forceRefresh?: boolean): Promise<ICompletionModelInformation[]> {

--- a/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -9,7 +9,7 @@ import { ConfigKey, IConfigurationService } from '../../../platform/configuratio
 import { AutoChatEndpoint } from '../../../platform/endpoint/common/autoChatEndpoint';
 import { IAutomodeService } from '../../../platform/endpoint/common/automodeService';
 import { ICAPIClientService } from '../../../platform/endpoint/common/capiClient';
-import { ChatEndpointFamily, IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation, IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { ChatEndpointFamily, EmbeddingsEndpointFamily, IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation, IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { CopilotChatEndpoint } from '../../../platform/endpoint/node/copilotChatEndpoint';
 import { EmbeddingEndpoint } from '../../../platform/endpoint/node/embeddingsEndpoint';
 import { IModelMetadataFetcher, ModelMetadataFetcher } from '../../../platform/endpoint/node/modelMetadataFetcher';
@@ -146,7 +146,7 @@ export class ProductionEndpointProvider implements IEndpointProvider {
 		return endpoint;
 	}
 
-	async getEmbeddingsEndpoint(): Promise<IEmbeddingsEndpoint> {
+	async getEmbeddingsEndpoint(family?: EmbeddingsEndpointFamily): Promise<IEmbeddingsEndpoint> {
 		this._logService.trace(`Resolving embedding model`);
 		const modelMetadata = await this._modelFetcher.getEmbeddingsModel('text-embedding-3-small');
 		const model = await this.getOrCreateEmbeddingEndpointInstance(modelMetadata);

--- a/src/extension/prompt/vscode-node/settingsEditorSearchServiceImpl.ts
+++ b/src/extension/prompt/vscode-node/settingsEditorSearchServiceImpl.ts
@@ -37,7 +37,7 @@ export class SettingsEditorSearchServiceImpl implements ISettingsEditorSearchSer
 
 		let embeddingResult: Embeddings;
 		try {
-			embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [query], {}, new TelemetryCorrelationId('SettingsEditorSearchServiceImpl::provideSettingsSearchResults'), token);
+			embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [query], { endpointType: 'capi' }, new TelemetryCorrelationId('SettingsEditorSearchServiceImpl::provideSettingsSearchResults'), token);
 		} catch {
 			if (token.isCancellationRequested) {
 				progress.report(canceledBundle);

--- a/src/extension/prompts/node/panel/newWorkspace/newWorkspace.tsx
+++ b/src/extension/prompts/node/panel/newWorkspace/newWorkspace.tsx
@@ -105,7 +105,7 @@ export class NewWorkspacePrompt extends PromptElement<NewWorkspacePromptProps, N
 			}
 			else if (instruction.intent === 'Project') {
 				if (this.props.useTemplates) {
-					const result = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [instruction.question], {}, undefined);
+					const result = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [instruction.question], { endpointType: 'capi' }, undefined);
 					progress.report(new ChatResponseProgressPart(l10n.t('Searching project template index...')));
 					const similarProjects = await this.projectTemplatesIndex.nClosestValues(result.values[0], 1);
 					if (similarProjects.length > 0) {

--- a/src/extension/prompts/node/panel/vscode.tsx
+++ b/src/extension/prompts/node/panel/vscode.tsx
@@ -136,7 +136,7 @@ export class VscodePrompt extends PromptElement<VscodePromptProps, VscodePromptS
 			return { settings: [], commands: [], query: userQuery };
 		}
 
-		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [userQuery], {}, undefined);
+		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [userQuery], { endpointType: 'capi' }, undefined);
 		if (token.isCancellationRequested) {
 			return { settings: [], commands: [], query: userQuery };
 		}

--- a/src/extension/test/vscode-node/endpoints.test.ts
+++ b/src/extension/test/vscode-node/endpoints.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { SinonSandbox, createSandbox } from 'sinon';
 import { LanguageModelChat } from 'vscode';
 import { CHAT_MODEL } from '../../../platform/configuration/common/configurationService';
-import { IChatModelInformation, ICompletionModelInformation } from '../../../platform/endpoint/common/endpointProvider';
+import { IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation } from '../../../platform/endpoint/common/endpointProvider';
 import { IModelMetadataFetcher } from '../../../platform/endpoint/node/modelMetadataFetcher';
 import { ITestingServicesAccessor } from '../../../platform/test/node/services';
 import { TokenizerType } from '../../../util/common/tokenizer';
@@ -40,6 +40,23 @@ class FakeModelMetadataFetcher implements IModelMetadataFetcher {
 				type: 'chat',
 				tokenizer: TokenizerType.O200K,
 				family: 'fake-family'
+			}
+		};
+	}
+
+	async getEmbeddingsModel(): Promise<IEmbeddingModelInformation> {
+		return {
+			id: 'text-embedding-3-small',
+			name: 'fake-name',
+			version: 'fake-version',
+			model_picker_enabled: false,
+			is_chat_default: false,
+			is_chat_fallback: false,
+			capabilities: {
+				type: 'embeddings',
+				tokenizer: TokenizerType.O200K,
+				family: 'text-embedding-3-small',
+				limits: { max_inputs: 256 }
 			}
 		};
 	}

--- a/src/platform/embeddings/common/embeddingsComputer.ts
+++ b/src/platform/embeddings/common/embeddingsComputer.ts
@@ -91,6 +91,7 @@ export const IEmbeddingsComputer = createServiceIdentifier<IEmbeddingsComputer>(
 
 export type ComputeEmbeddingsOptions = {
 	readonly inputType?: 'document' | 'query';
+	readonly endpointType?: 'capi' | 'github';
 };
 
 export interface IEmbeddingsComputer {

--- a/src/platform/embeddings/common/remoteEmbeddingsComputer.ts
+++ b/src/platform/embeddings/common/remoteEmbeddingsComputer.ts
@@ -272,7 +272,7 @@ export class RemoteEmbeddingsComputer implements IEmbeddingsComputer {
 				this._capiClientService,
 				endpoint,
 				token.token,
-				await createRequestHMAC(env.HMAC_SECRET), // TODO@bpasero we need web support for these environmental things
+				await createRequestHMAC(env.HMAC_SECRET),
 				'copilot-panel',
 				requestId,
 				body,

--- a/src/platform/embeddings/common/remoteEmbeddingsComputer.ts
+++ b/src/platform/embeddings/common/remoteEmbeddingsComputer.ts
@@ -7,19 +7,29 @@ import { RequestType } from '@vscode/copilot-api';
 import type { CancellationToken } from 'vscode';
 import { createRequestHMAC } from '../../../util/common/crypto';
 import { CallTracker, TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
+import { Limiter } from '../../../util/vs/base/common/async';
 import { env } from '../../../util/vs/base/common/process';
 import { generateUuid } from '../../../util/vs/base/common/uuid';
 import { IAuthenticationService } from '../../authentication/common/authentication';
 import { getGithubMetadataHeaders } from '../../chunking/common/chunkingEndpointClientImpl';
 import { ICAPIClientService } from '../../endpoint/common/capiClient';
+import { IEndpointProvider } from '../../endpoint/common/endpointProvider';
 import { IEnvService } from '../../env/common/envService';
 import { logExecTime } from '../../log/common/logExecTime';
 import { ILogService } from '../../log/common/logService';
 import { IFetcherService } from '../../networking/common/fetcherService';
-import { postRequest } from '../../networking/common/networking';
+import { IEmbeddingsEndpoint, postRequest } from '../../networking/common/networking';
 import { ITelemetryService } from '../../telemetry/common/telemetry';
-import { ComputeEmbeddingsOptions, Embedding, EmbeddingType, Embeddings, IEmbeddingsComputer } from './embeddingsComputer';
+import { ComputeEmbeddingsOptions, Embedding, EmbeddingType, EmbeddingTypeInfo, EmbeddingVector, Embeddings, IEmbeddingsComputer, getWellKnownEmbeddingTypeInfo } from './embeddingsComputer';
 
+interface CAPIEmbeddingResults {
+	readonly type: 'success';
+	readonly embeddings: EmbeddingVector[];
+}
+interface CAPIEmbeddingError {
+	readonly type: 'failed';
+	readonly reason: string;
+}
 
 export class RemoteEmbeddingsComputer implements IEmbeddingsComputer {
 
@@ -34,6 +44,7 @@ export class RemoteEmbeddingsComputer implements IEmbeddingsComputer {
 		@IFetcherService private readonly _fetcherService: IFetcherService,
 		@ILogService private readonly _logService: ILogService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IEndpointProvider private readonly _endpointProvider: IEndpointProvider,
 	) { }
 
 	public async computeEmbeddings(
@@ -44,6 +55,12 @@ export class RemoteEmbeddingsComputer implements IEmbeddingsComputer {
 		cancellationToken?: CancellationToken,
 	): Promise<Embeddings> {
 		return logExecTime(this._logService, 'RemoteEmbeddingsComputer::computeEmbeddings', async () => {
+
+			if (options?.endpointType === 'capi') {
+				const embeddings = await this.computeCAPIEmbeddings(inputs, options, cancellationToken);
+				return embeddings ?? { type: embeddingType, values: [] };
+			}
+
 			const token = (await this._authService.getAnyGitHubSession({ silent: true }))?.accessToken;
 			if (!token) {
 				throw new Error('No authentication token available');
@@ -126,5 +143,162 @@ export class RemoteEmbeddingsComputer implements IEmbeddingsComputer {
 
 			return { type: embeddingType, values: embeddingsOut };
 		});
+	}
+
+	private async computeCAPIEmbeddings(
+		inputs: readonly string[],
+		options?: ComputeEmbeddingsOptions,
+		cancellationToken?: CancellationToken,
+	) {
+		const typeInfo = getWellKnownEmbeddingTypeInfo(EmbeddingType.text3small_512);
+		if (!typeInfo) {
+			throw new Error(`Embeddings type info not found: ${EmbeddingType.text3small_512}`);
+		}
+		const endpoint = await this._endpointProvider.getEmbeddingsEndpoint('text3small');
+		const batchSize = endpoint.maxBatchSize;
+		// Open AI seems to allow 1 less than max tokens for the model requests. So if the max tokens is 8192, we can only send 8191 tokens.
+		const maxTokens = endpoint.modelMaxPromptTokens - 1;
+		return this.fetchResponseWithBatches(typeInfo, endpoint, inputs, cancellationToken, maxTokens, batchSize, options?.parallelism);
+	}
+
+	/**
+	 * A recursive helper that drives the public `fetchResponse` function. This allows accepting a batch and supports backing off the endpoint.
+	 * @param inputs The inputs to get embeddings for
+	 * @param cancellationToken A cancellation token to allow cancelling the requests
+	 * @param batchSize The batch size to calculate
+	 * @returns The embeddings
+	 */
+	private async fetchResponseWithBatches(
+		type: EmbeddingTypeInfo,
+		endpoint: IEmbeddingsEndpoint,
+		inputs: readonly string[],
+		cancellationToken: CancellationToken | undefined,
+		maxTokens: number,
+		batchSize: number,
+		parallelism = 1,
+	): Promise<Embeddings | undefined> {
+		// First we loop through all inputs and count their token length, if one exceeds max tokens then we fail
+		for (const input of inputs) {
+			const inputTokenLength = await endpoint.acquireTokenizer().tokenLength(input);
+			if (inputTokenLength > maxTokens) {
+				return undefined;
+			}
+		}
+
+		let embeddings: EmbeddingVector[] = [];
+		const promises: Promise<CAPIEmbeddingResults | undefined>[] = [];
+		const limiter = new Limiter<CAPIEmbeddingResults | undefined>(parallelism);
+		try {
+			for (let i = 0; i < inputs.length; i += batchSize) {
+				const currentBatch = inputs.slice(i, i + batchSize);
+				promises.push(limiter.queue(async () => {
+					if (cancellationToken?.isCancellationRequested) {
+						return;
+					}
+
+					const r = await this.rawEmbeddingsFetchWithTelemetry(type, endpoint, generateUuid(), currentBatch, cancellationToken);
+					if (r.type === 'failed') {
+						throw new Error('Embeddings request failed ' + r.reason);
+					}
+					return r;
+				}));
+			}
+
+			embeddings = (await Promise.all(promises)).flatMap(response => response?.embeddings ?? []);
+		} catch (e) {
+			return undefined;
+		} finally {
+			limiter.dispose();
+		}
+
+		if (cancellationToken?.isCancellationRequested) {
+			return undefined;
+		}
+
+		// If there are no embeddings, return undefined
+		if (embeddings.length === 0) {
+			return undefined;
+		}
+		return { type: EmbeddingType.text3small_512, values: embeddings.map((value): Embedding => ({ type: EmbeddingType.text3small_512, value })) };
+	}
+
+	private async rawEmbeddingsFetchWithTelemetry(
+		type: EmbeddingTypeInfo,
+		endpoint: IEmbeddingsEndpoint,
+		requestId: string,
+		inputs: readonly string[],
+		cancellationToken: CancellationToken | undefined
+	) {
+		const startTime = Date.now();
+		const rawRequest = await this.rawEmbeddingsFetch(type, endpoint, requestId, inputs, cancellationToken);
+		if (rawRequest.type === 'failed') {
+			this._telemetryService.sendMSFTTelemetryErrorEvent('embedding.error', {
+				type: rawRequest.type,
+				reason: rawRequest.reason
+			});
+			return rawRequest;
+		}
+
+		const tokenizer = endpoint.acquireTokenizer();
+		const tokenCounts = await Promise.all(inputs.map(input => tokenizer.tokenLength(input)));
+		const inputTokenCount = tokenCounts.reduce((acc, count) => acc + count, 0);
+		this._telemetryService.sendMSFTTelemetryEvent('embedding.success', {}, {
+			batchSize: inputs.length,
+			inputTokenCount,
+			timeToComplete: Date.now() - startTime
+		});
+		return rawRequest;
+	}
+
+	/**
+	 * The function which actually makes the request to the API and handles failures.
+	 * This is separated out from fetchResponse as fetchResponse does some manipulation to the input and handles errors differently
+	 */
+	public async rawEmbeddingsFetch(
+		type: EmbeddingTypeInfo,
+		endpoint: IEmbeddingsEndpoint,
+		requestId: string,
+		inputs: readonly string[],
+		cancellationToken: CancellationToken | undefined
+	): Promise<CAPIEmbeddingResults | CAPIEmbeddingError> {
+		try {
+			const token = await this._authService.getCopilotToken();
+
+			const body = { input: inputs, model: type.model, dimensions: type.dimensions };
+			endpoint.interceptBody?.(body);
+			const response = await postRequest(
+				this._fetcherService,
+				this._telemetryService,
+				this._capiClientService,
+				endpoint,
+				token.token,
+				await createRequestHMAC(env.HMAC_SECRET), // TODO@bpasero we need web support for these environmental things
+				'copilot-panel',
+				requestId,
+				body,
+				undefined,
+				cancellationToken
+			);
+			const jsonResponse = response.status === 200 ? await response.json() : await response.text();
+
+			type EmbeddingResponse = {
+				object: string;
+				index: number;
+				embedding: number[];
+			};
+			if (response.status === 200 && jsonResponse.data) {
+				return { type: 'success', embeddings: jsonResponse.data.map((d: EmbeddingResponse) => d.embedding) };
+			} else {
+				return { type: 'failed', reason: jsonResponse.error };
+			}
+		} catch (e) {
+			let errorMessage = (e as Error)?.message ?? 'Unknown error';
+			// Timeouts = JSON parse errors because the response is incomplete
+			if (errorMessage.match(/Unexpected.*JSON/i)) {
+				errorMessage = 'timeout';
+			}
+			return { type: 'failed', reason: errorMessage };
+
+		}
 	}
 }

--- a/src/platform/embeddings/common/remoteEmbeddingsComputer.ts
+++ b/src/platform/embeddings/common/remoteEmbeddingsComputer.ts
@@ -158,7 +158,7 @@ export class RemoteEmbeddingsComputer implements IEmbeddingsComputer {
 		const batchSize = endpoint.maxBatchSize;
 		// Open AI seems to allow 1 less than max tokens for the model requests. So if the max tokens is 8192, we can only send 8191 tokens.
 		const maxTokens = endpoint.modelMaxPromptTokens - 1;
-		return this.fetchResponseWithBatches(typeInfo, endpoint, inputs, cancellationToken, maxTokens, batchSize, options?.parallelism);
+		return this.fetchResponseWithBatches(typeInfo, endpoint, inputs, cancellationToken, maxTokens, batchSize);
 	}
 
 	/**

--- a/src/platform/embeddings/common/vscodeIndex.ts
+++ b/src/platform/embeddings/common/vscodeIndex.ts
@@ -108,7 +108,7 @@ abstract class RelatedInformationProviderEmbeddingsIndex<V extends { key: string
 			return [];
 		}
 		const startOfEmbeddingRequest = Date.now();
-		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [query], {}, new TelemetryCorrelationId('RelatedInformationProviderEmbeddingsIndex::provideRelatedInformation'), token);
+		const embeddingResult = await this.embeddingsComputer.computeEmbeddings(EmbeddingType.text3small_512, [query], { endpointType: 'capi' }, new TelemetryCorrelationId('RelatedInformationProviderEmbeddingsIndex::provideRelatedInformation'), token);
 		this._logService.debug(`Related Information: Remote similarly request took ${Date.now() - startOfEmbeddingRequest}ms`);
 		if (token.isCancellationRequested) {
 			// return an array of 0s the same length as comparisons

--- a/src/platform/endpoint/common/endpointProvider.ts
+++ b/src/platform/endpoint/common/endpointProvider.ts
@@ -116,7 +116,7 @@ export interface IEndpointProvider {
 	/**
 	 * Get the CAPI embedding endpoint information
 	 */
-	getEmbeddingsEndpoint(family: EmbeddingsEndpointFamily): Promise<IEmbeddingsEndpoint>;
+	getEmbeddingsEndpoint(family?: EmbeddingsEndpointFamily): Promise<IEmbeddingsEndpoint>;
 }
 
 export const IEndpointProvider = createServiceIdentifier<IEndpointProvider>('IEndpointProvider');

--- a/src/platform/endpoint/common/endpointProvider.ts
+++ b/src/platform/endpoint/common/endpointProvider.ts
@@ -9,7 +9,7 @@ import type { LanguageModelChat } from 'vscode';
 import { createServiceIdentifier } from '../../../util/common/services';
 import { TokenizerType } from '../../../util/common/tokenizer';
 import type { ChatRequest } from '../../../vscodeTypes';
-import { IChatEndpoint } from '../../networking/common/networking';
+import { IChatEndpoint, IEmbeddingsEndpoint } from '../../networking/common/networking';
 
 export type ModelPolicy = {
 	state: 'enabled' | 'disabled' | 'unconfigured';
@@ -36,6 +36,13 @@ export type IChatModelCapabilities = {
 	};
 };
 
+export type IEmbeddingModelCapabilities = {
+	type: 'embeddings';
+	family: string;
+	tokenizer: TokenizerType;
+	limits?: { max_inputs?: number };
+};
+
 type ICompletionModelCapabilities = {
 	type: 'completion';
 	family: string;
@@ -57,7 +64,7 @@ export interface IModelAPIResponse {
 	is_chat_fallback: boolean;
 	version: string;
 	billing?: { is_premium: boolean; multiplier: number; restricted_to?: string[] };
-	capabilities: IChatModelCapabilities | ICompletionModelCapabilities;
+	capabilities: IChatModelCapabilities | ICompletionModelCapabilities | IEmbeddingModelCapabilities;
 	supported_endpoints?: ModelSupportedEndpoint[];
 }
 
@@ -69,6 +76,12 @@ export type IChatModelInformation = IModelAPIResponse & {
 export function isChatModelInformation(model: IModelAPIResponse): model is IChatModelInformation {
 	return model.capabilities.type === 'chat';
 }
+
+export function isEmbeddingModelInformation(model: IModelAPIResponse): model is IEmbeddingModelInformation {
+	return model.capabilities.type === 'embeddings';
+}
+
+export type IEmbeddingModelInformation = IModelAPIResponse & { capabilities: IEmbeddingModelCapabilities };
 
 export type ICompletionModelInformation = IModelAPIResponse & {
 	capabilities: ICompletionModelCapabilities;
@@ -99,6 +112,11 @@ export interface IEndpointProvider {
 	 * @param requestOrFamily The chat request to get the endpoint for, the family you want the endpoint for, or the LanguageModelChat.
 	 */
 	getChatEndpoint(requestOrFamily: LanguageModelChat | ChatRequest | ChatEndpointFamily): Promise<IChatEndpoint>;
+
+	/**
+	 * Get the CAPI embedding endpoint information
+	 */
+	getEmbeddingsEndpoint(family: EmbeddingsEndpointFamily): Promise<IEmbeddingsEndpoint>;
 }
 
 export const IEndpointProvider = createServiceIdentifier<IEndpointProvider>('IEndpointProvider');

--- a/src/platform/endpoint/node/embeddingsEndpoint.ts
+++ b/src/platform/endpoint/node/embeddingsEndpoint.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { RequestMetadata, RequestType } from '@vscode/copilot-api';
+import { ITokenizer } from '../../../util/common/tokenizer';
+import { LEGACY_EMBEDDING_MODEL_ID } from '../../embeddings/common/embeddingsComputer';
+import { IEmbeddingsEndpoint } from '../../networking/common/networking';
+import { ITokenizerProvider } from '../../tokenizer/node/tokenizer';
+import { IEmbeddingModelInformation } from '../common/endpointProvider';
+
+export class EmbeddingEndpoint implements IEmbeddingsEndpoint {
+	public readonly maxBatchSize: number;
+	public readonly modelMaxPromptTokens: number;
+
+	public readonly name = this._modelInfo.name;
+	public readonly version = this._modelInfo.version;
+	public readonly family = this._modelInfo.capabilities.family;
+	public readonly tokenizer = this._modelInfo.capabilities.tokenizer;
+
+	constructor(
+		private _modelInfo: IEmbeddingModelInformation,
+		@ITokenizerProvider private readonly _tokenizerProvider: ITokenizerProvider
+	) {
+		this.maxBatchSize = this._modelInfo.capabilities.limits?.max_inputs ?? 256;
+		this.modelMaxPromptTokens = 8192;
+	}
+
+	public acquireTokenizer(): ITokenizer {
+		return this._tokenizerProvider.acquireTokenizer(this);
+	}
+
+	public get urlOrRequestMetadata(): string | RequestMetadata {
+		return { type: RequestType.CAPIEmbeddings, modelId: LEGACY_EMBEDDING_MODEL_ID.TEXT3SMALL };
+	}
+}

--- a/src/platform/endpoint/test/node/testEndpointProvider.ts
+++ b/src/platform/endpoint/test/node/testEndpointProvider.ts
@@ -23,7 +23,7 @@ import { IRequestLogger } from '../../../requestLogger/node/requestLogger';
 import { IExperimentationService } from '../../../telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../telemetry/common/telemetry';
 import { ICAPIClientService } from '../../common/capiClient';
-import { ChatEndpointFamily, IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation, IEndpointProvider } from '../../common/endpointProvider';
+import { ChatEndpointFamily, EmbeddingsEndpointFamily, IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation, IEndpointProvider } from '../../common/endpointProvider';
 import { EmbeddingEndpoint } from '../../node/embeddingsEndpoint';
 import { ModelMetadataFetcher } from '../../node/modelMetadataFetcher';
 import { AzureTestEndpoint } from './azureEndpoint';
@@ -204,7 +204,7 @@ export class TestEndpointProvider implements IEndpointProvider {
 			return await this.getChatEndpointInfo(this.gpt4oMiniModelToRunAgainst ?? CHAT_MODEL.GPT4OMINI, await this._modelLabChatModelMetadata, await this._prodChatModelMetadata);
 		}
 	}
-	async getEmbeddingsEndpoint(): Promise<IEmbeddingsEndpoint> {
+	async getEmbeddingsEndpoint(family?: EmbeddingsEndpointFamily): Promise<IEmbeddingsEndpoint> {
 		const id = LEGACY_EMBEDDING_MODEL_ID.TEXT3SMALL;
 		const modelInformation: IEmbeddingModelInformation = {
 			id: id,

--- a/src/platform/endpoint/test/node/testEndpointProvider.ts
+++ b/src/platform/endpoint/test/node/testEndpointProvider.ts
@@ -9,19 +9,22 @@ import type { ChatRequest, LanguageModelChat } from 'vscode';
 import { CacheableRequest, SQLiteCache } from '../../../../../test/base/cache';
 import { TestingCacheSalts } from '../../../../../test/base/salts';
 import { CurrentTestRunInfo } from '../../../../../test/base/simulationContext';
+import { TokenizerType } from '../../../../util/common/tokenizer';
 import { SequencerByKey } from '../../../../util/vs/base/common/async';
 import { IInstantiationService, ServicesAccessor } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { IAuthenticationService } from '../../../authentication/common/authentication';
 import { CHAT_MODEL, IConfigurationService } from '../../../configuration/common/configurationService';
+import { LEGACY_EMBEDDING_MODEL_ID } from '../../../embeddings/common/embeddingsComputer';
 import { IEnvService } from '../../../env/common/envService';
 import { ILogService } from '../../../log/common/logService';
 import { IFetcherService } from '../../../networking/common/fetcherService';
-import { IChatEndpoint } from '../../../networking/common/networking';
+import { IChatEndpoint, IEmbeddingsEndpoint } from '../../../networking/common/networking';
 import { IRequestLogger } from '../../../requestLogger/node/requestLogger';
 import { IExperimentationService } from '../../../telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../telemetry/common/telemetry';
 import { ICAPIClientService } from '../../common/capiClient';
-import { ChatEndpointFamily, IChatModelInformation, ICompletionModelInformation, IEndpointProvider } from '../../common/endpointProvider';
+import { ChatEndpointFamily, IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation, IEndpointProvider } from '../../common/endpointProvider';
+import { EmbeddingEndpoint } from '../../node/embeddingsEndpoint';
 import { ModelMetadataFetcher } from '../../node/modelMetadataFetcher';
 import { AzureTestEndpoint } from './azureEndpoint';
 import { CAPITestEndpoint } from './capiEndpoint';
@@ -120,6 +123,7 @@ export class TestEndpointProvider implements IEndpointProvider {
 
 	declare readonly _serviceBrand: undefined;
 
+	private _testEmbeddingEndpoint: IEmbeddingsEndpoint | undefined;
 	private _chatEndpoints: Map<string, IChatEndpoint> = new Map();
 	private _prodChatModelMetadata: Promise<Map<string, IChatModelInformation>>;
 	private _modelLabChatModelMetadata: Promise<Map<string, IChatModelInformation>>;
@@ -199,5 +203,24 @@ export class TestEndpointProvider implements IEndpointProvider {
 		} else {
 			return await this.getChatEndpointInfo(this.gpt4oMiniModelToRunAgainst ?? CHAT_MODEL.GPT4OMINI, await this._modelLabChatModelMetadata, await this._prodChatModelMetadata);
 		}
+	}
+	async getEmbeddingsEndpoint(): Promise<IEmbeddingsEndpoint> {
+		const id = LEGACY_EMBEDDING_MODEL_ID.TEXT3SMALL;
+		const modelInformation: IEmbeddingModelInformation = {
+			id: id,
+			name: id,
+			version: '1.0',
+			model_picker_enabled: false,
+			is_chat_default: false,
+			billing: { is_premium: false, multiplier: 0 },
+			is_chat_fallback: false,
+			capabilities: {
+				type: 'embeddings',
+				tokenizer: TokenizerType.O200K,
+				family: 'test'
+			}
+		};
+		this._testEmbeddingEndpoint ??= this._instantiationService.createInstance(EmbeddingEndpoint, modelInformation);
+		return this._testEmbeddingEndpoint;
 	}
 }

--- a/src/platform/networking/common/networking.ts
+++ b/src/platform/networking/common/networking.ts
@@ -120,6 +120,10 @@ export function stringifyUrlOrRequestMetadata(urlOrRequestMetadata: string | Req
 	return JSON.stringify(urlOrRequestMetadata);
 }
 
+export interface IEmbeddingsEndpoint extends IEndpoint {
+	readonly maxBatchSize: number;
+}
+
 export interface IMakeChatRequestOptions {
 	/** The debug name for this request */
 	debugName: string;

--- a/test/base/cachingEmbeddingsFetcher.ts
+++ b/test/base/cachingEmbeddingsFetcher.ts
@@ -7,6 +7,7 @@ import { IAuthenticationService } from '../../src/platform/authentication/common
 import { ComputeEmbeddingsOptions, Embedding, EmbeddingType, EmbeddingVector, Embeddings, LEGACY_EMBEDDING_MODEL_ID, getWellKnownEmbeddingTypeInfo } from '../../src/platform/embeddings/common/embeddingsComputer';
 import { RemoteEmbeddingsComputer } from '../../src/platform/embeddings/common/remoteEmbeddingsComputer';
 import { ICAPIClientService } from '../../src/platform/endpoint/common/capiClient';
+import { IEndpointProvider } from '../../src/platform/endpoint/common/endpointProvider';
 import { IEnvService } from '../../src/platform/env/common/envService';
 import { ILogService } from '../../src/platform/log/common/logService';
 import { IFetcherService } from '../../src/platform/networking/common/fetcherService';
@@ -50,6 +51,7 @@ export class CachingEmbeddingsComputer extends RemoteEmbeddingsComputer {
 		@IFetcherService fetcherService: IFetcherService,
 		@ILogService logService: ILogService,
 		@ITelemetryService telemetryService: ITelemetryService,
+		@IEndpointProvider endpointProvider: IEndpointProvider
 	) {
 		super(
 			authService,
@@ -58,6 +60,7 @@ export class CachingEmbeddingsComputer extends RemoteEmbeddingsComputer {
 			fetcherService,
 			logService,
 			telemetryService,
+			endpointProvider
 		);
 	}
 


### PR DESCRIPTION
Bring back support for CAPI text-3-small embeddings endpoints.

This was removed as a part of https://github.com/microsoft/vscode-copilot-chat/pull/595
