### PR TITLE
edits: add edit tool 'learning' for byok

### DIFF
--- a/src/extension/extension/vscode/services.ts
+++ b/src/extension/extension/vscode/services.ts
@@ -94,6 +94,7 @@ import { IMergeConflictService } from '../../git/common/mergeConflictService';
 import { MergeConflictServiceImpl } from '../../git/vscode/mergeConflictServiceImpl';
 import { ILaunchConfigService } from '../../onboardDebug/common/launchConfigService';
 import { LaunchConfigService } from '../../onboardDebug/vscode/launchConfigService';
+import { EditToolLearningService, IEditToolLearningService } from '../../tools/common/editToolLearningService';
 import { ToolGroupingService } from '../../tools/common/virtualTools/toolGroupingService';
 import { ToolGroupingCache } from '../../tools/common/virtualTools/virtualToolGroupCache';
 import { IToolGroupingCache, IToolGroupingService } from '../../tools/common/virtualTools/virtualToolTypes';
@@ -170,4 +171,5 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 	builder.define(IToolGroupingService, new SyncDescriptor(ToolGroupingService));
 	builder.define(IToolGroupingCache, new SyncDescriptor(ToolGroupingCache));
 	builder.define(IMergeConflictService, new SyncDescriptor(MergeConflictServiceImpl));
+	builder.define(IEditToolLearningService, new SyncDescriptor(EditToolLearningService));
 }

--- a/src/extension/intents/node/agentIntent.ts
+++ b/src/extension/intents/node/agentIntent.ts
@@ -42,6 +42,7 @@ import { ICodeMapperService } from '../../prompts/node/codeMapper/codeMapperServ
 import { TemporalContextStats } from '../../prompts/node/inline/temporalContext';
 import { EditCodePrompt2 } from '../../prompts/node/panel/editCodePrompt2';
 import { ToolResultMetadata } from '../../prompts/node/panel/toolCalling';
+import { IEditToolLearningService } from '../../tools/common/editToolLearningService';
 import { ContributedToolName, ToolName } from '../../tools/common/toolNames';
 import { IToolsService } from '../../tools/common/toolsService';
 import { VirtualTool } from '../../tools/common/virtualTools/virtualTool';
@@ -59,45 +60,55 @@ export const getAgentTools = (instaService: IInstantiationService, request: vsco
 		const configurationService = accessor.get<IConfigurationService>(IConfigurationService);
 		const experimentationService = accessor.get<IExperimentationService>(IExperimentationService);
 		const endpointProvider = accessor.get<IEndpointProvider>(IEndpointProvider);
+		const editToolLearningService = accessor.get(IEditToolLearningService);
 		const model = await endpointProvider.getChatEndpoint(request);
 
 		const allowTools: Record<string, boolean> = {};
-		allowTools[ToolName.EditFile] = true;
-		allowTools[ToolName.ReplaceString] = modelSupportsReplaceString(model);
-		allowTools[ToolName.ApplyPatch] = await modelSupportsApplyPatch(model) && !!toolsService.getTool(ToolName.ApplyPatch);
 
-		if (allowTools[ToolName.ApplyPatch] && modelCanUseApplyPatchExclusively(model) && configurationService.getExperimentBasedConfig(ConfigKey.Internal.Gpt5ApplyPatchExclusively, experimentationService)) {
-			allowTools[ToolName.EditFile] = false;
-		}
+		const learned = editToolLearningService.getPreferredEndpointEditTool(model);
+		if (learned) { // a learning-enabled (BYOK) model, we should go with what it prefers
+			allowTools[ToolName.EditFile] = learned.includes(ToolName.EditFile);
+			allowTools[ToolName.ReplaceString] = learned.includes(ToolName.ReplaceString);
+			allowTools[ToolName.MultiReplaceString] = learned.includes(ToolName.MultiReplaceString);
+			allowTools[ToolName.ApplyPatch] = learned.includes(ToolName.ApplyPatch);
+		} else {
+			allowTools[ToolName.EditFile] = true;
+			allowTools[ToolName.ReplaceString] = modelSupportsReplaceString(model);
+			allowTools[ToolName.ApplyPatch] = await modelSupportsApplyPatch(model) && !!toolsService.getTool(ToolName.ApplyPatch);
 
-		if (model.family === 'grok-code') {
-			const treatment = experimentationService.getTreatmentVariable<string>('copilotchat.hiddenModelBEditTool');
-			switch (treatment) {
-				case 'with_replace_string':
-					allowTools[ToolName.ReplaceString] = true;
-					allowTools[ToolName.MultiReplaceString] = configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceStringGrok, experimentationService);
-					allowTools[ToolName.EditFile] = true;
-					break;
-				case 'only_replace_string':
-					allowTools[ToolName.ReplaceString] = true;
-					allowTools[ToolName.MultiReplaceString] = configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceStringGrok, experimentationService);
-					allowTools[ToolName.EditFile] = false;
-					break;
-				case 'control':
-				default:
-					allowTools[ToolName.ReplaceString] = false;
-					allowTools[ToolName.EditFile] = true;
+			if (allowTools[ToolName.ApplyPatch] && modelCanUseApplyPatchExclusively(model) && configurationService.getExperimentBasedConfig(ConfigKey.Internal.Gpt5ApplyPatchExclusively, experimentationService)) {
+				allowTools[ToolName.EditFile] = false;
 			}
-		}
 
-		if (modelCanUseReplaceStringExclusively(model)) {
-			allowTools[ToolName.ReplaceString] = true;
-			allowTools[ToolName.EditFile] = false;
-		}
+			if (model.family === 'grok-code') {
+				const treatment = experimentationService.getTreatmentVariable<string>('copilotchat.hiddenModelBEditTool');
+				switch (treatment) {
+					case 'with_replace_string':
+						allowTools[ToolName.ReplaceString] = true;
+						allowTools[ToolName.MultiReplaceString] = configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceStringGrok, experimentationService);
+						allowTools[ToolName.EditFile] = true;
+						break;
+					case 'only_replace_string':
+						allowTools[ToolName.ReplaceString] = true;
+						allowTools[ToolName.MultiReplaceString] = configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceStringGrok, experimentationService);
+						allowTools[ToolName.EditFile] = false;
+						break;
+					case 'control':
+					default:
+						allowTools[ToolName.ReplaceString] = false;
+						allowTools[ToolName.EditFile] = true;
+				}
+			}
 
-		if (allowTools[ToolName.ReplaceString]) {
-			if (modelSupportsMultiReplaceString(model) && configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceString, experimentationService)) {
-				allowTools[ToolName.MultiReplaceString] = true;
+			if (modelCanUseReplaceStringExclusively(model)) {
+				allowTools[ToolName.ReplaceString] = true;
+				allowTools[ToolName.EditFile] = false;
+			}
+
+			if (allowTools[ToolName.ReplaceString]) {
+				if (modelSupportsMultiReplaceString(model) && configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceString, experimentationService)) {
+					allowTools[ToolName.MultiReplaceString] = true;
+				}
 			}
 		}
 

--- a/src/extension/test/vscode-node/services.ts
+++ b/src/extension/test/vscode-node/services.ts
@@ -101,6 +101,7 @@ import { PromptVariablesServiceImpl } from '../../prompt/vscode-node/promptVaria
 import { CodeMapperService, ICodeMapperService } from '../../prompts/node/codeMapper/codeMapperService';
 import { FixCookbookService, IFixCookbookService } from '../../prompts/node/inline/fixCookbookService';
 import { WorkspaceMutationManager } from '../../testing/node/setupTestsFileManager';
+import { EditToolLearningService, IEditToolLearningService } from '../../tools/common/editToolLearningService';
 import { IToolsService, NullToolsService } from '../../tools/common/toolsService';
 import { ToolGroupingService } from '../../tools/common/virtualTools/toolGroupingService';
 import { ToolGroupingCache } from '../../tools/common/virtualTools/virtualToolGroupCache';
@@ -148,6 +149,7 @@ export function createExtensionTestingServices(): TestingServiceCollection {
 	testingServiceCollection.define(INaiveChunkingService, new SyncDescriptor(NaiveChunkingService));
 	testingServiceCollection.define(ILinkifyService, new SyncDescriptor(LinkifyService));
 	testingServiceCollection.define(ITestGenInfoStorage, new SyncDescriptor(TestGenInfoStorage));
+	testingServiceCollection.define(IEditToolLearningService, new SyncDescriptor(EditToolLearningService));
 	testingServiceCollection.define(IDebugCommandToConfigConverter, new SyncDescriptor(DebugCommandToConfigConverter));
 	testingServiceCollection.define(ILaunchConfigService, new SyncDescriptor(LaunchConfigService));
 	testingServiceCollection.define(IDebuggableCommandIdentifier, new SyncDescriptor(DebuggableCommandIdentifier));

--- a/src/extension/tools/common/editToolLearningService.ts
+++ b/src/extension/tools/common/editToolLearningService.ts
@@ -1,0 +1,192 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { LanguageModelChat } from 'vscode';
+import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
+import { IChatEndpoint } from '../../../platform/networking/common/networking';
+import { createServiceIdentifier } from '../../../util/common/services';
+import { LRUCache } from '../../../util/vs/base/common/map';
+import { mapValues } from '../../../util/vs/base/common/objects';
+import { EditTools as _EditTools, EDIT_TOOL_LEARNING_STATES, IEditToolLearningData, LearningConfig, State } from './editToolLearningStates';
+import { ToolName } from './toolNames';
+
+export type EditTools = _EditTools;
+
+const CACHE_STORAGE_KEY = 'editToolLearning_cache';
+
+function mapToolsRecord<I, O>(record: { [K in EditTools]?: I }, fn: (input: I, tool: EditTools) => O) {
+	return mapValues(record, (value, key) => fn(value!, key as EditTools)) as { [K in EditTools]?: O };
+}
+
+interface IStoredToolData {
+	state: State;
+	tools: { [K in EditTools]?: { successBitset: string; attempts: number } };
+}
+
+export const IEditToolLearningService = createServiceIdentifier<IEditToolLearningService>('IEditToolLearningService');
+
+export interface IEditToolLearningService {
+	readonly _serviceBrand: undefined;
+	getPreferredEditTool(model: LanguageModelChat): Promise<EditTools[] | undefined>;
+	getPreferredEndpointEditTool(model: IChatEndpoint): EditTools[] | undefined;
+	didMakeEdit(model: LanguageModelChat, tool: EditTools, success: boolean): void;
+}
+
+function addToWindow(window: bigint, bit: bigint): bigint {
+	// Shift left to make room for new bit, add the bit, then mask to WINDOW_SIZE
+	const mask = (1n << BigInt(LearningConfig.WINDOW_SIZE)) - 1n;
+	return ((window << 1n) | bit) & mask;
+}
+
+export class EditToolLearningService implements IEditToolLearningService {
+	readonly _serviceBrand: undefined;
+
+	private _cache?: LRUCache<string, IEditToolLearningData>;
+
+	constructor(
+		@IVSCodeExtensionContext private readonly _context: IVSCodeExtensionContext,
+		@IEndpointProvider private readonly _endpointProvider: IEndpointProvider,
+	) { }
+
+	async getPreferredEditTool(model: LanguageModelChat): Promise<EditTools[] | undefined> {
+		const endpoint = await this._endpointProvider.getChatEndpoint(model);
+		return this.getPreferredEndpointEditTool(endpoint);
+	}
+
+	getPreferredEndpointEditTool(endpoint: IChatEndpoint): EditTools[] | undefined {
+		if (!endpoint.isExtensionContributed) {
+			return undefined;
+		}
+
+		const hardcoded = this._getHardcodedPreferences(endpoint.model);
+		if (hardcoded) {
+			return hardcoded;
+		}
+
+		const learningData = this._getModelLearningData(endpoint.model);
+		return this._computePreferences(learningData);
+	}
+
+	async didMakeEdit(model: LanguageModelChat, tool: EditTools, success: boolean): Promise<void> {
+		const endpoint = await this._endpointProvider.getChatEndpoint(model);
+
+		if (!endpoint.isExtensionContributed || this._getHardcodedPreferences(endpoint.family)) {
+			return;
+		}
+
+		const learningData = this._getModelLearningData(model.id);
+		this._recordEdit(learningData, tool, success);
+		await this._saveModelLearningData(model.id, learningData);
+	}
+
+	private _getHardcodedPreferences(family: string): EditTools[] | undefined {
+		const lowerFamily = family.toLowerCase();
+
+		if (lowerFamily.includes('gpt') || lowerFamily.includes('openai')) {
+			return [ToolName.ApplyPatch];
+		}
+
+		if (lowerFamily.includes('sonnet')) {
+			return [ToolName.ReplaceString, ToolName.MultiReplaceString];
+		}
+
+		return undefined;
+	}
+
+	private _computePreferences(data: IEditToolLearningData): EditTools[] | undefined {
+		return EDIT_TOOL_LEARNING_STATES[data.state].allowedTools;
+	}
+
+	private _checkStateTransitions(data: IEditToolLearningData): State {
+		const currentConfig = EDIT_TOOL_LEARNING_STATES[data.state];
+
+		for (const [targetState, condition] of Object.entries(currentConfig.transitions)) {
+			if (condition(data)) {
+				return Number(targetState) as State;
+			}
+		}
+
+		return data.state; // No transition
+	}
+
+	private _recordEdit(data: IEditToolLearningData, tool: EditTools, success: boolean): void {
+		const successBit = success ? 1n : 0n;
+		const toolData = (data.tools[tool] ??= { successBitset: 0n, attempts: 0 });
+		toolData.successBitset = addToWindow(toolData.successBitset, successBit);
+		toolData.attempts++;
+
+		const newState = this._checkStateTransitions(data);
+		if (newState !== data.state) {
+			data.state = newState;
+			data.tools = {};
+		}
+	}
+
+	private _getCache(): LRUCache<string, IEditToolLearningData> {
+		if (!this._cache) {
+			this._cache = this._loadCacheFromStorage();
+		}
+		return this._cache;
+	}
+
+	private _loadCacheFromStorage(): LRUCache<string, IEditToolLearningData> {
+		const cache = new LRUCache<string, IEditToolLearningData>(LearningConfig.CACHE_SIZE);
+		const storedCacheData = this._context.globalState.get<{ entries: [string, IStoredToolData][] }>(CACHE_STORAGE_KEY);
+
+		if (!storedCacheData?.entries) {
+			return cache;
+		}
+
+		for (const [modelId, storedData] of storedCacheData.entries) {
+			const data: IEditToolLearningData = {
+				state: storedData.state,
+				tools: mapToolsRecord(storedData.tools, r => ({
+					successBitset: BigInt(r.successBitset),
+					attempts: r.attempts,
+				})),
+			};
+			cache.set(modelId, data);
+		}
+
+		return cache;
+	}
+
+	private async _saveCacheToStorage(): Promise<void> {
+		if (!this._cache) {
+			return;
+		}
+
+		const entries: [string, IStoredToolData][] = Array.from(this._cache.entries(), ([modelId, data]) => {
+			const storedData = {
+				state: data.state,
+				tools: mapToolsRecord(data.tools, r => ({
+					successBitset: '0x' + r.successBitset.toString(16),
+					attempts: r.attempts
+				})),
+			};
+			return [modelId, storedData];
+		});
+
+		await this._context.globalState.update(CACHE_STORAGE_KEY, { entries });
+	}
+
+	private async _saveModelLearningData(modelId: string, data: IEditToolLearningData): Promise<void> {
+		const cache = this._getCache();
+		cache.set(modelId, data);
+		await this._saveCacheToStorage();
+	}
+
+	private _getModelLearningData(modelId: string): IEditToolLearningData {
+		const cache = this._getCache();
+
+		let data = cache.get(modelId);
+		if (!data) {
+			data = { state: State.Initial, tools: {} };
+			cache.set(modelId, data);
+		}
+		return data;
+	}
+}

--- a/src/extension/tools/common/editToolLearningStates.ts
+++ b/src/extension/tools/common/editToolLearningStates.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ToolName } from './toolNames';
+
+export type EditTools = ToolName.ApplyPatch | ToolName.ReplaceString | ToolName.EditFile | ToolName.MultiReplaceString;
+
+
+export interface IEditToolLearningData {
+	state: State;
+	tools: { [K in EditTools]?: ToolLearningData };
+}
+
+export const enum LearningConfig {
+	/** Rolling window size for tracking recent edit successes/failures per tool */
+	WINDOW_SIZE = 100,
+	/** Maximum number of models to keep in memory cache before LRU eviction */
+	CACHE_SIZE = 50,
+	/** Minimum attempts before making state transition decisions */
+	MIN_SAMPLE_SIZE = LearningConfig.WINDOW_SIZE * (2 / 3),
+	/** Success rate threshold for considering replace_string to be a usable tool */
+	SR_SUCCESS_THRESHOLD = 0.8,
+	/** Failure rate threshold to disable replace_string */
+	SR_FAILURE_THRESHOLD = 0.3,
+	/** Success rate threshold for considering multi_replace_string to be a usable tool */
+	MULTISR_SUCCESS_THRESHOLD = 0.7,
+	/** Failure rate threshold to disable multi_replace_string */
+	MULTISR_FAILURE_THRESHOLD = 0.4,
+}
+
+export const enum State {
+	Initial,
+	ReplaceStringForced,
+	ReplaceStringMaybeMulti,
+	EditFileOnly,
+	ReplaceStringOnly,
+	ReplaceStringWithMulti,
+}
+
+
+interface StateConfig {
+	allowedTools: EditTools[];
+	transitions: { [K in State]?: (data: IEditToolLearningData) => boolean };
+}
+
+
+interface ToolLearningData {
+	successBitset: bigint;
+	attempts: number;
+}
+
+// Top-level helper functions
+function getSuccessRate(successBitset: bigint, totalAttempts: number): number {
+	if (totalAttempts === 0) {
+		return 0;
+	}
+
+	const actualBits = Math.min(totalAttempts, LearningConfig.WINDOW_SIZE);
+	let successCount = 0;
+
+	for (let i = 0; i < actualBits; i++) {
+		if ((successBitset >> BigInt(i)) & 1n) {
+			successCount++;
+		}
+	}
+
+	return successCount / actualBits;
+}
+
+
+function sampleSize(data: IEditToolLearningData, tool: EditTools): number {
+	return Math.min(data.tools[tool]?.attempts || 0, LearningConfig.WINDOW_SIZE);
+}
+
+function successRate(data: IEditToolLearningData, tool: EditTools): number {
+	const toolData = data.tools[tool];
+	if (!toolData) { return 0; }
+	return getSuccessRate(toolData.successBitset, toolData.attempts);
+}
+
+export const EDIT_TOOL_LEARNING_STATES: Record<State, StateConfig> = {
+	[State.Initial]: {
+		allowedTools: [ToolName.EditFile, ToolName.ReplaceString],
+		transitions: {
+			[State.ReplaceStringMaybeMulti]: d =>
+				sampleSize(d, ToolName.ReplaceString) > LearningConfig.MIN_SAMPLE_SIZE &&
+				successRate(d, ToolName.ReplaceString) > LearningConfig.SR_SUCCESS_THRESHOLD,
+			[State.EditFileOnly]: d =>
+				sampleSize(d, ToolName.ReplaceString) > LearningConfig.MIN_SAMPLE_SIZE &&
+				successRate(d, ToolName.ReplaceString) < LearningConfig.SR_FAILURE_THRESHOLD,
+			[State.ReplaceStringForced]: d => {
+				// Models are instructed to prefer replace_string to insert_edit. If
+				// this model is not doing that (more than 70% of edits are insert_edit),
+				// force it to so we can get more data.
+				const editFileAttempts = sampleSize(d, ToolName.EditFile);
+				const replaceStringAttempts = sampleSize(d, ToolName.ReplaceString);
+				return editFileAttempts > LearningConfig.MIN_SAMPLE_SIZE && editFileAttempts / (editFileAttempts + replaceStringAttempts) > 0.7;
+			},
+		},
+	},
+	[State.ReplaceStringForced]: {
+		allowedTools: [ToolName.ReplaceString],
+		transitions: {
+			[State.ReplaceStringMaybeMulti]: d =>
+				sampleSize(d, ToolName.ReplaceString) > LearningConfig.MIN_SAMPLE_SIZE &&
+				successRate(d, ToolName.ReplaceString) > LearningConfig.SR_SUCCESS_THRESHOLD,
+			[State.EditFileOnly]: d =>
+				sampleSize(d, ToolName.ReplaceString) > LearningConfig.MIN_SAMPLE_SIZE &&
+				successRate(d, ToolName.ReplaceString) < LearningConfig.SR_FAILURE_THRESHOLD,
+		},
+	},
+	[State.ReplaceStringMaybeMulti]: {
+		allowedTools: [ToolName.ReplaceString, ToolName.MultiReplaceString],
+		transitions: {
+			[State.ReplaceStringWithMulti]: d =>
+				sampleSize(d, ToolName.MultiReplaceString) > LearningConfig.MIN_SAMPLE_SIZE &&
+				successRate(d, ToolName.MultiReplaceString) > LearningConfig.MULTISR_SUCCESS_THRESHOLD,
+			[State.ReplaceStringOnly]: d =>
+				sampleSize(d, ToolName.MultiReplaceString) > LearningConfig.MIN_SAMPLE_SIZE &&
+				successRate(d, ToolName.MultiReplaceString) < LearningConfig.MULTISR_FAILURE_THRESHOLD,
+		},
+	},
+
+	// Terminal states have no transitions
+	[State.EditFileOnly]: {
+		allowedTools: [ToolName.EditFile],
+		transitions: {},
+	},
+	[State.ReplaceStringOnly]: {
+		allowedTools: [ToolName.ReplaceString],
+		transitions: {},
+	},
+	[State.ReplaceStringWithMulti]: {
+		allowedTools: [ToolName.ReplaceString, ToolName.MultiReplaceString],
+		transitions: {},
+	},
+};

--- a/src/extension/tools/node/abstractReplaceStringTool.tsx
+++ b/src/extension/tools/node/abstractReplaceStringTool.tsx
@@ -29,6 +29,7 @@ import { ChatResponseTextEditPart, EndOfLine, Position as ExtPosition, LanguageM
 import { IBuildPromptContext } from '../../prompt/common/intents';
 import { renderPromptElementJSON } from '../../prompts/node/base/promptRenderer';
 import { CellOrNotebookEdit, processFullRewriteNotebookEdits } from '../../prompts/node/codeMapper/codeMapper';
+import { EditTools, IEditToolLearningService } from '../common/editToolLearningService';
 import { ToolName } from '../common/toolNames';
 import { ICopilotTool } from '../common/toolsRegistry';
 import { IToolsService } from '../common/toolsService';
@@ -72,6 +73,7 @@ export abstract class AbstractReplaceStringTool<T extends { explanation: string 
 		@IEndpointProvider private readonly endpointProvider: IEndpointProvider,
 		@IExperimentationService private readonly experimentationService: IExperimentationService,
 		@IConfigurationService protected readonly configurationService: IConfigurationService,
+		@IEditToolLearningService private readonly editToolLearningService: IEditToolLearningService,
 	) { }
 
 	public abstract invoke(options: vscode.LanguageModelToolInvocationOptions<T>, token: vscode.CancellationToken): Promise<LanguageModelToolResult>;
@@ -295,10 +297,12 @@ export abstract class AbstractReplaceStringTool<T extends { explanation: string 
 			);
 			updatedFile = result.updatedFile;
 			edits = result.edits;
+			this.recordEditSuccess(options, true);
 		} catch (e) {
 			if (!(e instanceof NoMatchError)) {
 				throw e;
 			}
+			this.recordEditSuccess(options, false);
 
 			if (this.experimentationService.getTreatmentVariable<boolean>('copilotchat.disableReplaceStringHealing') === true) {
 				throw e; // failsafe for next release.
@@ -412,6 +416,12 @@ export abstract class AbstractReplaceStringTool<T extends { explanation: string 
 
 	protected async modelForTelemetry(options: vscode.LanguageModelToolInvocationOptions<T>) {
 		return options.model && (await this.endpointProvider.getChatEndpoint(options.model)).model;
+	}
+
+	private async recordEditSuccess(options: vscode.LanguageModelToolInvocationOptions<T>, success: boolean) {
+		if (options.model) {
+			this.editToolLearningService.didMakeEdit(options.model, this.toolName() as EditTools, success);
+		}
 	}
 
 	async resolveInput(input: T, promptContext: IBuildPromptContext): Promise<T> {

--- a/src/extension/tools/node/insertEditTool.tsx
+++ b/src/extension/tools/node/insertEditTool.tsx
@@ -16,6 +16,7 @@ import { IInstantiationService } from '../../../util/vs/platform/instantiation/c
 import { LanguageModelPromptTsxPart, LanguageModelToolResult } from '../../../vscodeTypes';
 import { IBuildPromptContext } from '../../prompt/common/intents';
 import { renderPromptElementJSON } from '../../prompts/node/base/promptRenderer';
+import { EditTools, IEditToolLearningService } from '../common/editToolLearningService';
 import { ToolName } from '../common/toolNames';
 import { ICopilotTool, ToolRegistry } from '../common/toolsRegistry';
 import { IToolsService } from '../common/toolsService';
@@ -46,6 +47,7 @@ export class EditFileTool implements ICopilotTool<IEditFileParams> {
 		@IAlternativeNotebookContentService private readonly alternativeNotebookContentService: IAlternativeNotebookContentService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 		@IEndpointProvider private readonly endpointProvider: IEndpointProvider,
+		@IEditToolLearningService private readonly editToolLearningService: IEditToolLearningService,
 	) { }
 
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<IEditFileParams>, token: vscode.CancellationToken) {
@@ -66,7 +68,13 @@ export class EditFileTool implements ICopilotTool<IEditFileParams> {
 				uri
 			}
 		};
-		await this.toolsService.invokeTool(InternalEditToolId, internalOptions, token);
+		try {
+			await this.toolsService.invokeTool(InternalEditToolId, internalOptions, token);
+			void this.recordEditSuccess(options, ToolName.EditFile as EditTools, true);
+		} catch (error) {
+			void this.recordEditSuccess(options, ToolName.EditFile as EditTools, false);
+			throw error;
+		}
 
 		const isNotebook = this.notebookService.hasSupportedNotebooks(uri);
 		const document = isNotebook ?
@@ -109,6 +117,11 @@ export class EditFileTool implements ICopilotTool<IEditFileParams> {
 		return input;
 	}
 
+	private recordEditSuccess(options: vscode.LanguageModelToolInvocationOptions<IEditFileParams>, tool: EditTools, success: boolean) {
+		if (options.model) {
+			this.editToolLearningService.didMakeEdit(options.model, ToolName.EditFile, success);
+		}
+	}
 }
 
 ToolRegistry.registerTool(EditFileTool);

--- a/src/extension/tools/node/test/editToolLearningService.spec.ts
+++ b/src/extension/tools/node/test/editToolLearningService.spec.ts
@@ -1,0 +1,352 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LanguageModelChat } from 'vscode';
+import { IEndpointProvider } from '../../../../platform/endpoint/common/endpointProvider';
+import { IChatEndpoint } from '../../../../platform/networking/common/networking';
+import { MockExtensionContext } from '../../../../platform/test/node/extensionContext';
+import { EditToolLearningService, EditTools } from '../../common/editToolLearningService';
+import { LearningConfig } from '../../common/editToolLearningStates';
+import { ToolName } from '../../common/toolNames';
+
+describe('EditToolLearningService', () => {
+	let service: EditToolLearningService;
+	let mockContext: MockExtensionContext;
+	let mockEndpointProvider: IEndpointProvider;
+
+	// Helper to create mock language model
+	const createMockModel = (id = 'test-model'): LanguageModelChat => ({
+		id,
+		name: 'Test Model',
+		vendor: 'test-vendor',
+		family: 'test-family',
+		version: '1.0',
+		maxInputTokens: 4000,
+		capabilities: {
+			supportsToolCalling: true,
+			supportsImageToText: false,
+		},
+		countTokens: vi.fn(),
+		sendRequest: vi.fn(),
+	});
+
+	// Helper to create mock endpoint
+	const createMockEndpoint = (isExtensionContributed: boolean, family = 'test-family', model: LanguageModelChat): IChatEndpoint => ({
+		family,
+		model: model.id,
+		maxOutputTokens: 1000,
+		supportsToolCalls: true,
+		supportsVision: false,
+		supportsPrediction: false,
+		showInModelPicker: true,
+		isDefault: false,
+		isFallback: false,
+		isExtensionContributed,
+		policy: 'enabled',
+		urlOrRequestMetadata: 'test-url',
+		modelMaxPromptTokens: 4000,
+		name: 'test-model',
+		version: '1.0',
+		tokenizer: 'gpt',
+		acceptChatPolicy: vi.fn().mockResolvedValue(true),
+		processResponseFromChatEndpoint: vi.fn(),
+		acquireTokenizer: vi.fn(),
+		createChatCompletionRequest: vi.fn(),
+	} as any);
+
+	// Helper to simulate multiple edits for a tool
+	const simulateEdits = async (model: LanguageModelChat, tool: EditTools, successes: number, failures: number) => {
+		for (let i = 0; i < successes; i++) {
+			await service.didMakeEdit(model, tool, true);
+		}
+		for (let i = 0; i < failures; i++) {
+			await service.didMakeEdit(model, tool, false);
+		}
+	};
+
+	beforeEach(() => {
+		mockEndpointProvider = {
+			getChatEndpoint: vi.fn(),
+		} as any;
+
+		mockContext = new MockExtensionContext();
+		// Set up proper spies for global state methods
+		mockContext.globalState.get = vi.fn().mockReturnValue(undefined);
+		mockContext.globalState.update = vi.fn().mockResolvedValue(undefined);
+		service = new EditToolLearningService(mockContext as any, mockEndpointProvider);
+	});
+
+	describe('getPreferredEditTool', () => {
+		it('should return undefined for non-extension-contributed models', async () => {
+			const model = createMockModel();
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(false, undefined, model)
+			);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should return ApplyPatch for GPT family models', async () => {
+			const model = createMockModel('gpt-4');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'gpt', model)
+			);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.ApplyPatch]);
+		});
+
+		it('should return ApplyPatch for OpenAI family models', async () => {
+			const model = createMockModel('openai-gpt-3.5');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'openai', model)
+			);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.ApplyPatch]);
+		});
+
+		it('should return ReplaceString tools for Sonnet family models', async () => {
+			const model = createMockModel('claude-3-sonnet');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'claude', model)
+			);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.ReplaceString, ToolName.MultiReplaceString]);
+		});
+
+		it('should return initial state tools for unknown extension-contributed models', async () => {
+			const model = createMockModel();
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'unknown-model', model)
+			);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.EditFile, ToolName.ReplaceString]);
+		});
+	});
+
+	describe('didMakeEdit', () => {
+		it('should not record edits for non-extension-contributed models', async () => {
+			const model = createMockModel();
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(false, undefined, model)
+			);
+
+			await service.didMakeEdit(model, ToolName.ReplaceString, true);
+
+			// Should not have saved anything to storage
+			expect(mockContext.globalState.get).not.toHaveBeenCalled();
+		});
+
+		it('should not record edits for hardcoded preference models', async () => {
+			const model = createMockModel('gpt-4');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'gpt', model)
+			);
+
+			await service.didMakeEdit(model, ToolName.ApplyPatch, true);
+
+			// Should not have saved anything to storage since GPT models have hardcoded preferences
+			expect(mockContext.globalState.update).not.toHaveBeenCalled();
+		});
+
+		it('should record edits for extension-contributed models without hardcoded preferences', async () => {
+			const model = createMockModel('custom-model');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'custom-family', model)
+			);
+
+			await service.didMakeEdit(model, ToolName.ReplaceString, true);
+
+			expect(mockContext.globalState.update).toHaveBeenCalledWith(
+				'editToolLearning_cache',
+				expect.objectContaining({
+					entries: expect.arrayContaining([
+						expect.arrayContaining(['custom-model', expect.any(Object)])
+					])
+				})
+			);
+		});
+	});
+
+	describe('state transitions', () => {
+		let model: LanguageModelChat;
+
+		beforeEach(() => {
+			model = createMockModel('learning-model');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'learning-family', model)
+			);
+		});
+
+		it('should transition from Initial to ReplaceStringMaybeMulti on successful ReplaceString usage', async () => {
+			// Simulate enough successful ReplaceString edits
+			const successfulEdits = Math.ceil(LearningConfig.MIN_SAMPLE_SIZE);
+			await simulateEdits(model, ToolName.ReplaceString, successfulEdits, 0);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.ReplaceString, ToolName.MultiReplaceString]);
+		});
+
+		it('should transition from Initial to EditFileOnly on failed ReplaceString usage', async () => {
+			// Simulate enough failed ReplaceString edits to fall below failure threshold
+			const totalEdits = Math.ceil(LearningConfig.MIN_SAMPLE_SIZE);
+			const failedEdits = Math.ceil(totalEdits * (1 - LearningConfig.SR_FAILURE_THRESHOLD + 0.1));
+			const successfulEdits = totalEdits - failedEdits;
+
+			await simulateEdits(model, ToolName.ReplaceString, successfulEdits, failedEdits);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.EditFile]);
+		});
+
+		it('should transition from Initial to ReplaceStringForced when EditFile is overused', async () => {
+			// Simulate excessive EditFile usage
+			await simulateEdits(model, ToolName.EditFile, LearningConfig.WINDOW_SIZE, 0);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.ReplaceString]);
+		});
+
+		it('should transition from ReplaceStringMaybeMulti to ReplaceStringWithMulti on successful MultiReplaceString usage', async () => {
+			// First, get to ReplaceStringMaybeMulti state
+			const successfulReplaceEdits = Math.ceil(LearningConfig.MIN_SAMPLE_SIZE);
+			await simulateEdits(model, ToolName.ReplaceString, successfulReplaceEdits, 0);
+
+			// Then, simulate successful MultiReplaceString usage
+			const successfulMultiEdits = Math.ceil(LearningConfig.MIN_SAMPLE_SIZE);
+			await simulateEdits(model, ToolName.MultiReplaceString, successfulMultiEdits, 0);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.ReplaceString, ToolName.MultiReplaceString]);
+		});
+
+		it('should transition from ReplaceStringMaybeMulti to ReplaceStringOnly on failed MultiReplaceString usage', async () => {
+			// First, get to ReplaceStringMaybeMulti state
+			const successfulReplaceEdits = Math.ceil(LearningConfig.MIN_SAMPLE_SIZE);
+			await simulateEdits(model, ToolName.ReplaceString, successfulReplaceEdits, 0);
+
+			// Verify we're in ReplaceStringMaybeMulti state
+			let result = await service.getPreferredEditTool(model);
+			expect(result).toEqual([ToolName.ReplaceString, ToolName.MultiReplaceString]);
+
+			// Then, simulate failed MultiReplaceString usage to get below MULTISR_FAILURE_THRESHOLD (0.4)
+			const totalMultiEdits = Math.ceil(LearningConfig.MIN_SAMPLE_SIZE);
+			// We want success rate to be below 0.4, so let's use 0.3 (30% success rate)
+			const successfulMultiEdits = Math.floor(totalMultiEdits * 0.3);
+			const failedMultiEdits = totalMultiEdits - successfulMultiEdits;
+
+			await simulateEdits(model, ToolName.MultiReplaceString, successfulMultiEdits, failedMultiEdits);
+
+			result = await service.getPreferredEditTool(model);
+
+			// Should transition to ReplaceStringOnly state which only allows ReplaceString
+			expect(result).toEqual([ToolName.ReplaceString]);
+		});
+	});
+
+	describe('cache persistence', () => {
+		it('should persist learning data across service instances', async () => {
+			const model = createMockModel('persistent-model');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'persistent-family', model)
+			);
+
+			// Record some edits
+			await simulateEdits(model, ToolName.ReplaceString, 10, 5);
+
+			// Create a new service instance with the same context
+			const newService = new EditToolLearningService(mockContext as any, mockEndpointProvider);
+
+			// The new service should have access to the persisted data
+			const result = await newService.getPreferredEditTool(model);
+
+			// Should still be in initial state since we haven't reached MIN_SAMPLE_SIZE
+			expect(result).toEqual([ToolName.EditFile, ToolName.ReplaceString]);
+		});
+
+		it('should handle empty storage gracefully', async () => {
+			// Ensure no stored data (already set up in beforeEach)
+			const model = createMockModel('new-model');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'new-family', model)
+			);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.EditFile, ToolName.ReplaceString]);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle models with no recorded data', async () => {
+			const model = createMockModel('never-used-model');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'never-used-family', model)
+			);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.EditFile, ToolName.ReplaceString]);
+		});
+
+		it('should handle concurrent edits correctly', async () => {
+			const model = createMockModel('concurrent-model');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'concurrent-family', model)
+			);
+
+			// Simulate concurrent edits
+			const promises = [
+				service.didMakeEdit(model, ToolName.ReplaceString, true),
+				service.didMakeEdit(model, ToolName.ReplaceString, false),
+				service.didMakeEdit(model, ToolName.EditFile, true),
+			];
+
+			await Promise.all(promises);
+
+			// Should not throw and should have recorded all edits
+			const result = await service.getPreferredEditTool(model);
+			expect(result).toBeDefined();
+		});
+
+		it('should respect LRU cache size limits', async () => {
+
+			// Create more models than cache size
+			const modelsToCreate = LearningConfig.CACHE_SIZE + 5;
+			const models = Array.from({ length: modelsToCreate }, (_, i) => createMockModel(`model-${i}`));
+
+			// Record edits for all models
+			for (const model of models) {
+				vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValueOnce(
+					createMockEndpoint(true, 'test-family', model)
+				);
+				await service.didMakeEdit(model, ToolName.ReplaceString, true);
+			}
+
+			// All operations should complete without error
+			// The LRU cache should handle the overflow gracefully
+			const lastModel = models[models.length - 1];
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValueOnce(
+				createMockEndpoint(true, 'test-family', lastModel)
+			);
+			const result = await service.getPreferredEditTool(lastModel);
+			expect(result).toBeDefined();
+		});
+	});
+});

--- a/src/extension/tools/node/test/testTools.ts
+++ b/src/extension/tools/node/test/testTools.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as vscode from 'vscode';
+import { IEndpointProvider } from '../../../../platform/endpoint/common/endpointProvider';
 import { packageJson } from '../../../../platform/env/common/packagejson';
 import { ILanguageDiagnosticsService } from '../../../../platform/languages/common/languageDiagnosticsService';
 import { IAlternativeNotebookContentService } from '../../../../platform/notebook/common/alternativeContent';
@@ -15,12 +16,12 @@ import { IInstantiationService } from '../../../../util/vs/platform/instantiatio
 import { LanguageModelPromptTsxPart, LanguageModelToolResult } from '../../../../vscodeTypes';
 import { renderPromptElementJSON } from '../../../prompts/node/base/promptRenderer';
 import { ICodeMapperService } from '../../../prompts/node/codeMapper/codeMapperService';
+import { IEditToolLearningService } from '../../common/editToolLearningService';
 import { ContributedToolName, mapContributedToolNamesInSchema, mapContributedToolNamesInString, ToolName } from '../../common/toolNames';
 import { IToolsService } from '../../common/toolsService';
 import { ActionType } from '../applyPatch/parser';
 import { EditFileResult } from '../editFileToolResult';
 import { EditFileTool } from '../insertEditTool';
-import { IEndpointProvider } from '../../../../platform/endpoint/common/endpointProvider';
 
 interface IEditToolParams {
 	filePath: string;
@@ -46,8 +47,9 @@ export class TestEditFileTool extends EditFileTool {
 		@IAlternativeNotebookContentService alternativeNotebookContentService: IAlternativeNotebookContentService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IEndpointProvider endpointProvider: IEndpointProvider,
+		@IEditToolLearningService editToolLearningService: IEditToolLearningService,
 	) {
-		super(promptPathRepresentationService, instantiationService, workspaceService, toolsService, notebookService, languageDiagnosticsService, alternativeNotebookContentService, telemetryService, endpointProvider);
+		super(promptPathRepresentationService, instantiationService, workspaceService, toolsService, notebookService, languageDiagnosticsService, alternativeNotebookContentService, telemetryService, endpointProvider, editToolLearningService);
 		const contributedTool = packageJson.contributes.languageModelTools.find(contributedTool => contributedTool.name === ContributedToolName.EditFile);
 		if (!contributedTool) {
 			throw new Error(`Tool ${ContributedToolName.EditFile} is not in package.json`);

--- a/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -30,6 +30,7 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 	public readonly isFallback: boolean = false;
 	public readonly isPremium: boolean = false;
 	public readonly multiplier: number = 0;
+	public readonly isExtensionContributed = true;
 
 	constructor(
 		private readonly languageModel: vscode.LanguageModelChat,

--- a/src/platform/networking/common/networking.ts
+++ b/src/platform/networking/common/networking.ts
@@ -168,6 +168,7 @@ export interface IChatEndpoint extends IEndpoint {
 	readonly isDefault: boolean;
 	readonly isFallback: boolean;
 	readonly customModel?: CustomModel;
+	readonly isExtensionContributed?: boolean;
 	readonly policy: 'enabled' | { terms: string };
 	/**
 	 * Handles processing of responses from a chat endpoint. Each endpoint can have different response formats.


### PR DESCRIPTION
This implements the following for extension-contributed models:

- OAI/Sonnet-looking models will get apply_patch or replace_string
  exclusively, following the latest logic we have for 1p models.
- Other models get start with replace_string and insert_edit. If they
  are successful at replace_string, they get it exclusively. If they
  are very bad at replace_string, then they only get insert_edit.
- Models that get replace_string then also will get the multi_replace_string.
  Again depending whether they are good at it or not, they get to keep it.
- Learnings are kept in a global 50-entry LRU cache.