### PR TITLE
Remove `--depth 1` from git clone commands

### DIFF
--- a/build/pre-release.yml
+++ b/build/pre-release.yml
@@ -103,7 +103,7 @@ extends:
           $oauthToken = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($basicToken)) -split ":" | Select-Object -Last 1
           $PackageJson = Get-Content -Path package.json -Raw | ConvertFrom-Json
           $CompletionsCoreVersion = $PackageJson.completionsCore
-          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git --depth 1 src/extension/completions-core
+          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git src/extension/completions-core
           pushd src/extension/completions-core
           git checkout $CompletionsCoreVersion
           popd
@@ -182,7 +182,7 @@ extends:
           $oauthToken = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($basicToken)) -split ":" | Select-Object -Last 1
           $PackageJson = Get-Content -Path package.json -Raw | ConvertFrom-Json
           $CompletionsCoreVersion = $PackageJson.completionsCore
-          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git --depth 1 src/extension/completions-core
+          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git src/extension/completions-core
           pushd src/extension/completions-core
           git checkout $CompletionsCoreVersion
           popd

--- a/build/release.yml
+++ b/build/release.yml
@@ -105,7 +105,7 @@ extends:
           $oauthToken = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($basicToken)) -split ":" | Select-Object -Last 1
           $PackageJson = Get-Content -Path package.json -Raw | ConvertFrom-Json
           $CompletionsCoreVersion = $PackageJson.completionsCore
-          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git --depth 1 src/extension/completions-core
+          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git src/extension/completions-core
           pushd src/extension/completions-core
           git checkout $CompletionsCoreVersion
           popd
@@ -184,7 +184,7 @@ extends:
           $oauthToken = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($basicToken)) -split ":" | Select-Object -Last 1
           $PackageJson = Get-Content -Path package.json -Raw | ConvertFrom-Json
           $CompletionsCoreVersion = $PackageJson.completionsCore
-          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git --depth 1 src/extension/completions-core
+          git clone -b completions-port https://vscode:$oauthToken@github.com/microsoft/vscode-copilot-completions.git src/extension/completions-core
           pushd src/extension/completions-core
           git checkout $CompletionsCoreVersion
           popd


### PR DESCRIPTION
```Copilot Generated Description:``` Remove the `--depth 1` option from the git clone commands for the completions-core repository in multiple locations.