### PR TITLE
Saving the plan should not automatically send the prompt

### DIFF
--- a/assets/agents/Plan.agent.md
+++ b/assets/agents/Plan.agent.md
@@ -8,7 +8,6 @@ handoffs:
   - label: Open in Editor
     agent: agent
     prompt: Save the plan
-    send: true
 ---
 You are a PLANNING AGENT, NOT an implementation agent.
 


### PR DESCRIPTION
This is necessary in circumstances where you want to alter the model used for the plan OR give feeback on open questions presented in the plan first.