### PR TITLE
Revert "Allow execute prompt/task tools inside of execute prompt/task"

### DIFF
--- a/src/extension/prompt/node/executePromptToolCalling.ts
+++ b/src/extension/prompt/node/executePromptToolCalling.ts
@@ -73,8 +73,7 @@ export class ExecutePromptToolCallingLoop extends ToolCallingLoop<IExecutePrompt
 	}
 
 	protected async getAvailableTools(): Promise<LanguageModelToolInformation[]> {
-		// Exclude the todo list tool because there's only one todo list. We don't want a sub agent messing with it.
-		const excludedTools = new Set([ToolName.CoreManageTodoList]);
+		const excludedTools = new Set([ToolName.ExecutePrompt, ToolName.ExecuteTask, ToolName.CoreManageTodoList]);
 		return (await getAgentTools(this.instantiationService, this.options.request))
 			.filter(tool => !excludedTools.has(tool.name as ToolName))
 			// TODO can't do virtual tools at this level


### PR DESCRIPTION
Reverts microsoft/vscode-copilot-chat#1102

@digitarald was seeing infinite recursion... I saw it a couple of times. Let's disable it for now. I feel like for the future, it would be good to have this functionality, but I can workaround it for my use case.