### PR TITLE
Fix failing tests for markdown detection + Unskip passing tests

### DIFF
--- a/src/extension/prompt/common/codeGuesser.ts
+++ b/src/extension/prompt/common/codeGuesser.ts
@@ -37,6 +37,16 @@ function guessLineType(line: string): GuessedLineType {
 		return GuessedLineType.Code;
 	}
 
+	// If the line starts with a '#' followed by a space, it's possibly markdown header
+	// A popular exception is if the line contains C/C++ preprocessor directives
+	if (line.match(/^#+ .+$/)) {
+		const commonCppDirectives = ['# include', '# define', '# ifdef', '# ifndef', '# endif', '# pragma', '# if', '# else', '# elif', '# undef', '# error', '# line', '# warning'];
+		// If line does not contain any # directives used in C, C++.
+		if (!commonCppDirectives.some(directive => line.trim().startsWith(directive))) {
+			return GuessedLineType.NaturalLanguage;
+		}
+	}
+
 	// Natural Language Hints
 	{
 		// if the first character is upper-case

--- a/src/extension/prompt/node/test/codeGuesser.spec.ts
+++ b/src/extension/prompt/node/test/codeGuesser.spec.ts
@@ -79,14 +79,19 @@ suite('codeGuesser', () => {
 		assert.strictEqual(looksLikeCode(xmlSnippet), true);
 	});
 
-	test.skip('looksLikeCode - detects YAML as code', () => {
+	test('looksLikeCode - detects YAML as code', () => {
 		const yamlSnippet = 'key: value';
 		assert.strictEqual(looksLikeCode(yamlSnippet), true);
 	});
 
-	test.skip('looksLikeCode - detects Markdown as non-code', () => {
+	test('looksLikeCode - detects Markdown as non-code', () => {
 		const markdownSnippet = '# This is a heading';
 		assert.strictEqual(looksLikeCode(markdownSnippet), false);
+	});
+
+	test('looksLikeCode - detects C++ preprocessor directive as code', () => {
+		const cppPreprocessorSnippet = '# include <iostream>';
+		assert.strictEqual(looksLikeCode(cppPreprocessorSnippet), true);
 	});
 
 	test('looksLikeCode - detects plain text as non-code', () => {
@@ -94,7 +99,7 @@ suite('codeGuesser', () => {
 		assert.strictEqual(looksLikeCode(plainTextSnippet), false);
 	});
 
-	test.skip('looksLikeCode - detects shell script as code', () => {
+	test('looksLikeCode - detects shell script as code', () => {
 		const shellSnippet = 'echo "Hello World"';
 		assert.strictEqual(looksLikeCode(shellSnippet), true);
 	});


### PR DESCRIPTION
This PR does 2 things:
1. Fix the failing (and currently skipped) unit test `looksLikeCode - detects Markdown as non-code`
  - Any line that starts with `#` followed by a space is _most probably_ a markdown.
  - Except: C++ or C preprocessor directives like `# include <stdio.h>`
  - Python comment is another case, but we cannot detect them deterministically.  
2. Unskip already passing tests in `codeGuesser.spec.ts`