### PR TITLE
Simplify request logger a bit

### DIFF
--- a/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -161,14 +161,16 @@ export class AnthropicLMProvider implements BYOKModelProvider<LanguageModelChatI
 				messages: anthropicMessagesToRawMessagesForLogging(convertedMessages, system),
 				ourRequestId: requestId,
 				location: ChatLocation.Other,
-				tools: options.tools?.map((tool): OpenAiFunctionTool => ({
-					type: 'function',
-					function: {
-						name: tool.name,
-						description: tool.description,
-						parameters: tool.inputSchema
-					}
-				})),
+				body: {
+					tools: options.tools?.map((tool): OpenAiFunctionTool => ({
+						type: 'function',
+						function: {
+							name: tool.name,
+							description: tool.description,
+							parameters: tool.inputSchema
+						}
+					}))
+				},
 			});
 
 		// Check if memory tool is present

--- a/src/extension/byok/vscode-node/geminiNativeProvider.ts
+++ b/src/extension/byok/vscode-node/geminiNativeProvider.ts
@@ -108,14 +108,16 @@ export class GeminiNativeBYOKLMProvider implements BYOKModelProvider<LanguageMod
 				messages: geminiMessagesToRawMessagesForLogging(contents, systemInstruction),
 				ourRequestId: requestId,
 				location: ChatLocation.Other,
-				tools: options.tools?.map((tool): OpenAiFunctionTool => ({
-					type: 'function',
-					function: {
-						name: tool.name,
-						description: tool.description,
-						parameters: tool.inputSchema
-					}
-				})),
+				body: {
+					tools: options.tools?.map((tool): OpenAiFunctionTool => ({
+						type: 'function',
+						function: {
+							name: tool.name,
+							description: tool.description,
+							parameters: tool.inputSchema
+						}
+					}))
+				}
 			});
 
 		// Convert VS Code tools to Gemini function declarations

--- a/src/extension/conversation/vscode-node/feedbackReporter.ts
+++ b/src/extension/conversation/vscode-node/feedbackReporter.ts
@@ -136,7 +136,7 @@ export class FeedbackReporter extends Disposable implements IFeedbackReporter {
 		const responseDump = this._embedCodeblock('ASSISTANT', turn.responseMessage?.message || '');
 		const workspaceState = await this._instantiationService.createInstance(WorkspaceStateSnapshotHelper).captureWorkspaceStateSnapshot([]);
 		const workspaceStateDump = this._embedCodeblock('WORKSPACE STATE', JSON.stringify(workspaceState, null, 2));
-		const toolsDump = params?.tools ? this._embedCodeblock('TOOLS', JSON.stringify(params.tools, null, 2)) : '';
+		const toolsDump = params?.body?.tools ? this._embedCodeblock('TOOLS', JSON.stringify(params.body.tools, null, 2)) : '';
 		const metadata = this._embedCodeblock('METADATA', `requestID: ${turn.id}\nmodel: ${params?.model}`);
 		const edits = (await this._editLogService.getEditLog(turn.id))?.map((edit, i) => {
 			return this._embedCodeblock(`EDIT ${i + 1}`, JSON.stringify(edit, null, 2));

--- a/src/extension/prompt/node/chatMLFetcher.ts
+++ b/src/extension/prompt/node/chatMLFetcher.ts
@@ -131,9 +131,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			model: chatEndpoint.model,
 			ourRequestId,
 			location: opts.location,
-			postOptions,
 			body: requestBody,
-			tools: requestBody.tools,
 			ignoreStatefulMarker: opts.ignoreStatefulMarker
 		});
 		let tokenCount = -1;

--- a/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -178,8 +178,9 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 			model: this.model,
 			ourRequestId,
 			location,
-			postOptions: requestOptions,
-			tools: requestOptions?.tools,
+			body: {
+				...requestOptions
+			},
 			ignoreStatefulMarker: true
 		})
 			: undefined;

--- a/src/platform/requestLogger/node/requestLogger.ts
+++ b/src/platform/requestLogger/node/requestLogger.ts
@@ -8,7 +8,7 @@ import { HTMLTracer, IChatEndpointInfo, Raw, RenderPromptResult } from '@vscode/
 import { AsyncLocalStorage } from 'async_hooks';
 import type { Event } from 'vscode';
 import { ChatFetchError, ChatFetchResponseType, ChatLocation, ChatResponses, FetchSuccess } from '../../../platform/chat/common/commonTypes';
-import { IResponseDelta, OpenAiFunctionTool, OpenAiResponsesFunctionTool, OptionalChatRequestParams } from '../../../platform/networking/common/fetch';
+import { IResponseDelta, OptionalChatRequestParams } from '../../../platform/networking/common/fetch';
 import { IChatEndpoint, IEndpointBody } from '../../../platform/networking/common/networking';
 import { createServiceIdentifier } from '../../../util/common/services';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
@@ -128,7 +128,6 @@ export interface ILoggedToolCall {
 
 export interface ILoggedPendingRequest {
 	messages: Raw.ChatMessage[];
-	tools: (OpenAiFunctionTool | OpenAiResponsesFunctionTool)[] | undefined;
 	ourRequestId: string;
 	model: string;
 	location: ChatLocation;


### PR DESCRIPTION
Remove postOptions, since we should log params from the real request, and duplicated 'tools'.