### PR TITLE
Enable responses API reasoning summaries by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -3060,7 +3060,7 @@
 					},
 					"github.copilot.chat.responsesApiReasoningSummary": {
 						"type": "string",
-						"default": "off",
+						"default": "detailed",
 						"markdownDescription": "%github.copilot.config.responsesApiReasoningSummary%",
 						"tags": [
 							"experimental",

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -750,7 +750,7 @@ export namespace ConfigKey {
 	/** Configure reasoning effort sent to Responses API */
 	export const ResponsesApiReasoningEffort = defineExpSetting<'low' | 'medium' | 'high' | 'default'>('chat.responsesApiReasoningEffort', 'default');
 	/** Configure reasoning summary style sent to Responses API */
-	export const ResponsesApiReasoningSummary = defineExpSetting<'off' | 'detailed'>('chat.responsesApiReasoningSummary', 'off');
+	export const ResponsesApiReasoningSummary = defineExpSetting<'off' | 'detailed'>('chat.responsesApiReasoningSummary', 'detailed');
 	export const EnableChatImageUpload = defineExpSetting<boolean>('chat.imageUpload.enabled', true);
 
 	/** Add context from recently used files */


### PR DESCRIPTION
Goes with #1089 so that this scenario can be fully supported without exp