### PR TITLE
remove redundant message

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -465,7 +465,7 @@ export class CopilotChatSessionsProvider extends Disposable implements vscode.Ch
 							stream.warning(result.error);
 							return {};
 						}
-						stream.markdown(vscode.l10n.t('GitHub Copilot cloud agent has begun working on your request, ignoring uncommitted changes.'));
+						stream.markdown(vscode.l10n.t('GitHub Copilot cloud agent has begun working on your request.'));
 						return {};
 					}
 				default:


### PR DESCRIPTION
This string feels a bit redundant/confusing, especially since the user just acknowledged this.