### PR TITLE
Fix pipeline for code completions

### DIFF
--- a/build/pre-release.yml
+++ b/build/pre-release.yml
@@ -98,12 +98,13 @@ extends:
         displayName: mixin
 
       - pwsh: |
+          $ErrorActionPreference = "Stop"
           $result = git config --get-regexp .*extraheader ^AUTHORIZATION:
           $basicToken = $result -split "AUTHORIZATION: basic " | Select-Object -Last 1
           $oauthToken = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($basicToken)) -split ":" | Select-Object -Last 1
           $PackageJson = Get-Content -Path package.json -Raw | ConvertFrom-Json
           $CompletionsCoreVersion = $PackageJson.completionsCore
-          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git --depth 1 src/extension/completions-core
+          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git src/extension/completions-core
           pushd src/extension/completions-core
           git checkout $CompletionsCoreVersion
           popd
@@ -177,12 +178,13 @@ extends:
         displayName: Install dotnet cli
 
       - pwsh: |
+          $ErrorActionPreference = "Stop"
           $result = git config --get-regexp .*extraheader ^AUTHORIZATION:
           $basicToken = $result -split "AUTHORIZATION: basic " | Select-Object -Last 1
           $oauthToken = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($basicToken)) -split ":" | Select-Object -Last 1
           $PackageJson = Get-Content -Path package.json -Raw | ConvertFrom-Json
           $CompletionsCoreVersion = $PackageJson.completionsCore
-          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git --depth 1 src/extension/completions-core
+          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git src/extension/completions-core
           pushd src/extension/completions-core
           git checkout $CompletionsCoreVersion
           popd

--- a/build/release.yml
+++ b/build/release.yml
@@ -100,12 +100,13 @@ extends:
         displayName: mixin
 
       - pwsh: |
+          $ErrorActionPreference = "Stop"
           $result = git config --get-regexp .*extraheader ^AUTHORIZATION:
           $basicToken = $result -split "AUTHORIZATION: basic " | Select-Object -Last 1
           $oauthToken = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($basicToken)) -split ":" | Select-Object -Last 1
           $PackageJson = Get-Content -Path package.json -Raw | ConvertFrom-Json
           $CompletionsCoreVersion = $PackageJson.completionsCore
-          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git --depth 1 src/extension/completions-core
+          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git src/extension/completions-core
           pushd src/extension/completions-core
           git checkout $CompletionsCoreVersion
           popd
@@ -179,12 +180,13 @@ extends:
         displayName: Install dotnet cli
 
       - pwsh: |
+          $ErrorActionPreference = "Stop"
           $result = git config --get-regexp .*extraheader ^AUTHORIZATION:
           $basicToken = $result -split "AUTHORIZATION: basic " | Select-Object -Last 1
           $oauthToken = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($basicToken)) -split ":" | Select-Object -Last 1
           $PackageJson = Get-Content -Path package.json -Raw | ConvertFrom-Json
           $CompletionsCoreVersion = $PackageJson.completionsCore
-          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git --depth 1 src/extension/completions-core
+          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git src/extension/completions-core
           pushd src/extension/completions-core
           git checkout $CompletionsCoreVersion
           popd


### PR DESCRIPTION
```Copilot Generated Description:``` Update the pipeline to correctly clone the completions-core repository without the depth parameter. Set the error action preference to stop for better error handling.

fixes https://github.com/microsoft/vscode/issues/268280