### PR TITLE
remove initial launch config

### DIFF
--- a/package.json
+++ b/package.json
@@ -4132,16 +4132,7 @@
 							"program"
 						]
 					}
-				},
-				"initialConfigurations": [
-					{
-						"type": "vscode-chat-replay",
-						"request": "launch",
-						"name": "Debug Chat Replay",
-						"program": "${file}",
-						"stopOnEntry": true
-					}
-				]
+				}
 			}
 		]
 	},


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/270798#issuecomment-3391867902

no need to have this, the debugger will still launch for an open .chatreplay.json file

