### PR TITLE
Handle integer types in gemini BYOK

### DIFF
--- a/src/extension/byok/common/geminiFunctionDeclarationConverter.ts
+++ b/src/extension/byok/common/geminiFunctionDeclarationConverter.ts
@@ -30,8 +30,12 @@ function mapType(jsonType: string): Type {
 			return Type.STRING;
 		case "number":
 			return Type.NUMBER;
+		case "integer":
+			return Type.INTEGER;
 		case "boolean":
 			return Type.BOOLEAN;
+		case "null":
+			return Type.NULL;
 		default:
 			throw new Error(`Unsupported type: ${jsonType}`);
 	}

--- a/src/extension/byok/common/test/geminiFunctionDeclarationConverter.spec.ts
+++ b/src/extension/byok/common/test/geminiFunctionDeclarationConverter.spec.ts
@@ -64,6 +64,59 @@ describe('GeminiFunctionDeclarationConverter', () => {
 			expect(result.description).toBe('No description provided.');
 		});
 
+		it('should handle integer type by mapping to INTEGER', () => {
+			const schema: ToolJsonSchema = {
+				type: 'object',
+				properties: {
+					count: {
+						type: 'integer',
+						description: 'An integer count'
+					},
+					groupIndex: {
+						type: 'integer',
+						description: 'Group index'
+					}
+				},
+				required: ['count']
+			};
+
+			const result = toGeminiFunction('integerFunction', 'Function with integer parameters', schema);
+
+			expect(result.parameters).toBeDefined();
+			expect(result.parameters!.type).toBe(Type.OBJECT);
+			expect(result.parameters!.required).toEqual(['count']);
+			expect(result.parameters!.properties).toBeDefined();
+			expect(result.parameters!.properties!['count']).toEqual({
+				type: Type.INTEGER,
+				description: 'An integer count'
+			});
+			expect(result.parameters!.properties!['groupIndex']).toEqual({
+				type: Type.INTEGER,
+				description: 'Group index'
+			});
+		});
+
+		it('should handle null type by mapping to NULL', () => {
+			const schema: ToolJsonSchema = {
+				type: 'object',
+				properties: {
+					nullableField: {
+						type: 'null',
+						description: 'A nullable field'
+					}
+				}
+			};
+
+			const result = toGeminiFunction('nullFunction', 'Function with null parameter', schema);
+
+			expect(result.parameters).toBeDefined();
+			expect(result.parameters!.properties).toBeDefined();
+			expect(result.parameters!.properties!['nullableField']).toEqual({
+				type: Type.NULL,
+				description: 'A nullable field'
+			});
+		});
+
 		it('should handle array schema by using items as parameters', () => {
 			const schema: ToolJsonSchema = {
 				type: 'array',


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/272728

Agent mode uses **virtualToolSummarizer** which has parameters with "integer" type that the Gemini converter wasn't handling. Fix is to add mapping for integer. Also added mapping for 'null' type.

Now all the gemini types are handled, for ref below is the doc on gemini types schema:
https://ai.google.dev/api/caching#Type 