### PR TITLE
fix: skip extra glob pattern

### DIFF
--- a/src/extension/tools/node/findFilesTool.tsx
+++ b/src/extension/tools/node/findFilesTool.tsx
@@ -9,6 +9,7 @@ import { IPromptPathRepresentationService } from '../../../platform/prompts/comm
 import { URI } from '../../../util/vs/base/common/uri';
 
 import * as l10n from '@vscode/l10n';
+import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { ISearchService } from '../../../platform/search/common/searchService';
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
@@ -32,13 +33,16 @@ export class FindFilesTool implements ICopilotTool<IFindFilesToolParams> {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ISearchService private readonly searchService: ISearchService,
 		@IWorkspaceService private readonly workspaceService: IWorkspaceService,
+		@IEndpointProvider private readonly endpointProvider: IEndpointProvider,
 	) { }
 
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<IFindFilesToolParams>, token: CancellationToken) {
 		checkCancellation(token);
+		const endpoint = options.model && (await this.endpointProvider.getChatEndpoint(options.model));
+		const modelFamily = endpoint?.family;
 
 		// The input _should_ be a pattern matching inside a workspace, folder, but sometimes we get absolute paths, so try to resolve them
-		const pattern = inputGlobToPattern(options.input.query, this.workspaceService);
+		const pattern = inputGlobToPattern(options.input.query, this.workspaceService, modelFamily);
 
 		const results = await this.searchService.findFiles(pattern, undefined, token);
 		checkCancellation(token);

--- a/src/extension/tools/node/findTextInFilesTool.tsx
+++ b/src/extension/tools/node/findTextInFilesTool.tsx
@@ -7,6 +7,7 @@ import * as l10n from '@vscode/l10n';
 import { BasePromptElementProps, PromptElement, PromptElementProps, PromptPiece, PromptReference, PromptSizing, TextChunk } from '@vscode/prompt-tsx';
 import type * as vscode from 'vscode';
 import { OffsetLineColumnConverter } from '../../../platform/editing/common/offsetLineColumnConverter';
+import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { IPromptPathRepresentationService } from '../../../platform/prompts/common/promptPathRepresentationService';
 import { ISearchService } from '../../../platform/search/common/searchService';
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
@@ -40,11 +41,15 @@ export class FindTextInFilesTool implements ICopilotTool<IFindTextInFilesToolPar
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ISearchService private readonly searchService: ISearchService,
 		@IWorkspaceService private readonly workspaceService: IWorkspaceService,
+		@IEndpointProvider private readonly endpointProvider: IEndpointProvider,
 	) { }
 
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<IFindTextInFilesToolParams>, token: CancellationToken) {
+		const endpoint = options.model && (await this.endpointProvider.getChatEndpoint(options.model));
+		const modelFamily = endpoint?.family;
+
 		// The input _should_ be a pattern matching inside a workspace, folder, but sometimes we get absolute paths, so try to resolve them
-		const patterns = options.input.includePattern ? inputGlobToPattern(options.input.includePattern, this.workspaceService) : undefined;
+		const patterns = options.input.includePattern ? inputGlobToPattern(options.input.includePattern, this.workspaceService, modelFamily) : undefined;
 
 		checkCancellation(token);
 		const askedForTooManyResults = options.input.maxResults && options.input.maxResults > MaxResultsCap;


### PR DESCRIPTION
Skip adding extra input glob pattern with "/**" for models except gpt-4.1 to avoid duplicate results from workspace.findTextInFiles2(). 