### PR TITLE
Copilot CLI Terminal handling of npm not found

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCLIShim.ps1
+++ b/src/extension/chatSessions/vscode-node/copilotCLIShim.ps1
@@ -78,12 +78,12 @@ function Test-AndLaunchCopilot {
                     Test-AndLaunchCopilot $Arguments
                     return
                 } else {
-                    Write-Host "Installation failed. Please check your npm configuration and try again."
-                    exit 1
+                    Read-Host "Installation failed. Please check your npm configuration and try again."
+                    return
                 }
             } catch {
-                Write-Host "Installation failed. Please check your npm configuration and try again."
-                exit 1
+                Read-Host "Installation failed. Please check your npm configuration and try again."
+                return
             }
         } else {
             exit 0
@@ -103,12 +103,12 @@ function Test-AndLaunchCopilot {
                     Test-AndLaunchCopilot $Arguments
                     return
                 } else {
-                    Write-Host "Reinstallation failed. Please check your npm configuration and try again."
-                    exit 1
+                    Read-Host "Reinstallation failed. Please check your npm configuration and try again."
+                    return
                 }
             } catch {
-                Write-Host "Reinstallation failed. Please check your npm configuration and try again."
-                exit 1
+                Read-Host "Reinstallation failed. Please check your npm configuration and try again."
+                return
             }
         } else {
             exit 0
@@ -130,12 +130,12 @@ function Test-AndLaunchCopilot {
                     Test-AndLaunchCopilot $Arguments
                     return
                 } else {
-                    Write-Host "Reinstallation failed. Please check your npm configuration and try again."
-                    exit 1
+                    Read-Host "Reinstallation failed. Please check your npm configuration and try again."
+                    return
                 }
             } catch {
-                Write-Host "Reinstallation failed. Please check your npm configuration and try again."
-                exit 1
+                Read-Host "Reinstallation failed. Please check your npm configuration and try again."
+                return
             }
         } else {
             exit 0
@@ -164,12 +164,12 @@ function Test-AndLaunchCopilot {
                     Test-AndLaunchCopilot $Arguments
                     return
                 } else {
-                    Write-Host "Reinstallation failed. Please check your npm configuration and try again."
-                    exit 1
+                    Read-Host "Reinstallation failed. Please check your npm configuration and try again."
+                    return
                 }
             } catch {
-                Write-Host "Reinstallation failed. Please check your npm configuration and try again."
-                exit 1
+                Read-Host "Reinstallation failed. Please check your npm configuration and try again."
+                return
             }
         } else {
             exit 0
@@ -187,12 +187,12 @@ function Test-AndLaunchCopilot {
                     Test-AndLaunchCopilot $Arguments
                     return
                 } else {
-                    Write-Host "Update failed. Please check your npm configuration and try again."
-                    exit 1
+                    Read-Host "Update failed. Please check your npm configuration and try again."
+                    return
                 }
             } catch {
-                Write-Host "Update failed. Please check your npm configuration and try again."
-                exit 1
+                Read-Host "Update failed. Please check your npm configuration and try again."
+                return
             }
         } else {
             exit 0
@@ -205,8 +205,8 @@ function Test-AndLaunchCopilot {
         & $realCopilot @Arguments
     } else {
         Write-Host "Error: Could not find the real GitHub Copilot CLI binary"
-        Write-Host "Please ensure it's properly installed with: npm install -g @github/copilot"
-        exit 1
+        Read-Host "Please ensure it's properly installed with: npm install -g @github/copilot"
+        return
     }
 }
 

--- a/src/extension/chatSessions/vscode-node/copilotCLIShim.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLIShim.ts
@@ -100,7 +100,7 @@ async function ensureInstalled() {
 			if (runNpm(['install', '-g', PACKAGE_NAME], 'Installing')) {
 				return ensureInstalled();
 			}
-			process.exit(1);
+			await pressKeyToExit();
 		} else {
 			process.exit(0);
 		}
@@ -116,11 +116,21 @@ async function validateVersion(version: string) {
 			if (runNpm(['update', '-g', PACKAGE_NAME], 'Update')) {
 				return true;
 			}
-			process.exit(1);
+			await pressKeyToExit();
 		} else {
 			process.exit(0);
 		}
 	}
+}
+
+async function pressKeyToExit(message: string = 'Press Enter to exit...'): Promise<void> {
+	await new Promise<void>((resolve) => {
+		rl.question(`${message}`, () => {
+			resolve();
+		});
+	});
+	process.exit(0);
+
 }
 
 (async function main() {
@@ -130,8 +140,7 @@ async function validateVersion(version: string) {
 	}
 	if (!info) {
 		warn('Error: Could not locate Copilot CLI after update.');
-		warn(`Try manually reinstalling with: npm install -g ${PACKAGE_NAME} (https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli)`);
-		process.exit(1);
+		await pressKeyToExit(`Try manually reinstalling with: npm install -g ${PACKAGE_NAME} (https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli)`);
 	}
 	const args = process.argv.slice(2);
 
@@ -142,6 +151,6 @@ async function validateVersion(version: string) {
 		args.shift();
 	}
 
-	const { status } = spawnSync('copilot', args, { stdio: 'inherit', env });
-	process.exit(status);
+	spawnSync('copilot', args, { stdio: 'inherit', env });
+	process.exit(0);
 })();


### PR DESCRIPTION
Fixes issues where npm isn't installed and when you click `y` to install `Copilot` the terminal just exists without any reason
New behaviour : You will now see the errors