### PR TITLE
Don't block extension activation on auth

### DIFF
--- a/src/extension/common/contributions.ts
+++ b/src/extension/common/contributions.ts
@@ -5,7 +5,6 @@
 
 import { ILogService } from '../../platform/log/common/logService';
 import { Disposable, isDisposable } from '../../util/vs/base/common/lifecycle';
-import { StopWatch } from '../../util/vs/base/common/stopwatch';
 import { IInstantiationService, ServicesAccessor } from '../../util/vs/platform/instantiation/common/instantiation';
 
 export interface IExtensionContribution {
@@ -16,12 +15,6 @@ export interface IExtensionContribution {
 	 * Dispose of the contribution.
 	 */
 	dispose?(): void;
-
-	/**
-	 * A promise that the extension `activate` method will wait on before completing.
-	 * USE this carefully as it will delay startup of our extension.
-	 */
-	activationBlocker?: Promise<any>;
 }
 
 export interface IExtensionContributionFactory {
@@ -38,8 +31,6 @@ export function asContributionFactory(ctor: { new(...args: any[]): any }): IExte
 }
 
 export class ContributionCollection extends Disposable {
-	private readonly allActivationBlockers: Promise<any>[] = [];
-
 	constructor(
 		contribs: IExtensionContributionFactory[],
 		@ILogService logService: ILogService,
@@ -55,22 +46,9 @@ export class ContributionCollection extends Disposable {
 				if (isDisposable(instance)) {
 					this._register(instance);
 				}
-
-				if (instance?.activationBlocker) {
-					const sw = StopWatch.create();
-					const id = instance.id || 'UNKNOWN';
-					this.allActivationBlockers.push(instance.activationBlocker.finally(() => {
-						logService.info(`activationBlocker from '${id}' took for ${Math.round(sw.elapsed())}ms`);
-					}));
-				}
 			} catch (error) {
 				logService.error(error, `Error while loading contribution`);
 			}
 		}
-	}
-
-	async waitForActivationBlockers(): Promise<void> {
-		// WAIT for all activation blockers to complete
-		await Promise.allSettled(this.allActivationBlockers);
 	}
 }

--- a/src/extension/conversation/vscode-node/conversationFeature.ts
+++ b/src/extension/conversation/vscode-node/conversationFeature.ts
@@ -18,7 +18,6 @@ import { ILogService } from '../../../platform/log/common/logService';
 import { ISettingsEditorSearchService } from '../../../platform/settingsEditor/common/settingsEditorSearchService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
 import { isUri } from '../../../util/common/types';
-import { DeferredPromise } from '../../../util/vs/base/common/async';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
 import { DisposableStore, IDisposable, combinedDisposable } from '../../../util/vs/base/common/lifecycle';
 import { URI } from '../../../util/vs/base/common/uri';
@@ -62,7 +61,6 @@ export class ConversationFeature implements IExtensionContribution {
 	private _settingsSearchProviderRegistered = false;
 
 	readonly id = 'conversationFeature';
-	readonly activationBlocker?: Promise<any>;
 
 	constructor(
 		@IInstantiationService private instantiationService: IInstantiationService,
@@ -87,25 +85,7 @@ export class ConversationFeature implements IExtensionContribution {
 		// Register Copilot token listener
 		this.registerCopilotTokenListener();
 
-		const activationBlockerDeferred = new DeferredPromise<void>();
-		this.activationBlocker = activationBlockerDeferred.p;
-		if (authenticationService.copilotToken) {
-			this.logService.debug(`ConversationFeature: Copilot token already available`);
-			this.activated = true;
-			activationBlockerDeferred.complete();
-		}
-
-		this._disposables.add(authenticationService.onDidAuthenticationChange(async () => {
-			const hasSession = !!authenticationService.copilotToken;
-			this.logService.debug(`ConversationFeature: onDidAuthenticationChange has token: ${hasSession}`);
-			if (hasSession) {
-				this.activated = true;
-			} else {
-				this.activated = false;
-			}
-
-			activationBlockerDeferred.complete();
-		}));
+		this.activated = true;
 	}
 
 	get enabled() {

--- a/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -28,7 +28,7 @@ import { isEncryptedThinkingDelta } from '../../../platform/thinking/common/thin
 import { BaseTokensPerCompletion } from '../../../platform/tokenizer/node/tokenizer';
 import { TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
 import { Emitter } from '../../../util/vs/base/common/event';
-import { Disposable, MutableDisposable } from '../../../util/vs/base/common/lifecycle';
+import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { isDefined, isNumber, isString, isStringArray } from '../../../util/vs/base/common/types';
 import { localize } from '../../../util/vs/nls';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
@@ -42,8 +42,6 @@ import { LanguageModelAccessPrompt } from './languageModelAccessPrompt';
 export class LanguageModelAccess extends Disposable implements IExtensionContribution {
 
 	readonly id = 'languageModelAccess';
-
-	readonly activationBlocker?: Promise<any>;
 
 	private readonly _onDidChange = this._register(new Emitter<void>());
 	private _currentModels: vscode.LanguageModelChatInformation[] = []; // Store current models for reference
@@ -71,10 +69,8 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 		}
 
 		// initial
-		this.activationBlocker = Promise.all([
-			this._registerChatProvider(),
-			this._registerEmbeddings(),
-		]);
+		this._registerChatProvider();
+		this._registerEmbeddings();
 	}
 
 	override dispose(): void {
@@ -85,7 +81,7 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 		return this._currentModels;
 	}
 
-	private async _registerChatProvider(): Promise<void> {
+	private _registerChatProvider(): void {
 		const provider: vscode.LanguageModelChatProvider = {
 			onDidChangeLanguageModelChatInformation: this._onDidChange.event,
 			provideLanguageModelChatInformation: this._provideLanguageModelChatInfo.bind(this),
@@ -231,34 +227,22 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 
 	private async _registerEmbeddings(): Promise<void> {
 
-		const dispo = this._register(new MutableDisposable());
+		const embeddingsComputer = this._embeddingsComputer;
+		const embeddingType = EmbeddingType.text3small_512;
+		const model = getWellKnownEmbeddingTypeInfo(embeddingType)?.model;
+		if (!model) {
+			throw new Error(`No model found for embedding type ${embeddingType.id}`);
+		}
 
+		const that = this;
+		this._register(vscode.lm.registerEmbeddingsProvider(`copilot.${model}`, new class implements vscode.EmbeddingsProvider {
+			async provideEmbeddings(input: string[], token: vscode.CancellationToken): Promise<vscode.Embedding[]> {
+				await that._getToken();
 
-		const update = async () => {
-
-			if (!await this._getToken()) {
-				dispo.clear();
-				return;
+				const result = await embeddingsComputer.computeEmbeddings(embeddingType, input, {}, new TelemetryCorrelationId('EmbeddingsProvider::provideEmbeddings'), token);
+				return result.values.map(embedding => ({ values: embedding.value.slice(0) }));
 			}
-
-			const embeddingsComputer = this._embeddingsComputer;
-			const embeddingType = EmbeddingType.text3small_512;
-			const model = getWellKnownEmbeddingTypeInfo(embeddingType)?.model;
-			if (!model) {
-				throw new Error(`No model found for embedding type ${embeddingType.id}`);
-			}
-
-			dispo.clear();
-			dispo.value = vscode.lm.registerEmbeddingsProvider(`copilot.${model}`, new class implements vscode.EmbeddingsProvider {
-				async provideEmbeddings(input: string[], token: vscode.CancellationToken): Promise<vscode.Embedding[]> {
-					const result = await embeddingsComputer.computeEmbeddings(embeddingType, input, {}, new TelemetryCorrelationId('EmbeddingsProvider::provideEmbeddings'), token);
-					return result.values.map(embedding => ({ values: embedding.value.slice(0) }));
-				}
-			});
-		};
-
-		this._register(this._authenticationService.onDidAuthenticationChange(() => update()));
-		await update();
+		}));
 	}
 
 	private async _getToken(): Promise<CopilotToken | undefined> {

--- a/src/extension/extension/vscode/extension.ts
+++ b/src/extension/extension/vscode/extension.ts
@@ -68,11 +68,8 @@ export async function baseActivate(configuration: IExtensionActivationConfigurat
 		// It will then auto refresh every 30 minutes after that.
 		await expService.hasTreatments();
 
-		// THIS is awaited because some contributions can block activation
-		// via `IExtensionContribution#activationBlocker`
 		const contributions = instantiationService.createInstance(ContributionCollection, configuration.contributions);
 		context.subscriptions.push(contributions);
-		await contributions.waitForActivationBlockers();
 	});
 
 	if (ExtensionMode.Test === context.extensionMode && !isScenarioAutomation) {

--- a/src/extension/extension/vscode/extension.ts
+++ b/src/extension/extension/vscode/extension.ts
@@ -9,6 +9,7 @@ import { isScenarioAutomation } from '../../../platform/env/common/envService';
 import { isProduction } from '../../../platform/env/common/packagejson';
 import { IHeatmapService } from '../../../platform/heatmap/common/heatmapService';
 import { IIgnoreService } from '../../../platform/ignore/common/ignoreService';
+import { ILogService } from '../../../platform/log/common/logService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { IInstantiationServiceBuilder, InstantiationServiceBuilder } from '../../../util/common/services';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
@@ -70,6 +71,8 @@ export async function baseActivate(configuration: IExtensionActivationConfigurat
 
 		const contributions = instantiationService.createInstance(ContributionCollection, configuration.contributions);
 		context.subscriptions.push(contributions);
+
+		accessor.get(ILogService).trace('Extension activated');
 	});
 
 	if (ExtensionMode.Test === context.extensionMode && !isScenarioAutomation) {


### PR DESCRIPTION
This is hopefully the most minimal and least risky change to test this. If we keep it, then there is more cleanup that could be done in conversationFeature.ts and chatParticipants.ts.

I tested that the welcome views for things like an expired subscription still show correctly.

Now, we go to the built-in ChatSetup participant to drive extension install if needed, and for the now shorter time that the extension is activating. Then the request is forwarded to the extension, and auth happens inside any registered providers. 

Decouples the extension activation process from GitHub authentication, allowing the extension to activate without blocking on user sign-in. Removes unnecessary activation blockers and cleans up related code. Adds logging for better traceability during activation.

Fixes microsoft/vscode-copilot#3879