### PR TITLE
Remove unused imports from test files

### DIFF
--- a/src/extension/completions-core/vscode-node/lib/src/suggestions/test/partialSuggestions.test.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/suggestions/test/partialSuggestions.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { suite, test } from 'mocha';
 import {
 	SuggestionStatus,
 	computeCompCharLen,

--- a/src/extension/completions-core/vscode-node/lib/src/test/textDocumentManager.test.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/test/textDocumentManager.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { suite, test } from 'mocha';
 import { Context } from '../context';
 import { makeFsUri } from '../util/uri';
 import { createLibTestingContext } from './context';

--- a/src/extension/completions-core/vscode-node/prompt/src/test/indentation.test.ts
+++ b/src/extension/completions-core/vscode-node/prompt/src/test/indentation.test.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
-import { suite } from 'mocha';
 import dedent from 'ts-dedent';
 import {
 	blankNode,

--- a/src/extension/completions-core/vscode-node/prompt/src/test/indentationLanguages.test.ts
+++ b/src/extension/completions-core/vscode-node/prompt/src/test/indentationLanguages.test.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
-import { suite } from 'mocha';
 import dedent from 'ts-dedent';
 import { blankNode, isLine, lineNode, parseTree, topNode, virtualNode, visitTree } from '../indentation';
 import { compareTreeWithSpec } from './testHelpers';

--- a/src/extension/completions-core/vscode-node/prompt/src/test/indentationParsing.test.ts
+++ b/src/extension/completions-core/vscode-node/prompt/src/test/indentationParsing.test.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
-import { suite } from 'mocha';
 import dedent from 'ts-dedent';
 import {
 	blankNode,

--- a/src/extension/completions-core/vscode-node/prompt/src/test/languageMarker.test.ts
+++ b/src/extension/completions-core/vscode-node/prompt/src/test/languageMarker.test.ts
@@ -14,7 +14,6 @@ import {
 import { DocumentInfoWithOffset } from '../prompt';
 import * as assert from 'assert';
 import * as fs from 'fs';
-import { suite } from 'mocha';
 import { resolve } from 'path';
 
 suite('LanguageMarker Test Suite', function () {

--- a/src/extension/completions-core/vscode-node/prompt/src/test/multisnippet.test.ts
+++ b/src/extension/completions-core/vscode-node/prompt/src/test/multisnippet.test.ts
@@ -10,7 +10,6 @@ import {
 	nullSimilarFilesOptions,
 } from '../snippetInclusion/similarFiles';
 import * as assert from 'assert';
-import { suite } from 'mocha';
 import dedent from 'ts-dedent';
 
 suite('Test Multiple Snippet Selection', function () {

--- a/src/extension/completions-core/vscode-node/prompt/src/test/similarFiles.test.ts
+++ b/src/extension/completions-core/vscode-node/prompt/src/test/similarFiles.test.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
-import { suite } from 'mocha';
 import dedent from 'ts-dedent';
 import { DocumentInfoWithOffset, SimilarFileInfo } from '../prompt';
 import { FixedWindowSizeJaccardMatcher, computeScore } from '../snippetInclusion/jaccardMatching';

--- a/src/extension/completions-core/vscode-node/prompt/src/test/snippets.test.ts
+++ b/src/extension/completions-core/vscode-node/prompt/src/test/snippets.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import { SnippetProviderType, SnippetSemantics, announceSnippet } from '../snippetInclusion/snippets';
 import * as assert from 'assert';
-import { suite } from 'mocha';
 import dedent from 'ts-dedent';
 
 suite('Unit tests for snippet.ts', () => {

--- a/src/extension/completions-core/vscode-node/prompt/src/test/suffixmatch.test.ts
+++ b/src/extension/completions-core/vscode-node/prompt/src/test/suffixmatch.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import { findEditDistanceScore } from '../suffixMatchCriteria';
 import * as assert from 'assert';
-import { suite } from 'mocha';
 
 suite('EditDistanceScore Test Suite', function () {
 	test('findEditDistanceScore computes correct score of two number[]', function () {

--- a/src/extension/completions-core/vscode-node/prompt/src/test/tokenizer.test.ts
+++ b/src/extension/completions-core/vscode-node/prompt/src/test/tokenizer.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
 import * as fs from 'fs';
-import { suite } from 'mocha';
 import { resolve } from 'path';
 import { ApproximateTokenizer, getTokenizer, TokenizerName } from '../tokenization';
 

--- a/src/extension/completions-core/vscode-node/prompt/src/test/windowDelineation.test.ts
+++ b/src/extension/completions-core/vscode-node/prompt/src/test/windowDelineation.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import { getIndentationWindowsDelineations } from '../snippetInclusion/windowDelineations';
 import * as assert from 'assert';
-import { suite } from 'mocha';
 import dedent from 'ts-dedent';
 
 const SOURCE = {


### PR DESCRIPTION
```Copilot Generated Description:``` Remove unnecessary imports of `suite` from the `mocha` testing framework across multiple test files.