### PR TITLE
Fixes for responses API with BYOK

### DIFF
--- a/src/extension/byok/node/openAIEndpoint.ts
+++ b/src/extension/byok/node/openAIEndpoint.ts
@@ -86,6 +86,11 @@ export class OpenAIEndpoint extends ChatEndpoint {
 			body.stream_options = undefined;
 			if (!this.modelMetadata.capabilities.supports.thinking) {
 				body.reasoning = undefined;
+				body.include = undefined;
+			}
+			if (body.previous_response_id && !body.previous_response_id.startsWith('resp_')) {
+				// Don't use a response ID from CAPI
+				body.previous_response_id = undefined;
 			}
 			return body;
 		} else {


### PR DESCRIPTION
Port fixes from #1056
- Switching between BYOK and CAPI using responses API fails because we share the previous_response_id. It would be fine to send an invalid one because this is the same case as when it expires, but it's a different format.
- Using a non-reasoning BYOK openai model fails