### PR TITLE
Fix comment tagging format for cloud follow ups

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -79,8 +79,6 @@ const DEFAULT_AGENT_ID = '___vscode_default___';
 export class CopilotChatSessionsProvider extends Disposable implements vscode.ChatSessionContentProvider, vscode.ChatSessionItemProvider {
 	public static readonly TYPE = 'copilot-cloud-agent';
 	private readonly DELEGATE_MODAL_DETAILS = vscode.l10n.t('The agent will work asynchronously to create a pull request with your requested changes.');
-	private readonly COPILOT = 'GitHub Copilot Cloud Agent';
-
 	private readonly _onDidChangeChatSessionItems = this._register(new vscode.EventEmitter<void>());
 	public readonly onDidChangeChatSessionItems = this._onDidChangeChatSessionItems.event;
 	private readonly _onDidCommitChatSessionItem = this._register(new vscode.EventEmitter<{ original: vscode.ChatSessionItem; modified: vscode.ChatSessionItem }>());


### PR DESCRIPTION
ensures we tag the right user when following up with cloud agent

eg: https://github.com/microsoft/vscode-copilot-chat/pull/1516#issuecomment-3434069247