### PR TITLE
set enablement context for command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1803,7 +1803,8 @@
 			{
 				"command": "github.copilot.chat.replay",
 				"title": "Start Chat Replay",
-				"icon": "$(debug-line-by-line)"
+				"icon": "$(debug-line-by-line)",
+				"enablement": "resourceLangId == chatReplay && !inDebugMode"
 			},
 			{
 				"command": "github.copilot.chat.replay.enableWorkspaceEditTracing",


### PR DESCRIPTION
don't show the command when not appropriate