### PR TITLE
Fix Markdown link in Run Command tool

### DIFF
--- a/src/extension/tools/node/vscodeCmdTool.tsx
+++ b/src/extension/tools/node/vscodeCmdTool.tsx
@@ -56,6 +56,8 @@ class VSCodeCmdTool implements vscode.LanguageModelTool<IVSCodeCmdToolToolInput>
 		}
 
 		const quickOpenCommand = 'workbench.action.quickOpen';
+		// Populate the Quick Open box with command ID rather than command name to avoid issues where Copilot didn't use the precise name,
+		// or when the Copilot response language (Spanish, French, etc.) might be different here than the UI one.
 		const commandStr = commandUri(quickOpenCommand, [">" + commandId]);
 		const markdownString = new MarkdownString(l10n.t(`Copilot will execute the [{0}]({1}) command.`, options.input.name, commandStr));
 		markdownString.isTrusted = { enabledCommands: [quickOpenCommand] };


### PR DESCRIPTION
The link wasn't working before
<img width="354" height="329" alt="image" src="https://github.com/user-attachments/assets/3ff2e2d1-ba4b-4f40-bb7e-4e6838d8605d" />

Fixes https://github.com/microsoft/vscode/issues/272449
Partial fix for: https://github.com/microsoft/vscode/issues/252415