### PR TITLE
tools: use a binary format for local tool embedding cache

### DIFF
--- a/src/extension/tools/common/virtualTools/toolEmbeddingsComputer.ts
+++ b/src/extension/tools/common/virtualTools/toolEmbeddingsComputer.ts
@@ -64,7 +64,7 @@ export class ToolEmbeddingsComputer implements IToolEmbeddingsComputer {
 			embeddingType,
 			caches: [
 				precomputed,
-				instantiationService.createInstance(ToolEmbeddingLocalCache),
+				instantiationService.createInstance(ToolEmbeddingLocalCache, embeddingType),
 			],
 		};
 	}

--- a/src/extension/tools/common/virtualTools/toolEmbeddingsLocalCache.ts
+++ b/src/extension/tools/common/virtualTools/toolEmbeddingsLocalCache.ts
@@ -5,49 +5,89 @@
 
 import type { LanguageModelToolInformation } from 'vscode';
 import { Embedding, EmbeddingType } from '../../../../platform/embeddings/common/embeddingsComputer';
+import { packEmbedding, unpackEmbedding } from '../../../../platform/embeddings/common/embeddingsStorage';
 import { IVSCodeExtensionContext } from '../../../../platform/extContext/common/extensionContext';
 import { IFileSystemService } from '../../../../platform/filesystem/common/fileSystemService';
+import { readVariableLengthQuantity, writeVariableLengthQuantity } from '../../../../util/common/variableLengthQuantity';
 import { RunOnceScheduler } from '../../../../util/vs/base/common/async';
+import { VSBuffer, decodeHex, encodeHex } from '../../../../util/vs/base/common/buffer';
 import { StringSHA1 } from '../../../../util/vs/base/common/hash';
 import { Disposable } from '../../../../util/vs/base/common/lifecycle';
 import { LRUCache } from '../../../../util/vs/base/common/map';
 import { URI } from '../../../../util/vs/base/common/uri';
 import { IToolEmbeddingsCache } from './toolEmbeddingsComputer';
 
-interface IStoredData {
-	version: 1;
-	entries: [string, Embedding][];
-}
-
-const EMBEDDING_CACHE_FILE_NAME = 'toolEmbeddingsCache.json';
+const EMBEDDING_CACHE_FILE_NAME = 'toolEmbeddingsCache.bin';
+const CACHE_VERSION = 1;
+const SHA1_DIGEST_LENGTH = 20; // SHA-1 produces 20 bytes
 
 export class ToolEmbeddingLocalCache extends Disposable implements IToolEmbeddingsCache {
 	private readonly _storageUri: URI;
 	private readonly _lru = new LRUCache<string, Embedding>(1000);
 	private readonly _toolHashes = new WeakMap<LanguageModelToolInformation, string>();
-	private readonly _storageScheduler = this._register(new RunOnceScheduler(() => this._save(), 5000));
+	private readonly _storageScheduler = this._register(new RunOnceScheduler(() => this.save(), 5000));
+	private readonly _embeddingType: EmbeddingType;
 
 	constructor(
+		embeddingType: EmbeddingType,
 		@IFileSystemService private readonly _fileSystemService: IFileSystemService,
 		@IVSCodeExtensionContext _context: IVSCodeExtensionContext,
 	) {
 		super();
+		this._embeddingType = embeddingType;
 		this._storageUri = URI.joinPath(_context.globalStorageUri, EMBEDDING_CACHE_FILE_NAME);
 	}
 
 	public async initialize(): Promise<void> {
 		try {
-			const data = new TextDecoder().decode(await this._fileSystemService.readFile(this._storageUri, true));
-			const stored: IStoredData = JSON.parse(data);
-			if (stored.version !== 1) {
+			const buffer = VSBuffer.wrap(await this._fileSystemService.readFile(this._storageUri, true));
+			let offset = 0;
+
+			// Read version
+			const versionResult = readVariableLengthQuantity(buffer, offset);
+			offset += versionResult.consumed;
+			if (versionResult.value !== CACHE_VERSION) {
 				return;
 			}
 
-			for (const [key, value] of stored.entries) {
-				this._lru.set(key, {
-					type: new EmbeddingType(value.type.id),
-					value: value.value,
-				});
+			// Read embedding type and validate it matches
+			const typeLengthResult = readVariableLengthQuantity(buffer, offset);
+			offset += typeLengthResult.consumed;
+			const typeLength = typeLengthResult.value;
+
+			const typeBytes = buffer.slice(offset, offset + typeLength);
+			offset += typeLength;
+			const storedEmbeddingTypeId = new TextDecoder().decode(typeBytes.buffer);
+			const storedEmbeddingType = new EmbeddingType(storedEmbeddingTypeId);
+
+			// If stored type doesn't match current type, discard the cache
+			if (!storedEmbeddingType.equals(this._embeddingType)) {
+				return;
+			}
+
+			// Read number of entries
+			const entriesCountResult = readVariableLengthQuantity(buffer, offset);
+			offset += entriesCountResult.consumed;
+			const entriesCount = entriesCountResult.value;
+
+			// Read each entry
+			for (let i = 0; i < entriesCount; i++) {
+				// Read key (fixed length SHA-1 digest)
+				const keyBytes = buffer.slice(offset, offset + SHA1_DIGEST_LENGTH);
+				offset += SHA1_DIGEST_LENGTH;
+				const key = encodeHex(keyBytes);
+
+				// Read embedding data length and data
+				const embeddingLengthResult = readVariableLengthQuantity(buffer, offset);
+				offset += embeddingLengthResult.consumed;
+				const embeddingLength = embeddingLengthResult.value;
+
+				const embeddingBytes = buffer.slice(offset, offset + embeddingLength);
+				offset += embeddingLength;
+
+				// Unpack embedding and store in cache
+				const embedding = unpackEmbedding(this._embeddingType, new Uint8Array(embeddingBytes.buffer));
+				this._lru.set(key, embedding);
 			}
 		} catch {
 			// ignored
@@ -78,18 +118,42 @@ export class ToolEmbeddingLocalCache extends Disposable implements IToolEmbeddin
 		return hash;
 	}
 
-	private _save() {
+	public async save() {
+		this._storageScheduler.cancel();
+
 		if (!this._lru.size) {
 			return;
 		}
 
-		const data: IStoredData = {
-			version: 1,
-			entries: this._lru.toJSON(),
-		};
+		const entries = this._lru.toJSON();
+		const buffers: VSBuffer[] = [];
 
-		const content = new TextEncoder().encode(JSON.stringify(data));
-		this._fileSystemService.writeFile(this._storageUri, content);
+		// Write version
+		buffers.push(writeVariableLengthQuantity(CACHE_VERSION));
+
+		// Write embedding type at top level
+		const typeBytes = new TextEncoder().encode(this._embeddingType.id);
+		buffers.push(writeVariableLengthQuantity(typeBytes.length));
+		buffers.push(VSBuffer.wrap(typeBytes));
+
+		// Write number of entries
+		buffers.push(writeVariableLengthQuantity(entries.length));
+
+		// Write each entry
+		for (const [key, embedding] of entries) {
+			// Write key as binary (decode hex string to binary)
+			const keyBinary = decodeHex(key);
+			buffers.push(VSBuffer.wrap(keyBinary.buffer));
+
+			// Pack and write embedding data (no need to store type per entry)
+			const packedEmbedding = packEmbedding(embedding);
+			buffers.push(writeVariableLengthQuantity(packedEmbedding.length));
+			buffers.push(VSBuffer.wrap(packedEmbedding));
+		}
+
+		// Concatenate all buffers and write to file
+		const totalBuffer = VSBuffer.concat(buffers);
+		await this._fileSystemService.writeFile(this._storageUri, totalBuffer.buffer);
 	}
 }
 

--- a/src/extension/tools/test/node/virtualTools/toolEmbeddingsLocalCache.spec.ts
+++ b/src/extension/tools/test/node/virtualTools/toolEmbeddingsLocalCache.spec.ts
@@ -1,0 +1,306 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { LanguageModelToolInformation } from 'vscode';
+import { Embedding, EmbeddingType } from '../../../../../platform/embeddings/common/embeddingsComputer';
+import { IVSCodeExtensionContext } from '../../../../../platform/extContext/common/extensionContext';
+import { IFileSystemService } from '../../../../../platform/filesystem/common/fileSystemService';
+import { MockFileSystemService } from '../../../../../platform/filesystem/node/test/mockFileSystemService';
+import { ITestingServicesAccessor } from '../../../../../platform/test/node/services';
+import { DisposableStore } from '../../../../../util/vs/base/common/lifecycle';
+import { URI } from '../../../../../util/vs/base/common/uri';
+import { createExtensionUnitTestingServices } from '../../../../test/node/services';
+import { ToolEmbeddingLocalCache } from '../../../common/virtualTools/toolEmbeddingsLocalCache';
+
+// Enhanced MockFileSystemService that supports writeFile for testing
+class TestableFileSystemService extends MockFileSystemService {
+	private writtenFiles = new Map<string, Uint8Array>();
+
+	override async writeFile(uri: URI, content: Uint8Array): Promise<void> {
+		const uriString = uri.toString();
+		this.writtenFiles.set(uriString, content);
+
+		// Make the file available for reading
+		const contentString = Buffer.from(content).toString('base64');
+		this.mockFile(uri, contentString);
+	}
+
+	override async readFile(uri: URI): Promise<Uint8Array> {
+		const uriString = uri.toString();
+
+		// Check if file was written in this test session
+		if (this.writtenFiles.has(uriString)) {
+			return this.writtenFiles.get(uriString)!;
+		}
+
+		// Fall back to mocked files (return as base64 decoded)
+		try {
+			const base64Content = await super.readFile(uri);
+			return Buffer.from(new TextDecoder().decode(base64Content), 'base64');
+		} catch {
+			throw new Error('ENOENT');
+		}
+	}
+
+	getWrittenContent(uri: URI): Uint8Array | undefined {
+		return this.writtenFiles.get(uri.toString());
+	}
+}
+
+describe('ToolEmbeddingLocalCache', () => {
+	let disposables: DisposableStore;
+	let accessor: ITestingServicesAccessor;
+	let mockFileSystem: TestableFileSystemService;
+	let cache: ToolEmbeddingLocalCache;
+	let mockContext: IVSCodeExtensionContext;
+	let embeddingType: EmbeddingType;
+
+	// Sample test data
+	const createSampleTool = (name: string, description: string = `Description for ${name}`): LanguageModelToolInformation => ({
+		name,
+		description
+	} as LanguageModelToolInformation);
+
+	const createSampleEmbedding = (type: EmbeddingType, values: number[] = [0.1, 0.2, 0.3, 0.4]): Embedding => ({
+		type,
+		value: values
+	});
+
+	// Helper to create embeddings with Float32 precision for accurate testing
+	const createFloat32Embedding = (type: EmbeddingType, values: number[]): Embedding => ({
+		type,
+		value: Array.from(Float32Array.from(values))
+	});
+
+	// Helper to compare embeddings with Float32 tolerance
+	const expectEmbeddingToEqual = (actual: Embedding | undefined, expected: Embedding) => {
+		expect(actual).toBeDefined();
+		expect(actual!.type).toEqual(expected.type);
+		expect(actual!.value.length).toBe(expected.value.length);
+		// Compare with Float32 precision
+		actual!.value.forEach((actualVal, i) => {
+			const expectedVal = expected.value[i];
+			expect(Math.abs(actualVal - expectedVal)).toBeLessThan(1e-5);
+		});
+	};
+
+	beforeEach(() => {
+		disposables = new DisposableStore();
+		const testingServiceCollection = disposables.add(createExtensionUnitTestingServices());
+		mockFileSystem = new TestableFileSystemService();
+		testingServiceCollection.set(IFileSystemService, mockFileSystem);
+		testingServiceCollection.set(IVSCodeExtensionContext, { globalStorageUri: URI.file('/tmp') } as any);
+		accessor = testingServiceCollection.createTestingAccessor();
+		mockContext = accessor.get(IVSCodeExtensionContext);
+		embeddingType = EmbeddingType.text3small_512;
+
+		// Create cache instance
+		cache = disposables.add(new ToolEmbeddingLocalCache(
+			embeddingType,
+			mockFileSystem,
+			mockContext
+		));
+	});
+
+	afterEach(() => {
+		disposables.dispose();
+	});
+
+	describe('Basic Operations', () => {
+		it('should initialize without error when no cache file exists', async () => {
+			await expect(cache.initialize()).resolves.not.toThrow();
+		});
+
+		it('should get undefined for non-existent tool', () => {
+			const tool = createSampleTool('nonexistent');
+			expect(cache.get(tool)).toBeUndefined();
+		});
+
+		it('should store and retrieve embeddings', () => {
+			const tool = createSampleTool('test-tool');
+			const embedding = createSampleEmbedding(embeddingType);
+
+			cache.set(tool, embedding);
+			const retrieved = cache.get(tool);
+
+			expect(retrieved).toEqual(embedding);
+		});
+
+		it('should generate consistent keys for same tool', () => {
+			const tool1 = createSampleTool('same-tool', 'description');
+			const tool2 = createSampleTool('same-tool', 'description');
+			const embedding = createSampleEmbedding(embeddingType);
+
+			cache.set(tool1, embedding);
+			const retrieved = cache.get(tool2);
+
+			expect(retrieved).toEqual(embedding);
+		});
+
+		it('should generate different keys for different tools', () => {
+			const tool1 = createSampleTool('tool1');
+			const tool2 = createSampleTool('tool2');
+			const embedding1 = createSampleEmbedding(embeddingType, [0.1, 0.2]);
+			const embedding2 = createSampleEmbedding(embeddingType, [0.3, 0.4]);
+
+			cache.set(tool1, embedding1);
+			cache.set(tool2, embedding2);
+
+			expect(cache.get(tool1)).toEqual(embedding1);
+			expect(cache.get(tool2)).toEqual(embedding2);
+		});
+	});
+
+	describe('Persistence', () => {
+		it('should save and load cache to/from binary format', async () => {
+			const tool1 = createSampleTool('persistent-tool-1');
+			const tool2 = createSampleTool('persistent-tool-2');
+			const embedding1 = createFloat32Embedding(embeddingType, [0.1, 0.2, 0.3, 0.4]);
+			const embedding2 = createFloat32Embedding(embeddingType, [0.5, 0.6, 0.7, 0.8]);
+
+			// Store embeddings
+			cache.set(tool1, embedding1);
+			cache.set(tool2, embedding2);
+
+			// Manually save
+			cache.save();
+
+			// Verify file was written
+			const cacheUri = URI.joinPath(mockContext.globalStorageUri, 'toolEmbeddingsCache.bin');
+			const writtenContent = mockFileSystem.getWrittenContent(cacheUri);
+			expect(writtenContent).toBeDefined();
+			expect(writtenContent!.length).toBeGreaterThan(0);
+
+			// Create new cache and load
+			const newCache = disposables.add(new ToolEmbeddingLocalCache(
+				embeddingType,
+				mockFileSystem,
+				mockContext
+			));
+
+			await newCache.initialize();
+
+			// Verify loaded data with Float32 precision
+			expectEmbeddingToEqual(newCache.get(tool1), embedding1);
+			expectEmbeddingToEqual(newCache.get(tool2), embedding2);
+		});
+
+		it('should discard cache when embedding type does not match', async () => {
+			const tool = createSampleTool('type-mismatch-tool');
+			const embedding = createSampleEmbedding(embeddingType);
+
+			// Store with current type
+			cache.set(tool, embedding);
+			cache.save();
+
+			// Create cache with different embedding type
+			const differentType = EmbeddingType.metis_1024_I16_Binary;
+			const newCache = disposables.add(new ToolEmbeddingLocalCache(
+				differentType,
+				mockFileSystem,
+				mockContext
+			));
+
+			await newCache.initialize();
+
+			// Should not find the embedding due to type mismatch
+			expect(newCache.get(tool)).toBeUndefined();
+		});
+
+		it('should handle corrupted cache file gracefully', async () => {
+			const cacheUri = URI.joinPath(mockContext.globalStorageUri, 'toolEmbeddingsCache.bin');
+
+			// Write corrupted data
+			const corruptedData = new Uint8Array([0xFF, 0xFF, 0xFF, 0xFF]);
+			await mockFileSystem.writeFile(cacheUri, corruptedData);
+
+			// Should not throw and should start with empty cache
+			await expect(cache.initialize()).resolves.not.toThrow();
+
+			const tool = createSampleTool('test-after-corruption');
+			expect(cache.get(tool)).toBeUndefined();
+		});
+
+		it('should handle version mismatch gracefully', async () => {
+			const tool = createSampleTool('version-test-tool');
+			const embedding = createSampleEmbedding(embeddingType);
+
+			// Store with current implementation
+			cache.set(tool, embedding);
+			cache.save();
+
+			// Modify the saved file to have wrong version (overwrite first bytes)
+			const cacheUri = URI.joinPath(mockContext.globalStorageUri, 'toolEmbeddingsCache.bin');
+			const currentContent = mockFileSystem.getWrittenContent(cacheUri)!;
+			const modifiedContent = new Uint8Array(currentContent);
+			modifiedContent[0] = 99; // Invalid version
+			await mockFileSystem.writeFile(cacheUri, modifiedContent);
+
+			// Create new cache
+			const newCache = disposables.add(new ToolEmbeddingLocalCache(
+				embeddingType,
+				mockFileSystem,
+				mockContext
+			));
+
+			await newCache.initialize();
+
+			// Should start with empty cache due to version mismatch
+			expect(newCache.get(tool)).toBeUndefined();
+		});
+	});
+
+	describe('Binary Format Efficiency', () => {
+		it('should use binary format with fixed-length keys', async () => {
+			const tool = createSampleTool('efficiency-test');
+			const embedding = createSampleEmbedding(embeddingType, new Array(512).fill(0).map((_, i) => i / 512));
+
+			cache.set(tool, embedding);
+			cache.save();
+
+			const cacheUri = URI.joinPath(mockContext.globalStorageUri, 'toolEmbeddingsCache.bin');
+			const content = mockFileSystem.getWrittenContent(cacheUri)!;
+
+			// Should be much smaller than JSON would be
+			// A JSON representation would be several KB, binary should be much less
+			expect(content.length).toBeLessThan(3000); // Reasonable upper bound
+			expect(content.length).toBeGreaterThan(100); // Has actual content
+		});
+	});
+
+	describe('Multiple Tool Scenarios', () => {
+		it('should handle many tools efficiently', async () => {
+			const tools: LanguageModelToolInformation[] = [];
+			const embeddings: Embedding[] = [];
+
+			// Create 50 tools with different embeddings
+			for (let i = 0; i < 50; i++) {
+				const tool = createSampleTool(`bulk-tool-${i}`, `Description ${i}`);
+				const embedding = createSampleEmbedding(embeddingType, [i, i + 0.1, i + 0.2, i + 0.3]);
+
+				tools.push(tool);
+				embeddings.push(embedding);
+				cache.set(tool, embedding);
+			}
+
+			await cache.save();
+
+			const newCache = disposables.add(new ToolEmbeddingLocalCache(
+				embeddingType,
+				mockFileSystem,
+				mockContext
+			));
+
+			await newCache.initialize();
+
+			// Verify all can be retrieved
+			tools.forEach((tool, i) => {
+				expect(cache.get(tool)).toEqual(embeddings[i]);
+				expectEmbeddingToEqual(newCache.get(tool), embeddings[i]);
+			});
+		});
+	});
+});

--- a/src/platform/embeddings/common/embeddingsStorage.ts
+++ b/src/platform/embeddings/common/embeddingsStorage.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Embedding, EmbeddingType, getWellKnownEmbeddingTypeInfo } from './embeddingsComputer';
+
+/**
+ * Packs the embedding into a binary value for efficient storage.
+ */
+export function packEmbedding(embedding: Embedding): Uint8Array {
+	const embeddingMetadata = getWellKnownEmbeddingTypeInfo(embedding.type);
+	if (embeddingMetadata?.quantization.document === 'binary') {
+		// Generate packed binary
+		if (embedding.value.length % 8 !== 0) {
+			throw new Error(`Embedding value length must be a multiple of 8 for ${embedding.type.id}, got ${embedding.value.length}`);
+		}
+
+		const data = new Uint8Array(embedding.value.length / 8);
+		for (let i = 0; i < embedding.value.length; i += 8) {
+			let value = 0;
+			for (let j = 0; j < 8; j++) {
+				value |= (embedding.value[i + j] >= 0 ? 1 : 0) << j;
+			}
+			data[i / 8] = value;
+		}
+		return data;
+	}
+
+	// All other formats default to float32 for now
+	const data = Float32Array.from(embedding.value);
+	return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+}
+
+/**
+ * Unpacks an embedding from a binary value packed with {@link packEmbedding}.
+ */
+export function unpackEmbedding(type: EmbeddingType, data: Uint8Array): Embedding {
+	const embeddingMetadata = getWellKnownEmbeddingTypeInfo(type);
+	if (embeddingMetadata?.quantization.document === 'binary') {
+		// Old metis versions may have stored the values as a float32
+		if (!(type.equals(EmbeddingType.metis_1024_I16_Binary) && data.length >= 1024)) {
+			const values = new Array(data.length * 8);
+			for (let i = 0; i < data.length; i++) {
+				const byte = data[i];
+				for (let j = 0; j < 8; j++) {
+					values[i * 8 + j] = (byte & (1 << j)) > 0 ? 0.03125 : -0.03125;
+				}
+			}
+			return { type, value: values };
+		}
+	}
+
+	const float32Array = new Float32Array(data.buffer, data.byteOffset, data.byteLength / 4);
+	return { type, value: Array.from(float32Array) };
+}

--- a/src/platform/embeddings/test/node/packEmbedding.spec.ts
+++ b/src/platform/embeddings/test/node/packEmbedding.spec.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { suite, test } from 'vitest';
 import { Embedding, EmbeddingType } from '../../../embeddings/common/embeddingsComputer';
-import { packEmbedding, unpackEmbedding } from '../../node/workspaceChunkAndEmbeddingCache';
+import { packEmbedding, unpackEmbedding } from '../../common/embeddingsStorage';
 
 suite('Pack Embedding', () => {
 	test('Text3small should pack and unpack to same values', () => {

--- a/src/platform/workspaceChunkSearch/node/workspaceChunkAndEmbeddingCache.ts
+++ b/src/platform/workspaceChunkSearch/node/workspaceChunkAndEmbeddingCache.ts
@@ -14,10 +14,11 @@ import { URI } from '../../../util/vs/base/common/uri';
 import { Range } from '../../../util/vs/editor/common/core/range';
 import { IInstantiationService, ServicesAccessor } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { FileChunkWithEmbedding } from '../../chunking/common/chunk';
-import { Embedding, EmbeddingType, getWellKnownEmbeddingTypeInfo } from '../../embeddings/common/embeddingsComputer';
+import { EmbeddingType } from '../../embeddings/common/embeddingsComputer';
 import { IFileSystemService } from '../../filesystem/common/fileSystemService';
 import { ILogService } from '../../log/common/logService';
 import { FileRepresentation, IWorkspaceFileIndex } from './workspaceFileIndex';
+import { unpackEmbedding, packEmbedding } from '../../embeddings/common/embeddingsStorage';
 
 type CacheEntry = {
 	readonly contentVersionId: string | undefined;
@@ -355,54 +356,4 @@ class DbCache implements IWorkspaceChunkAndEmbeddingCache {
 
 		return chunks;
 	}
-}
-
-/**
- * Packs the embedding into a binary value for efficient storage.
- */
-export function packEmbedding(embedding: Embedding): Uint8Array {
-	const embeddingMetadata = getWellKnownEmbeddingTypeInfo(embedding.type);
-	if (embeddingMetadata?.quantization.document === 'binary') {
-		// Generate packed binary
-		if (embedding.value.length % 8 !== 0) {
-			throw new Error(`Embedding value length must be a multiple of 8 for ${embedding.type.id}, got ${embedding.value.length}`);
-		}
-
-		const data = new Uint8Array(embedding.value.length / 8);
-		for (let i = 0; i < embedding.value.length; i += 8) {
-			let value = 0;
-			for (let j = 0; j < 8; j++) {
-				value |= (embedding.value[i + j] >= 0 ? 1 : 0) << j;
-			}
-			data[i / 8] = value;
-		}
-		return data;
-	}
-
-	// All other formats default to float32 for now
-	const data = Float32Array.from(embedding.value);
-	return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
-}
-
-/**
- * Unpacks an embedding from a binary value packed with {@link packEmbedding}.
- */
-export function unpackEmbedding(type: EmbeddingType, data: Uint8Array): Embedding {
-	const embeddingMetadata = getWellKnownEmbeddingTypeInfo(type);
-	if (embeddingMetadata?.quantization.document === 'binary') {
-		// Old metis versions may have stored the values as a float32
-		if (!(type.equals(EmbeddingType.metis_1024_I16_Binary) && data.length >= 1024)) {
-			const values = new Array(data.length * 8);
-			for (let i = 0; i < data.length; i++) {
-				const byte = data[i];
-				for (let j = 0; j < 8; j++) {
-					values[i * 8 + j] = (byte & (1 << j)) > 0 ? 0.03125 : -0.03125;
-				}
-			}
-			return { type, value: values };
-		}
-	}
-
-	const float32Array = new Float32Array(data.buffer, data.byteOffset, data.byteLength / 4);
-	return { type, value: Array.from(float32Array) };
 }


### PR DESCRIPTION
Reduces cache size by about 75%