### PR TITLE
Get copilot token faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"version": "0.32.0",
 	"build": "1",
 	"internalAIKey": "1058ec22-3c95-4951-8443-f26c1f325911",
-	"completionsCore": "3acd8894289d201737afff63c5183b567e6e2774",
+	"completionsCore": "3af6b0751a55539616515d4c1389511e771ddcdb",
 	"completionsCoreVersion": "1.372.0",
 	"internalLargeStorageAriaKey": "ec712b3202c5462fb6877acae7f1f9d7-c19ad55e-3e3c-4f99-984b-827f6d95bd9e-6917",
 	"ariaKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",

--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Raw } from '@vscode/prompt-tsx';
+import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
 import { FetchStreamSource } from '../../../platform/chat/common/chatMLFetcher';
 import { ChatFetchError, ChatFetchResponseType, ChatLocation } from '../../../platform/chat/common/commonTypes';
 import { toTextParts } from '../../../platform/chat/common/globalStringUtils';
@@ -96,6 +97,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		@ILanguageContextProviderService private readonly langCtxService: ILanguageContextProviderService,
 		@ILanguageDiagnosticsService private readonly langDiagService: ILanguageDiagnosticsService,
 		@IIgnoreService private readonly ignoreService: IIgnoreService,
+		@IAuthenticationService private readonly authenticationService: IAuthenticationService,
 	) {
 		this.delayer = new Delayer(this.configService, this.expService);
 		this.tracer = createTracer(['NES', 'XtabProvider'], (s) => this.logService.trace(s));
@@ -321,6 +323,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		logContext.setPrompt(messages);
 		telemetryBuilder.setPrompt(messages);
 
+		const secret = (await this.authenticationService.getCopilotToken(undefined, true)).token;
 		await this.debounce(delaySession, telemetryBuilder);
 		if (cancellationToken.isCancellationRequested) {
 			return Result.error(new NoNextEditReason.GotCancelled('afterDebounce'));
@@ -344,6 +347,9 @@ export class XtabProvider implements IStatelessNextEditProvider {
 				shouldRemoveCursorTagFromResponse,
 				promptingStrategy: promptOptions.promptingStrategy,
 				retryState,
+			},
+			{
+				secretKey: secret,
 			},
 			delaySession,
 			tracer,
@@ -448,6 +454,9 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			shouldRemoveCursorTagFromResponse: boolean;
 			retryState: RetryState;
 		},
+		requestOptions: {
+			secretKey: string;
+		},
 		delaySession: DelaySession,
 		parentTracer: ITracer,
 		telemetryBuilder: StatelessNextEditTelemetryBuilder,
@@ -496,6 +505,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 					temperature: 0,
 					stream: true,
 					prediction,
+					secretKey: requestOptions.secretKey,
 				} satisfies OptionalChatRequestParams,
 				userInitiatedRequest: undefined,
 				telemetryProperties: {

--- a/src/platform/authentication/common/authentication.ts
+++ b/src/platform/authentication/common/authentication.ts
@@ -120,10 +120,11 @@ export interface IAuthenticationService {
 	 * necessary.
 	 *
 	 * @param force will force a refresh of the token, even if not expired
+	 * @param fast will skip waiting for the GitHub session to be fetched before getting the Copilot token.
 	 * @returns a Copilot token or throws an error if none is found.
 	 * @note For best practice of handling of the user's authentication state, you should react to {@link onDidAuthenticationChange}.
 	 */
-	getCopilotToken(force?: boolean): Promise<CopilotToken>;
+	getCopilotToken(force?: boolean, fast?: boolean): Promise<CopilotToken>;
 
 	/**
 	 * Drop the current Copilot token as we received an HTTP error while trying
@@ -212,9 +213,11 @@ export abstract class BaseAuthenticationService extends Disposable implements IA
 	get copilotToken(): CopilotToken | undefined {
 		return this._tokenStore.copilotToken;
 	}
-	async getCopilotToken(force?: boolean): Promise<CopilotToken> {
+	async getCopilotToken(force?: boolean, fast?: boolean): Promise<CopilotToken> {
 		try {
-			await this.getAnyGitHubSession({ silent: true });
+			if (!fast) {
+				await this.getAnyGitHubSession({ silent: true });
+			}
 			// TODO: could this take in an auth session?
 			const token = await this._tokenManager.getCopilotToken(force);
 			this._tokenStore.copilotToken = token;


### PR DESCRIPTION
```Copilot Generated Description:``` Modify the `getCopilotToken` method to include a `fast` parameter that allows skipping the wait for the GitHub session, enabling faster retrieval of the Copilot token. Update related service implementations and usage to accommodate this change.

https://github.com/microsoft/vscode-internalbacklog/issues/5877