### PR TITLE
use a relative path in edit traces for replays

### DIFF
--- a/src/extension/intents/node/chatReplayIntent.ts
+++ b/src/extension/intents/node/chatReplayIntent.ts
@@ -100,7 +100,7 @@ export class ChatReplayIntent implements IIntent {
 			if (workspaceFolders.length > 0) {
 				uri = Uri.joinPath(workspaceFolders[0], edits.path);
 			} else {
-				uri = Uri.file(edits.path);
+				throw new Error('No workspace folder available to resolve relative path: ' + edits.path);
 			}
 		} else {
 			// Absolute path

--- a/src/extension/intents/node/chatReplayIntent.ts
+++ b/src/extension/intents/node/chatReplayIntent.ts
@@ -93,7 +93,19 @@ export class ChatReplayIntent implements IIntent {
 	}
 
 	private async makeEdit(edits: FileEdits, stream: vscode.ChatResponseStream) {
-		const uri = Uri.file(edits.path);
+		let uri: Uri;
+		if (!edits.path.startsWith('/') && !edits.path.match(/^[a-zA-Z]:/)) {
+			// Relative path - join with first workspace folder
+			const workspaceFolders = this.workspaceService.getWorkspaceFolders();
+			if (workspaceFolders.length > 0) {
+				uri = Uri.joinPath(workspaceFolders[0], edits.path);
+			} else {
+				uri = Uri.file(edits.path);
+			}
+		} else {
+			// Absolute path
+			uri = Uri.file(edits.path);
+		}
 		await this.ensureFileExists(uri);
 
 		stream.markdown('\n```\n');

--- a/src/extension/prompt/vscode-node/workspaceEditRecorder.ts
+++ b/src/extension/prompt/vscode-node/workspaceEditRecorder.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-
+import * as vscode from 'vscode';
 import { ObservableGit } from '../../../platform/inlineEdits/common/observableGit';
 import { WorkspaceDocumentEditHistory } from '../../../platform/inlineEdits/common/workspaceEditTracker/workspaceDocumentEditTracker';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
@@ -30,8 +30,10 @@ export class WorkspaceEditRecorder extends Disposable {
 		this._workspace.openDocuments.get().forEach(doc => {
 			const edits = this._workspaceDocumentEditHistory.getRecentEdits(doc.id);
 			if (edits && edits.edits.replacements.length > 0) {
+				const docUri = vscode.Uri.parse(doc.id.path);
+				const relativePath = vscode.workspace.asRelativePath(docUri, false);
 				serializedEdits.push({
-					path: doc.id.path,
+					path: relativePath,
 					edits: JSON.stringify(edits.edits)
 				});
 			}


### PR DESCRIPTION
put a relative path in the trace so that it can be replayed in another location