### PR TITLE
errors - indicate rate limiting errors back to the client

### DIFF
--- a/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -389,6 +389,10 @@ export class CopilotLanguageModelWrapper extends Disposable {
 				const err = new vscode.LanguageModelError(details.message);
 				err.name = 'ChatQuotaExceeded';
 				throw err;
+			} else if (result.type === ChatFetchResponseType.RateLimited) {
+				const err = new Error(result.reason);
+				err.name = 'ChatRateLimited';
+				throw err;
 			}
 
 			throw new Error(result.reason);

--- a/src/extension/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/extension/vscode.proposed.chatParticipantPrivate.d.ts
@@ -182,6 +182,8 @@ declare module 'vscode' {
 
 		isQuotaExceeded?: boolean;
 
+		isRateLimited?: boolean;
+
 		level?: ChatErrorLevel;
 
 		code?: string;

--- a/src/platform/chat/common/commonTypes.ts
+++ b/src/platform/chat/common/commonTypes.ts
@@ -273,7 +273,8 @@ function getErrorDetailsFromChatFetchErrorInner(fetchResult: ChatFetchError, cop
 		case ChatFetchResponseType.RateLimited:
 			return {
 				message: getRateLimitMessage(fetchResult, hideRateLimitTimeEstimate),
-				level: ChatErrorLevel.Info
+				level: ChatErrorLevel.Info,
+				isRateLimited: true
 			};
 		case ChatFetchResponseType.QuotaExceeded:
 			return {


### PR DESCRIPTION
@lramos15 please have a look, this is for being able to show a specific UI for no-auth users in the client when a response is rate limited.