### PR TITLE
Add `toolMetadata` to exported logs in JSON from chat debug view

### DIFF
--- a/src/extension/prompt/vscode-node/requestLoggerImpl.ts
+++ b/src/extension/prompt/vscode-node/requestLoggerImpl.ts
@@ -326,8 +326,7 @@ export class RequestLogger extends AbstractRequestLogger {
 	public override logToolCall(id: string, name: string, args: unknown, response: LanguageModelToolResult2, thinking?: ThinkingData): void {
 		const edits = this._workspaceEditRecorder?.getEditsAndReset();
 		// Extract toolMetadata from response if it exists
-		const extendedResponse = response as ExtendedLanguageModelToolResult;
-		const toolMetadata = extendedResponse.toolMetadata || undefined;
+		const toolMetadata = 'toolMetadata' in response ? (response as ExtendedLanguageModelToolResult).toolMetadata : undefined;
 		this._addEntry(new LoggedToolCall(
 			id,
 			name,

--- a/src/extension/prompt/vscode-node/requestLoggerImpl.ts
+++ b/src/extension/prompt/vscode-node/requestLoggerImpl.ts
@@ -229,7 +229,7 @@ class LoggedToolCall implements ILoggedToolCall {
 		public readonly time: number,
 		public readonly thinking?: ThinkingData,
 		public readonly edits?: { path: string; edits: string }[],
-		public readonly toolMetadata?: any,
+		public readonly toolMetadata?: unknown,
 	) { }
 
 	async toJSON(): Promise<object> {

--- a/src/extension/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/extension/vscode.proposed.chatParticipantPrivate.d.ts
@@ -236,7 +236,7 @@ declare module 'vscode' {
 	export class ExtendedLanguageModelToolResult extends LanguageModelToolResult {
 		toolResultMessage?: string | MarkdownString;
 		toolResultDetails?: Array<Uri | Location>;
-		toolMetadata?: any;
+		toolMetadata?: unknown;
 	}
 
 	// #region Chat participant detection

--- a/src/extension/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/extension/vscode.proposed.chatParticipantPrivate.d.ts
@@ -236,6 +236,7 @@ declare module 'vscode' {
 	export class ExtendedLanguageModelToolResult extends LanguageModelToolResult {
 		toolResultMessage?: string | MarkdownString;
 		toolResultDetails?: Array<Uri | Location>;
+		toolMetadata?: any;
 	}
 
 	// #region Chat participant detection


### PR DESCRIPTION
<img width="1197" height="449" alt="image" src="https://github.com/user-attachments/assets/828c23d9-4d68-4d58-bae6-96f9009a06f4" />

Upstream PR: microsoft/vscode#268182