### PR TITLE
Set common UI kind and remote name for GitHub telemetry

### DIFF
--- a/src/platform/env/common/envService.ts
+++ b/src/platform/env/common/envService.ts
@@ -44,6 +44,7 @@ export interface IEnvService {
 	 * @see vscode.env.remoteName
 	 */
 	readonly remoteName: string | undefined;
+	readonly uiKind: 'desktop' | 'web';
 	readonly OS: OperatingSystem;
 	readonly uriScheme: string;
 	readonly extensionId: string;
@@ -76,6 +77,7 @@ export abstract class AbstractEnvService implements IEnvService {
 	abstract get extensionId(): string;
 	abstract get machineId(): string;
 	abstract get remoteName(): string | undefined;
+	abstract get uiKind(): 'desktop' | 'web';
 	abstract get OS(): OperatingSystem;
 	abstract get uriScheme(): string;
 	abstract get appRoot(): string;

--- a/src/platform/env/common/nullEnvService.ts
+++ b/src/platform/env/common/nullEnvService.ts
@@ -38,6 +38,10 @@ export class NullEnvService extends AbstractEnvService {
 		return undefined;
 	}
 
+	override get uiKind(): 'desktop' | 'web' {
+		return 'desktop';
+	}
+
 	override get uriScheme(): string {
 		return 'code-null';
 	}

--- a/src/platform/env/vscode/envServiceImpl.ts
+++ b/src/platform/env/vscode/envServiceImpl.ts
@@ -28,6 +28,12 @@ export class EnvServiceImpl implements IEnvService {
 	public get remoteName(): string | undefined {
 		return vscode.env.remoteName;
 	}
+	public get uiKind(): 'desktop' | 'web' {
+		switch (vscode.env.uiKind) {
+			case vscode.UIKind.Desktop: return 'desktop';
+			case vscode.UIKind.Web: return 'web';
+		}
+	}
 
 	public get isActive(): boolean {
 		return vscode.window.state.active;

--- a/src/platform/telemetry/node/azureInsightsReporter.ts
+++ b/src/platform/telemetry/node/azureInsightsReporter.ts
@@ -122,8 +122,8 @@ function decorateWithCommonProperties(properties: TelemetryProperties, envServic
 	properties['common_vscodemachineid'] = envService.machineId;
 	properties['common_vscodesessionid'] = envService.sessionId;
 
-	properties['common_uikind'] = 'desktop';
-	properties['common_remotename'] = 'none';
+	properties['common_uikind'] = envService.uiKind;
+	properties['common_remotename'] = envService.remoteName ?? 'none';
 	properties['common_isnewappinstall'] = '';
 	return properties;
 }


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce properties for `uiKind` and update `common_uikind` and `common_remotename` in telemetry to reflect the current environment settings.