### PR TITLE
Port java dependency extension version filter

### DIFF
--- a/src/extension/completions-core/vscode-node/extension/src/config.ts
+++ b/src/extension/completions-core/vscode-node/extension/src/config.ts
@@ -105,6 +105,7 @@ export class VSCodeEditorInfo extends EditorAndPluginInfo {
 			'ms-python.python',
 			'ms-python.vscode-pylance',
 			'vscjava.vscode-java-pack',
+			'vscjava.vscode-java-dependency',
 			'vscode.typescript-language-features',
 			'ms-vscode.vscode-typescript-next',
 			'ms-dotnettools.csharp',

--- a/src/extension/completions-core/vscode-node/lib/src/experiments/filters.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/experiments/filters.ts
@@ -41,10 +41,6 @@ export enum Filter {
 	/** The Copilot Client Version */
 	CopilotClientVersion = 'X-Copilot-ClientVersion',
 
-	// Copilot-specific filters for related plugins
-	// Any additions to this list also need to be:
-	// 1. Added to the ExP backend by submitting a DRI ticket to ExP.
-	// 2. Enabled in the Control Tower UI by any experimentation admin.
 	CopilotRelatedPluginVersionCppTools = CopilotRelatedPluginVersionPrefix + 'msvscodecpptools',
 	CopilotRelatedPluginVersionCMakeTools = CopilotRelatedPluginVersionPrefix + 'msvscodecmaketools',
 	CopilotRelatedPluginVersionMakefileTools = CopilotRelatedPluginVersionPrefix + 'msvscodemakefiletools',
@@ -52,6 +48,7 @@ export enum Filter {
 	CopilotRelatedPluginVersionPython = CopilotRelatedPluginVersionPrefix + 'mspythonpython',
 	CopilotRelatedPluginVersionPylance = CopilotRelatedPluginVersionPrefix + 'mspythonvscodepylance',
 	CopilotRelatedPluginVersionJavaPack = CopilotRelatedPluginVersionPrefix + 'vscjavavscodejavapack',
+	CopilotRelatedPluginVersionJavaManager = CopilotRelatedPluginVersionPrefix + 'vscjavavscodejavadependency',
 	CopilotRelatedPluginVersionTypescript = CopilotRelatedPluginVersionPrefix + 'vscodetypescriptlanguagefeatures',
 	CopilotRelatedPluginVersionTypescriptNext = CopilotRelatedPluginVersionPrefix + 'msvscodevscodetypescriptnext',
 	CopilotRelatedPluginVersionCSharp = CopilotRelatedPluginVersionPrefix + 'msdotnettoolscsharp',


### PR DESCRIPTION
```Copilot Generated Description:``` Add the extension ID `vscjava.vscode-java-dependency` to the list of related plugins and update the filter enumeration accordingly.

Fixes microsoft/vscode-internalbacklog#6082