### PR TITLE
edits: rm multi_replace for grok, simplify edit tools check

### DIFF
--- a/src/extension/intents/node/agentIntent.ts
+++ b/src/extension/intents/node/agentIntent.ts
@@ -88,10 +88,6 @@ export const getAgentTools = (instaService: IInstantiationService, request: vsco
 			if (allowTools[ToolName.ReplaceString] && await modelSupportsMultiReplaceString(model)) {
 				allowTools[ToolName.MultiReplaceString] = true;
 			}
-
-			if (model.family === 'grok-code' && configurationService.getExperimentBasedConfig(ConfigKey.Internal.MultiReplaceStringGrok, experimentationService)) {
-				allowTools[ToolName.MultiReplaceString] = true;
-			}
 		}
 
 		allowTools[ToolName.RunTests] = await testService.hasAnyTests();

--- a/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -70,14 +70,14 @@ export function modelPrefersJsonNotebookRepresentation(model: LanguageModelChat 
  * Model supports replace_string_in_file as an edit tool.
  */
 export async function modelSupportsReplaceString(model: LanguageModelChat | IChatEndpoint): Promise<boolean> {
-	return model.family.startsWith('claude') || model.family.startsWith('Anthropic') || model.family.includes('gemini') || model.family.includes('grok-code') || await isHiddenModelB(model);
+	return model.family.includes('gemini') || model.family.includes('grok-code') || await modelSupportsMultiReplaceString(model);
 }
 
 /**
  * Model supports multi_replace_string_in_file as an edit tool.
  */
 export async function modelSupportsMultiReplaceString(model: LanguageModelChat | IChatEndpoint): Promise<boolean> {
-	return await modelSupportsReplaceString(model) && !model.family.includes('gemini') && !model.family.includes('grok-code');
+	return model.family.startsWith('claude') || model.family.startsWith('Anthropic') || await isHiddenModelB(model);
 }
 
 /**


### PR DESCRIPTION
Does not look like current grok is happy with the multi_edit_tool. Remove the enablement.

Also simplify the `modelSupportsMultiReplaceString`. Previously models added to `modelSupportsReplaceString` implicitly enabled multi, but this is not desirable.

cc @bhavyaus (hidden model B was multi-enabled, did not know if this is intentional but I kept the logic)
cc @pwang347 