### PR TITLE
Fix sessions not loading with undefined `problem_statement`

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -254,6 +254,10 @@ export class CopilotChatSessionsProvider extends Disposable implements vscode.Ch
 			}
 			const jobInfo = await this._octoKitService.getJobBySessionId(repoId.org, repoId.repo, sessions[0].id, 'vscode-copilot-chat');
 			let prompt = jobInfo.problem_statement;
+			if (typeof jobInfo.problem_statement !== 'string') {
+				return undefined;
+			}
+
 			const titleMatch = jobInfo.problem_statement.match(/TITLE: \s*(.*)/i);
 			if (titleMatch && titleMatch[1]) {
 				prompt = titleMatch[1].trim();


### PR DESCRIPTION
Not sure what happens but some of my sessions return an undefined `problem_statement`. This causes the entire session to fail to load