### PR TITLE
testing: static Copilot Token loading 

### DIFF
--- a/src/platform/authentication/node/copilotTokenManager.ts
+++ b/src/platform/authentication/node/copilotTokenManager.ts
@@ -20,7 +20,7 @@ import { TelemetryData } from '../../telemetry/common/telemetryData';
 import { CopilotToken, CopilotUserInfo, ExtendedTokenInfo, TokenInfo, TokenInfoOrError, containsInternalOrg } from '../common/copilotToken';
 import { CheckCopilotToken, ICopilotTokenManager, NotGitHubLoginFailed, nowSeconds } from '../common/copilotTokenManager';
 
-export const tokenErrorString = `Tests: either GITHUB_PAT, GITHUB_OAUTH_TOKEN, or VSCODE_COPILOT_CHAT_TOKEN must be set. Run "npm run get_token" to get one.`;
+export const tokenErrorString = `Tests: either GITHUB_PAT, GITHUB_OAUTH_TOKEN, or GITHUB_OAUTH_TOKEN+VSCODE_COPILOT_CHAT_TOKEN must be set. Run "npm run get_token" to get credentials.`;
 
 export function getStaticGitHubToken() {
 	if (process.env.GITHUB_PAT) {


### PR DESCRIPTION
Dependency of https://github.com/microsoft/vscode-copilot-evaluation/pull/420.

Includes some minor low, risk cleanups of the `getOrCreateTestingCopilotTokenManager`.

Aside: next dev-cycle, we should investigate if the `GITHUB_PAT` paths can be completely removed since the other token managers serve the same purpose.