### PR TITLE
edits: include healing data in replace_string result, exp to disable, examples

### DIFF
--- a/src/extension/tools/node/applyPatchTool.tsx
+++ b/src/extension/tools/node/applyPatchTool.tsx
@@ -354,6 +354,9 @@ export class ApplyPatchTool implements ICopilotTool<IApplyPatchToolParams> {
 
 				files.push({ uri, isNotebook: !!notebookUri, existingDiagnostics, operation: resourceToOperation.get(uri) ?? ActionType.UPDATE });
 			}
+			if (healed && files.length) {
+				files[0].healed = healed;
+			}
 
 			timeout(2000).then(() => {
 				// The tool can't wait for edits to be applied, so just wait before starting the survival tracker.
@@ -401,7 +404,7 @@ export class ApplyPatchTool implements ICopilotTool<IApplyPatchToolParams> {
 					await renderPromptElementJSON(
 						this.instantiationService,
 						EditFileResult,
-						{ files, diagnosticsTimeout: 2000, toolName: ToolName.ApplyPatch, requestId: options.chatRequestId, model: options.model, healed },
+						{ files, diagnosticsTimeout: 2000, toolName: ToolName.ApplyPatch, requestId: options.chatRequestId, model: options.model },
 						options.tokenizationOptions ?? {
 							tokenBudget: 1000,
 							countTokens: (t) => Promise.resolve(t.length * 3 / 4)

--- a/src/extension/tools/node/editFileHealing.tsx
+++ b/src/extension/tools/node/editFileHealing.tsx
@@ -244,7 +244,7 @@ Return ONLY the corrected target snippet in the specified JSON format with the k
 `.trim();
 
 	try {
-		const result = await getJsonResponse(healEndpoint, prompt, oldString_CORRECTION_SCHEMA, token);
+		const result = await getJsonResponse(healEndpoint, prompt, oldString_CORRECTION_SCHEMA, { corrected_target_snippet: '<corrected target snippet here>' }, token);
 		if (
 			result &&
 			typeof result.corrected_target_snippet === 'string' &&
@@ -314,7 +314,7 @@ Return ONLY the corrected string in the specified JSON format with the key 'corr
   `.trim();
 
 	try {
-		const result = await getJsonResponse(endpoint, prompt, newString_CORRECTION_SCHEMA, token);
+		const result = await getJsonResponse(endpoint, prompt, newString_CORRECTION_SCHEMA, { corrected_newString: '<corrected newString here>' }, token);
 		if (
 			result &&
 			typeof result.corrected_newString === 'string' &&
@@ -369,7 +369,7 @@ Return ONLY the corrected string in the specified JSON format with the key 'corr
   `.trim();
 
 	try {
-		const result = await getJsonResponse(geminiClient, prompt, CORRECT_newString_ESCAPING_SCHEMA, token);
+		const result = await getJsonResponse(geminiClient, prompt, CORRECT_newString_ESCAPING_SCHEMA, { corrected_newString_escaping: '<corrected newString here>' }, token);
 		if (
 			result &&
 			typeof result.corrected_newString_escaping === 'string' &&
@@ -396,12 +396,14 @@ const CORRECT_STRING_ESCAPING_SCHEMA: ObjectJsonSchema = {
 	required: ['corrected_string_escaping'],
 };
 
-async function getJsonResponse(endpoint: IChatEndpoint, prompt: string, schema: ObjectJsonSchema, token: CancellationToken) {
+async function getJsonResponse(endpoint: IChatEndpoint, prompt: string, schema: ObjectJsonSchema, example: object, token: CancellationToken) {
 	prompt += `\n\nYour response must follow the JSON format:
 
 	\`\`\`
 ${JSON.stringify(schema, null, 2)}
 \`\`\`
+
+For example: ${JSON.stringify(example)}
 `.trim();
 
 	const contents: Raw.ChatMessage[] = [
@@ -415,7 +417,7 @@ ${JSON.stringify(schema, null, 2)}
 		messages: contents,
 		finishedCb: undefined,
 		location: ChatLocation.Other,
-		enableRetryOnFilter: true
+		enableRetryOnFilter: true,
 	}, token);
 
 	if (result.type !== ChatFetchResponseType.Success) {
@@ -457,7 +459,7 @@ Return ONLY the corrected string in the specified JSON format with the key 'corr
 
 
 	try {
-		const result = await getJsonResponse(endpoint, prompt, CORRECT_STRING_ESCAPING_SCHEMA, token);
+		const result = await getJsonResponse(endpoint, prompt, CORRECT_STRING_ESCAPING_SCHEMA, { corrected_string_escaping: '<corrected string here>' }, token);
 
 		if (
 			result &&

--- a/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -89,6 +89,14 @@ export async function modelCanUseReplaceStringExclusively(model: LanguageModelCh
 }
 
 /**
+ * We should attempt to automatically heal incorrect edits the model may emit.
+ * @note whether this is respected is currently controlled via EXP
+ */
+export function modelShouldUseReplaceStringHealing(model: LanguageModelChat | IChatEndpoint) {
+	return model.family.includes('gemini');
+}
+
+/**
  * The model can accept image urls as the `image_url` parameter in mcp tool results.
  */
 export async function modelCanUseMcpResultImageURL(model: LanguageModelChat | IChatEndpoint): Promise<boolean> {


### PR DESCRIPTION
- Include healed patch in replace_string tool results
- Add EXP to disable replace_string healing for non-Gemini models
- Add an example to the replace_string prompts for greater fidelity