### PR TITLE
Fixes to the gh coding agent provider

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotChatSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotChatSessionsProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { getGithubRepoIdFromFetchUrl, IGitService } from '../../../platform/git/common/gitService';
+import { getGithubRepoIdFromFetchUrl, GithubRepoId, IGitService } from '../../../platform/git/common/gitService';
 import { PullRequestSearchItem } from '../../../platform/github/common/githubAPI';
 import { IOctoKitService } from '../../../platform/github/common/githubService';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
@@ -18,6 +18,7 @@ export class CopilotChatSessionsProvider extends Disposable implements vscode.Ch
 	private readonly _onDidCommitChatSessionItem = this._register(new vscode.EventEmitter<{ original: vscode.ChatSessionItem; modified: vscode.ChatSessionItem }>());
 	public onDidCommitChatSessionItem = this._onDidCommitChatSessionItem.event;
 	private chatSessions: Map<number, PullRequestSearchItem> = new Map();
+	private chatSessionItemsPromise: Promise<vscode.ChatSessionItem[]> | undefined;
 
 	constructor(
 		@IOctoKitService private readonly _octoKitService: IOctoKitService,
@@ -27,44 +28,59 @@ export class CopilotChatSessionsProvider extends Disposable implements vscode.Ch
 	}
 
 	async provideChatSessionItems(token: vscode.CancellationToken): Promise<vscode.ChatSessionItem[]> {
-		// TODO: Return same promise if fetching the chat session items multiple times
-		const repo = this._gitService.activeRepository.get();
-		if (!repo || !repo.remoteFetchUrls?.[0]) {
-			return [];
+		if (this.chatSessionItemsPromise) {
+			return this.chatSessionItemsPromise;
 		}
-		const repoId = getGithubRepoIdFromFetchUrl(repo.remoteFetchUrls[0]);
-		if (!repoId) {
-			return [];
-		}
-		const pullRequests = await this._octoKitService.getCopilotPullRequestsForUser(repoId.org, repoId.repo);
-		const sessionItems = await Promise.all(pullRequests.map(async pr => {
-			const uri = await this.toOpenPullRequestWebviewUri({ owner: pr.repository.owner.login, repo: pr.repository.name, pullRequestNumber: pr.number });
-			const prLinkTitle = vscode.l10n.t('Open pull request in VS Code');
-			const description = new vscode.MarkdownString(`[#${pr.number}](${uri.toString()} "${prLinkTitle}")`);
-			const session = {
-				id: pr.number.toString(),
-				label: pr.title,
-				status: this.getSessionState(pr.state),
-				description,
-				timing: {
-					startTime: new Date(pr.updatedAt).getTime(),
-				},
-				statistics: {
-					insertions: pr.additions,
-					deletions: pr.deletions
-				},
-				fullDatabaseId: pr.fullDatabaseId.toString(),
-			};
-			this.chatSessions.set(pr.number, pr);
-			return session;
-		}));
-		return sessionItems;
+		this.chatSessionItemsPromise = (async () => {
+			const repoId = await this.getRepoId();
+			if (!repoId) {
+				return [];
+			}
+			const pullRequests = await this._octoKitService.getCopilotPullRequestsForUser(repoId.org, repoId.repo);
+			const sessionItems = await Promise.all(pullRequests.map(async pr => {
+				const uri = await this.toOpenPullRequestWebviewUri({ owner: pr.repository.owner.login, repo: pr.repository.name, pullRequestNumber: pr.number });
+				const prLinkTitle = vscode.l10n.t('Open pull request in VS Code');
+				const description = new vscode.MarkdownString(`[#${pr.number}](${uri.toString()} "${prLinkTitle}")`);
+				const session = {
+					id: pr.number.toString(),
+					label: pr.title,
+					status: this.getSessionState(pr.state),
+					description,
+					timing: {
+						startTime: new Date(pr.updatedAt).getTime(),
+					},
+					statistics: {
+						insertions: pr.additions,
+						deletions: pr.deletions
+					},
+					fullDatabaseId: pr.fullDatabaseId.toString(),
+				};
+				this.chatSessions.set(pr.number, pr);
+				return session;
+			}));
+			return sessionItems;
+		})().finally(() => {
+			this.chatSessionItemsPromise = undefined;
+		});
+		return this.chatSessionItemsPromise;
 	}
 
 	async provideChatSessionContent(sessionId: string, token: vscode.CancellationToken): Promise<vscode.ChatSession> {
-		const pr = this.chatSessions.get(Number(sessionId));
+		let pr = this.chatSessions.get(Number(sessionId));
 		if (!pr) {
-			throw new Error(`Session not found for ID: ${sessionId}`);
+			try {
+				const repoId = await this.getRepoId();
+				if (!repoId) {
+					throw new Error(`Failed to determine GitHub repo from workspace`);
+				}
+				const pullRequests = await this._octoKitService.getCopilotPullRequestsForUser(repoId.org, repoId.repo);
+				pr = pullRequests.find(pr => pr.number.toString() === sessionId);
+				if (!pr) {
+					throw new Error(`Pull request not found for ID: ${sessionId}`);
+				}
+			} catch (e) {
+				throw new Error(`Session not found for ID: ${sessionId}`, e);
+			}
 		}
 		const sessions = await this._octoKitService.getCopilotSessionsForPR(pr.fullDatabaseId.toString());
 		const sessionContentBuilder = new ChatSessionContentBuilder(CopilotChatSessionsProvider.TYPE, (sessionId: string) => this._octoKitService.getSessionLogs(sessionId));
@@ -95,5 +111,21 @@ export class CopilotChatSessionsProvider extends Disposable implements vscode.Ch
 		const query = JSON.stringify(params);
 		const extensionId = UriHandlers[UriHandlerPaths.External_OpenPullRequestWebview];
 		return await vscode.env.asExternalUri(vscode.Uri.from({ scheme: vscode.env.uriScheme, authority: extensionId, path: UriHandlerPaths.External_OpenPullRequestWebview, query }));
+	}
+
+	private async getRepoId(): Promise<GithubRepoId | undefined> {
+		let timeout = 5000;
+		while (!this._gitService.isInitialized) {
+			await new Promise(resolve => setTimeout(resolve, 100));
+			timeout -= 100;
+			if (timeout <= 0) {
+				break;
+			}
+		}
+
+		const repo = this._gitService.activeRepository.get();
+		if (repo && repo.remoteFetchUrls?.[0]) {
+			return getGithubRepoIdFromFetchUrl(repo.remoteFetchUrls[0]);
+		}
 	}
 }


### PR DESCRIPTION
Fixes:
1. Return same promise if the item provider is called multiple times before the first call is completed.
2. Content provider handling when cache is empty