### PR TITLE
Try removing call to `getAnyGitHubSession`

### DIFF
--- a/src/platform/authentication/common/authentication.ts
+++ b/src/platform/authentication/common/authentication.ts
@@ -214,8 +214,6 @@ export abstract class BaseAuthenticationService extends Disposable implements IA
 	}
 	async getCopilotToken(force?: boolean): Promise<CopilotToken> {
 		try {
-			await this.getAnyGitHubSession({ silent: true });
-			// TODO: could this take in an auth session?
 			const token = await this._tokenManager.getCopilotToken(force);
 			this._tokenStore.copilotToken = token;
 			this._copilotTokenError = undefined;


### PR DESCRIPTION
To pave the way for no-auth flow.

This change seemed to work... It's been like [over a year since that's been there](https://github.com/microsoft/vscode-copilot/commit/1f6636e500298d9450213f74476d6aa1953948cf#diff-9db62a6d561075ca956f626ad3ff4449a0f48dacc55894af9796c2578312abe9R118-R119), and it was done intentionally... but you know this code has changed dramatically over the course of a year. The reason is lost on me.

Let's just see how this goes.

Fixes https://github.com/microsoft/vscode/issues/267989