### PR TITLE
fix inline v2 for notebooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1437,7 +1437,7 @@
 				"locations": [
 					"notebook"
 				],
-				"when": "config.inlineChat.enableV2",
+				"when": "config.inlineChat.enableV2 && config.inlineChat.notebookAgent",
 				"commands": [
 					{
 						"name": "fix",
@@ -3144,7 +3144,10 @@
 						]
 					},
 					"github.copilot.chat.completionsFetcher": {
-						"type": ["string", "null"],
+						"type": [
+							"string",
+							"null"
+						],
 						"markdownDescription": "%github.copilot.config.completionsFetcher%",
 						"tags": [
 							"experimental",
@@ -3156,7 +3159,10 @@
 						]
 					},
 					"github.copilot.chat.nesFetcher": {
-						"type": ["string", "null"],
+						"type": [
+							"string",
+							"null"
+						],
 						"markdownDescription": "%github.copilot.config.nesFetcher%",
 						"tags": [
 							"experimental",

--- a/src/extension/prompt/node/chatParticipantRequestHandler.ts
+++ b/src/extension/prompt/node/chatParticipantRequestHandler.ts
@@ -232,6 +232,7 @@ export class ChatParticipantRequestHandler {
 
 				const history = this.conversation.turns.slice(0, -1);
 				const intent = await this.selectIntent(command, history);
+				this._logService.trace(`[${ChatLocation.toStringShorter(this.location)}] selected intent: ${intent.id}`);
 
 				let chatResult: Promise<ChatResult>;
 				if (typeof intent.handleRequest === 'function') {

--- a/src/platform/chat/common/commonTypes.ts
+++ b/src/platform/chat/common/commonTypes.ts
@@ -71,8 +71,9 @@ export namespace ChatLocation {
 	export function toStringShorter(chatLocation: ChatLocation): string {
 		switch (chatLocation) {
 			case ChatLocation.Editor:
-			case ChatLocation.Notebook:
 				return 'inline';
+			case ChatLocation.Notebook:
+				return 'notebook';
 			case ChatLocation.Panel:
 				return 'panel';
 			case ChatLocation.EditingSession:


### PR DESCRIPTION
I made the mistake of thinking location2 was used for the location filter of registered participants, so the notebookEditorAgent was always being selected with inline v2 enabled, but with that agent would fall back to an unknown intent because location2 was a textEditor and that wasn't supported.

This will fix inlineV2 for notebooks, but I will also look into the option of always delegating to the notebookEditorAgent, instead of the editingSessionEditor (inline v2).