### PR TITLE
feat: Hide editFile tool message

### DIFF
--- a/src/extension/tools/node/editFileToolUtils.tsx
+++ b/src/extension/tools/node/editFileToolUtils.tsx
@@ -667,7 +667,8 @@ export async function createEditConfirmation(accessor: ServicesAccessor, uris: r
 		confirmationMessages: {
 			title: t('Allow edits to sensitive files?'),
 			message: message + ' ' + t`Do you want to allow this?` + '\n\n' + asString(),
-		}
+		},
+		presentation: 'hiddenAfterComplete'
 	};
 }
 

--- a/src/extension/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/extension/vscode.proposed.chatParticipantPrivate.d.ts
@@ -236,7 +236,7 @@ declare module 'vscode' {
 
 	export interface PreparedToolInvocation {
 		pastTenseMessage?: string | MarkdownString;
-		presentation?: 'hidden' | undefined;
+		presentation?: 'hidden' | 'hiddenAfterComplete' | undefined;
 	}
 
 	export class ExtendedLanguageModelToolResult extends LanguageModelToolResult {


### PR DESCRIPTION
Hide messages of edit file tools like
`Using "Apply Patch"`
`Using "Replace String"`
to reduce the chat clutter as after the message we already show the files being modified.

This is to fix https://github.com/microsoft/vscode/issues/265037