### PR TITLE
Linkify line numbers to enable precise line navigation from chat responses

### DIFF
--- a/src/extension/linkify/common/filePathLinkifier.ts
+++ b/src/extension/linkify/common/filePathLinkifier.ts
@@ -79,7 +79,13 @@ export class FilePathLinkifier implements IContributedLinkifier {
 			pathText ??= match.groups?.['inlineCodePath'] ?? match.groups?.['plainTextPath'] ?? '';
 
 			parts.push(this.resolvePathText(pathText, context)
-				.then(uri => uri ? new LinkifyLocationAnchor(uri) : matched));
+				.then(uri => {
+					if (!uri) {
+						return matched;
+					}
+					// Do not try to parse line annotations here; central parser & buffer will upgrade later.
+					return new LinkifyLocationAnchor(uri);
+				}));
 
 			endLastMatch = match.index + matched.length;
 		}

--- a/src/extension/linkify/common/filePathLinkifier.ts
+++ b/src/extension/linkify/common/filePathLinkifier.ts
@@ -79,13 +79,7 @@ export class FilePathLinkifier implements IContributedLinkifier {
 			pathText ??= match.groups?.['inlineCodePath'] ?? match.groups?.['plainTextPath'] ?? '';
 
 			parts.push(this.resolvePathText(pathText, context)
-				.then(uri => {
-					if (!uri) {
-						return matched;
-					}
-					// Do not try to parse line annotations here; central parser & buffer will upgrade later.
-					return new LinkifyLocationAnchor(uri);
-				}));
+				.then(uri => uri ? new LinkifyLocationAnchor(uri) : matched));
 
 			endLastMatch = match.index + matched.length;
 		}

--- a/src/extension/linkify/common/lineAnnotationParser.ts
+++ b/src/extension/linkify/common/lineAnnotationParser.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// General, extensible parser for line annotations following a file path.
+// Keeps logic maintainable by avoiding a monolithic fragile regex.
+
+const RANGE_CONNECTORS = new Set(['-', '–', '—', 'to', 'through', 'thru']);
+const LINE_TOKENS = new Set(['line', 'lines', 'ln', 'l']);
+
+export interface ParsedLineAnnotation {
+	readonly startLine: number; // zero-based
+	readonly raw: string;       // raw matched snippet
+}
+
+const parenRe = /^\s*\((lines?)\s+(\d+)(?:\s*([–—-]|to|through|thru)\s*(\d+))?\)/i;
+
+export function parseLineNumberAnnotation(text: string, maxScan = 160): ParsedLineAnnotation | undefined {
+	if (!text) { return undefined; }
+	const slice = text.slice(0, maxScan);
+	const pm = parenRe.exec(slice);
+	if (pm) {
+		const line = toLine(pm[2]);
+		if (line !== undefined) {
+			return { startLine: line, raw: pm[0] };
+		}
+	}
+	const tokenRe = /[A-Za-z]+|\d+|[–—-]/g;
+	const tokens: string[] = [];
+	let m: RegExpExecArray | null;
+	while ((m = tokenRe.exec(slice))) {
+		tokens.push(m[0]);
+		if (tokens.length > 40) { break; }
+	}
+	for (let i = 0; i < tokens.length; i++) {
+		const tk = tokens[i].toLowerCase();
+		if (LINE_TOKENS.has(tk)) {
+			const numToken = tokens[i + 1];
+			if (numToken && /^\d+$/.test(numToken)) {
+				const line = toLine(numToken);
+				if (line === undefined) { continue; }
+				const maybeConnector = tokens[i + 2]?.toLowerCase();
+				if (maybeConnector && RANGE_CONNECTORS.has(maybeConnector)) {
+					const secondNum = tokens[i + 3];
+					if (!secondNum || !/^\d+$/.test(secondNum)) {
+						return { startLine: line, raw: reconstruct(tokens, i, 4) };
+					}
+					return { startLine: line, raw: reconstruct(tokens, i, 4) };
+				}
+				return { startLine: line, raw: reconstruct(tokens, i, 2) };
+			}
+		}
+	}
+	return undefined;
+}
+
+function toLine(token: string): number | undefined {
+	const n = parseInt(token, 10);
+	return isNaN(n) || n <= 0 ? undefined : n - 1;
+}
+
+function reconstruct(tokens: string[], start: number, span: number): string {
+	return tokens.slice(start, start + span).join(' ');
+}
+
+if (typeof process !== 'undefined' && process.env?.VITEST_INTERNAL_EVAL === 'lineAnnotationParserDev') {
+	const samples = [
+		'(line 42)',
+		'(lines 10-15)',
+		'is located at lines 77–85.',
+		'is found at lines 5-9',
+		'is at lines 6 through 11',
+		'on line 120',
+		'at line 33',
+		'lines 44-50',
+		'Ln 22',
+		'line 9'
+	];
+	for (const s of samples) {
+		console.log('ANNOT_SAMPLE', s, parseLineNumberAnnotation(s));
+	}
+}

--- a/src/extension/linkify/common/lineAnnotationParser.ts
+++ b/src/extension/linkify/common/lineAnnotationParser.ts
@@ -90,21 +90,3 @@ function toLine(token: string): number | undefined {
 function reconstruct(tokens: string[], start: number, span: number): string {
 	return tokens.slice(start, start + span).join(' ');
 }
-
-if (typeof process !== 'undefined' && process.env?.VITEST_INTERNAL_EVAL === 'lineAnnotationParserDev') {
-	const samples = [
-		'(line 42)',
-		'(lines 10-15)',
-		'is located at lines 77–85.',
-		'is found at lines 5-9',
-		'is at lines 6 through 11',
-		'on line 120',
-		'at line 33',
-		'lines 44-50',
-		'Ln 22',
-		'line 9'
-	];
-	for (const s of samples) {
-		console.log('ANNOT_SAMPLE', s, parseLineNumberAnnotation(s));
-	}
-}

--- a/src/extension/linkify/common/lineAnnotationParser.ts
+++ b/src/extension/linkify/common/lineAnnotationParser.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// General, extensible parser for line annotations following a file path.
+// General parser for line annotations following a file path.
 // Supported patterns (single-line anchor uses first line in range):
 //
 // Parenthesized forms:
@@ -22,13 +22,12 @@
 //   is found at lines 5-9
 //   is at lines 6 through 11
 //
-// We intentionally only expose the start line (zero-based) because downstream
+// Intentionally only expose the start line (zero-based) because downstream
 // logic currently navigates to a single line even if a range was referenced.
 // Extending to full range selection would involve carrying an endLine as well.
 //
 // Design notes:
-// - Token-based approach avoids brittle giant regex and makes future synonym
-//   additions trivial (expand LINE_TOKENS or RANGE_CONNECTORS sets).
+// - Uses token-based approach
 // - Max scan limits ensure we do not waste time over very long trailing text.
 // - We ignore invalid ranges like "lines 10 through" (missing second number)
 //   but still treat the first number as the target line.
@@ -93,7 +92,7 @@ export function parseTrailingLineNumberAnnotation(text: string, maxScan = 160): 
 
 	const slice = text.slice(0, maxScan);
 
-	// Fast path: Check for parenthesized form like "(line 42)" or "(lines 10-12)"
+	// Check for parenthesized form like "(line 42)" or "(lines 10-12)"
 	const pm = parenRe.exec(slice);
 	if (pm) {
 		const line = toLine(pm[2]);
@@ -128,8 +127,7 @@ export function parseTrailingLineNumberAnnotation(text: string, maxScan = 160): 
 //   ln 22 of <file>
 //   at line 19 in <file>
 //   line 19 in <file>
-// Tokenization would work here too, but a concise end-anchored regex is sufficient
-// because we only inspect a short contiguous snapshot directly preceding the file path.
+// We only inspect a short contiguous snapshot directly preceding the file path.
 // Returns startLine (zero-based) if matched.
 export function parsePrecedingLineNumberAnnotation(text: string): ParsedLineAnnotation | undefined {
 	if (!text) { return undefined; }

--- a/src/extension/linkify/common/linkifier.ts
+++ b/src/extension/linkify/common/linkifier.ts
@@ -333,7 +333,7 @@ export class Linkifier implements ILinkifier {
 		return out;
 	}
 
-	// --- Simplified buffering helpers ---
+	// --- buffering helpers ---
 
 	private processCoalescedParts(parts: readonly LinkifiedPart[]): LinkifiedPart[] {
 		const emit: LinkifiedPart[] = [];

--- a/src/extension/linkify/common/linkifier.ts
+++ b/src/extension/linkify/common/linkifier.ts
@@ -339,8 +339,8 @@ export class Linkifier implements ILinkifier {
 		const emit: LinkifiedPart[] = [];
 		for (const part of parts) {
 			if (part instanceof LinkifyLocationAnchor) {
-				const value: any = part.value;
-				if (value && value.range) { // already has line info
+				const value = part.value;
+				if (typeof value === 'object' && value !== null && 'range' in value) { // already has line info
 					emit.push(part);
 					continue;
 				}
@@ -348,9 +348,6 @@ export class Linkifier implements ILinkifier {
 					emit.push(...this.flushAnchorBuffer());
 				}
 				this._delayedAnchorBuffer = { anchor: part, afterText: '', totalChars: 0 };
-				if (typeof process !== 'undefined' && process.env?.VITEST) {
-					console.log('[Linkifier.buffer] Started buffering anchor', { uri: String(value) });
-				}
 				continue;
 			}
 			if (this._delayedAnchorBuffer && typeof part === 'string') {
@@ -381,9 +378,6 @@ export class Linkifier implements ILinkifier {
 		const parsed = parseLineNumberAnnotation(afterText);
 		if (parsed) {
 			resultAnchor = new LinkifyLocationAnchor({ uri: anchor.value, range: new Range(new Position(parsed.startLine, 0), new Position(parsed.startLine, 0)) } as Location);
-			if (typeof process !== 'undefined' && process.env?.VITEST) {
-				console.log('[Linkifier.buffer] Upgraded buffered anchor', { uri: String(anchor.value), lineNumber: parsed.startLine + 1 });
-			}
 		}
 		this._delayedAnchorBuffer = undefined;
 		return afterText.length > 0 ? [resultAnchor, afterText] : [resultAnchor];

--- a/src/extension/linkify/common/linkifyService.ts
+++ b/src/extension/linkify/common/linkifyService.ts
@@ -86,6 +86,7 @@ export class LinkifyService implements ILinkifyService {
 		@IWorkspaceService workspaceService: IWorkspaceService,
 		@IEnvService private readonly envService: IEnvService,
 	) {
+		// Single file path linkifier now handles line number annotations inline
 		this.registerGlobalLinkifier({ create: () => new FilePathLinkifier(fileSystem, workspaceService) });
 	}
 

--- a/src/extension/linkify/common/linkifyService.ts
+++ b/src/extension/linkify/common/linkifyService.ts
@@ -86,7 +86,6 @@ export class LinkifyService implements ILinkifyService {
 		@IWorkspaceService workspaceService: IWorkspaceService,
 		@IEnvService private readonly envService: IEnvService,
 	) {
-		// Single file path linkifier now handles line number annotations inline
 		this.registerGlobalLinkifier({ create: () => new FilePathLinkifier(fileSystem, workspaceService) });
 	}
 

--- a/src/extension/linkify/test/node/filePathLinkifier.spec.ts
+++ b/src/extension/linkify/test/node/filePathLinkifier.spec.ts
@@ -6,6 +6,7 @@
 import { suite, test } from 'vitest';
 import { isWindows } from '../../../../util/vs/base/common/platform';
 import { URI } from '../../../../util/vs/base/common/uri';
+import { Location, Position, Range } from '../../../../vscodeTypes';
 import { LinkifyLocationAnchor } from '../../common/linkifiedText';
 import { assertPartsEqual, createTestLinkifierService, linkify, workspaceFile } from './util';
 
@@ -252,6 +253,100 @@ suite('File Path Linkifier', () => {
 				new LinkifyLocationAnchor(workspaceFile('file.ts')),
 				`**`,
 			],
+		);
+	});
+
+	test(`Should create file link with single line annotation`, async () => {
+		const linkifier = createTestLinkifierService(
+			'inspectdb.py'
+		);
+
+		const result = await linkify(linkifier,
+			'inspectdb.py (line 340) - The primary usage.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				new LinkifyLocationAnchor({ uri: workspaceFile('inspectdb.py'), range: new Range(new Position(339, 0), new Position(339, 0)) } as Location),
+				' (line 340) - The primary usage.'
+			]
+		);
+	});
+
+	test(`Should create file link with multi line annotation (range)`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'The return statement in exampleScript.ts is located at lines 77–85.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'The return statement in ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(76, 0), new Position(76, 0)) } as Location),
+				' is located at lines 77–85.'
+			]
+		);
+	});
+
+	test(`Should create file link with multi line annotation using 'found' phrase`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'The return statement for the createScenarioFromLogContext function in exampleScript.ts is found at lines 76–82.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'The return statement for the createScenarioFromLogContext function in ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(75, 0), new Position(75, 0)) } as Location),
+				' is found at lines 76–82.'
+			]
+		);
+	});
+
+	test(`Should create file link with multi line annotation using 'at' phrase`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'The return statement for the createScenarioFromLogContext function in exampleScript.ts is at lines 76–82.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'The return statement for the createScenarioFromLogContext function in ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(75, 0), new Position(75, 0)) } as Location),
+				' is at lines 76–82.'
+			]
+		);
+	});
+
+	test(`Should create file link with multi line annotation using hyphen range`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'The return statement for the createScenarioFromLogContext function in exampleScript.ts is at lines 76-83.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'The return statement for the createScenarioFromLogContext function in ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(75, 0), new Position(75, 0)) } as Location),
+				' is at lines 76-83.'
+			]
 		);
 	});
 });

--- a/src/extension/linkify/test/node/filePathLinkifier.spec.ts
+++ b/src/extension/linkify/test/node/filePathLinkifier.spec.ts
@@ -443,4 +443,138 @@ suite('File Path Linkifier', () => {
 			]
 		);
 	});
+
+	test(`Should upgrade file link with preceding range annotation 'in lines 5-7 of file'`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'Critical init in lines 5-7 of exampleScript.ts ensures state.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'Critical init in lines 5-7 of ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(4, 0), new Position(4, 0)) } as Location),
+				' ensures state.'
+			]
+		);
+	});
+
+	test(`Should upgrade file link with preceding single line annotation 'on line 45 of file'`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'Bug fix applied on line 45 of exampleScript.ts today.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'Bug fix applied on line 45 of ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(44, 0), new Position(44, 0)) } as Location),
+				' today.'
+			]
+		);
+	});
+
+	test(`Should upgrade file link with preceding shorthand 'ln 22 of file'`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'Configuration lives ln 22 of exampleScript.ts for now.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'Configuration lives ln 22 of ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(21, 0), new Position(21, 0)) } as Location),
+				' for now.'
+			]
+		);
+	});
+
+	test(`Should upgrade file link with preceding single line annotation using 'at line N in file'`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'The main function is defined at line 19 in exampleScript.ts.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'The main function is defined at line 19 in ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(18, 0), new Position(18, 0)) } as Location),
+				'.'
+			]
+		);
+	});
+
+	test(`Should upgrade file link with preceding single line annotation using 'line N in file' (no leading preposition)`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'Review line 19 in exampleScript.ts for correctness.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'Review line 19 in ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(18, 0), new Position(18, 0)) } as Location),
+				' for correctness.'
+			]
+		);
+	});
+
+	test(`Should upgrade file link with preceding single line annotation and trailing punctuation`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'The main function is defined at line 25 in exampleScript.ts.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'The main function is defined at line 25 in ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(24, 0), new Position(24, 0)) } as Location),
+				'.'
+			]
+		);
+	});
+
+	test(`Should not mis-upgrade when 'lines' appears without 'of' before file name`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'Review lines 10-12 exampleScript.ts for coverage.'
+		);
+
+		// No preceding upgrade; file anchor should be plain (no range) because pattern missing 'of'.
+		assertPartsEqual(
+			result.parts,
+			[
+				'Review lines 10-12 ',
+				new LinkifyLocationAnchor(workspaceFile('exampleScript.ts')),
+				' for coverage.'
+			]
+		);
+	});
 });

--- a/src/extension/linkify/test/node/filePathLinkifier.spec.ts
+++ b/src/extension/linkify/test/node/filePathLinkifier.spec.ts
@@ -349,4 +349,116 @@ suite('File Path Linkifier', () => {
 			]
 		);
 	});
+
+	test(`Should create file link with parenthesized multi line annotation variant (lines 10-12)`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'exampleScript.ts (lines 10-12) reference'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(9, 0), new Position(9, 0)) } as Location),
+				' (lines 10-12) reference'
+			]
+		);
+	});
+
+	test(`Should create file link with 'on line' prose variant`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'The init logic in exampleScript.ts on line 45.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'The init logic in ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(44, 0), new Position(44, 0)) } as Location),
+				' on line 45.'
+			]
+		);
+	});
+
+	test(`Should create file link with 'through' range connector`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'exampleScript.ts is at lines 5 through 9.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(4, 0), new Position(4, 0)) } as Location),
+				' is at lines 5 through 9.'
+			]
+		);
+	});
+
+	test(`Should create file link with 'to' range connector`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'This section in exampleScript.ts spans lines 3 to 7.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'This section in ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(2, 0), new Position(2, 0)) } as Location),
+				' spans lines 3 to 7.'
+			]
+		);
+	});
+
+	test(`Should create file link with 'Ln' shorthand single line`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'Check exampleScript.ts Ln 22 for setup.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'Check ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(21, 0), new Position(21, 0)) } as Location),
+				' Ln 22 for setup.'
+			]
+		);
+	});
+
+	test(`Should not create file link for non-annotation word containing 'line' substring (deadline 30)`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'This exampleScript.ts deadline 30 is informational.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'This ',
+				new LinkifyLocationAnchor(workspaceFile('exampleScript.ts')),
+				' deadline 30 is informational.'
+			]
+		);
+	});
 });

--- a/src/extension/linkify/test/node/filePathLinkifier.spec.ts
+++ b/src/extension/linkify/test/node/filePathLinkifier.spec.ts
@@ -577,4 +577,23 @@ suite('File Path Linkifier', () => {
 			]
 		);
 	});
+
+	test(`Should upgrade file link with formatted preceding single line annotation (bold line number)`, async () => {
+		const linkifier = createTestLinkifierService(
+			'exampleScript.ts'
+		);
+
+		const result = await linkify(linkifier,
+			'The main function is defined at **line 25** in exampleScript.ts.'
+		);
+
+		assertPartsEqual(
+			result.parts,
+			[
+				'The main function is defined at **line 25** in ',
+				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(24, 0), new Position(24, 0)) } as Location),
+				'.'
+			]
+		);
+	});
 });

--- a/src/extension/linkify/test/node/filePathLinkifier.spec.ts
+++ b/src/extension/linkify/test/node/filePathLinkifier.spec.ts
@@ -293,55 +293,43 @@ suite('File Path Linkifier', () => {
 		);
 	});
 
-	test(`Should create file link with multi line annotation using 'found' phrase`, async () => {
+	test(`Should create file link with multi line annotation using various phrases and dash types`, async () => {
 		const linkifier = createTestLinkifierService(
 			'exampleScript.ts'
 		);
 
-		const result = await linkify(linkifier,
+		// Test 'found at' with en-dash
+		const result1 = await linkify(linkifier,
 			'The return statement for the createScenarioFromLogContext function in exampleScript.ts is found at lines 76–82.'
 		);
-
 		assertPartsEqual(
-			result.parts,
+			result1.parts,
 			[
 				'The return statement for the createScenarioFromLogContext function in ',
 				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(75, 0), new Position(75, 0)) } as Location),
 				' is found at lines 76–82.'
 			]
 		);
-	});
 
-	test(`Should create file link with multi line annotation using 'at' phrase`, async () => {
-		const linkifier = createTestLinkifierService(
-			'exampleScript.ts'
-		);
-
-		const result = await linkify(linkifier,
+		// Test 'is at' with en-dash
+		const result2 = await linkify(linkifier,
 			'The return statement for the createScenarioFromLogContext function in exampleScript.ts is at lines 76–82.'
 		);
-
 		assertPartsEqual(
-			result.parts,
+			result2.parts,
 			[
 				'The return statement for the createScenarioFromLogContext function in ',
 				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(75, 0), new Position(75, 0)) } as Location),
 				' is at lines 76–82.'
 			]
 		);
-	});
 
-	test(`Should create file link with multi line annotation using hyphen range`, async () => {
-		const linkifier = createTestLinkifierService(
-			'exampleScript.ts'
-		);
-
-		const result = await linkify(linkifier,
+		// Test 'is at' with hyphen
+		const result3 = await linkify(linkifier,
 			'The return statement for the createScenarioFromLogContext function in exampleScript.ts is at lines 76-83.'
 		);
-
 		assertPartsEqual(
-			result.parts,
+			result3.parts,
 			[
 				'The return statement for the createScenarioFromLogContext function in ',
 				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(75, 0), new Position(75, 0)) } as Location),
@@ -387,35 +375,29 @@ suite('File Path Linkifier', () => {
 		);
 	});
 
-	test(`Should create file link with 'through' range connector`, async () => {
+	test(`Should create file link with range connectors ('through' and 'to')`, async () => {
 		const linkifier = createTestLinkifierService(
 			'exampleScript.ts'
 		);
 
-		const result = await linkify(linkifier,
+		// Test 'through' connector
+		const result1 = await linkify(linkifier,
 			'exampleScript.ts is at lines 5 through 9.'
 		);
-
 		assertPartsEqual(
-			result.parts,
+			result1.parts,
 			[
 				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(4, 0), new Position(4, 0)) } as Location),
 				' is at lines 5 through 9.'
 			]
 		);
-	});
 
-	test(`Should create file link with 'to' range connector`, async () => {
-		const linkifier = createTestLinkifierService(
-			'exampleScript.ts'
-		);
-
-		const result = await linkify(linkifier,
+		// Test 'to' connector
+		const result2 = await linkify(linkifier,
 			'This section in exampleScript.ts spans lines 3 to 7.'
 		);
-
 		assertPartsEqual(
-			result.parts,
+			result2.parts,
 			[
 				'This section in ',
 				new LinkifyLocationAnchor({ uri: workspaceFile('exampleScript.ts'), range: new Range(new Position(2, 0), new Position(2, 0)) } as Location),

--- a/src/extension/linkify/test/node/util.ts
+++ b/src/extension/linkify/test/node/util.ts
@@ -78,9 +78,10 @@ export function assertPartsEqual(actualParts: readonly LinkifiedPart[], expected
 			assert.strictEqual(actual, expected);
 		} else if (actual instanceof LinkifyLocationAnchor) {
 			assert(expected instanceof LinkifyLocationAnchor, "Expected LinkifyLocationAnchor");
-			const actualVal: any = actual.value as any;
-			const expectedVal: any = expected.value as any;
-			if (actualVal && expectedVal && 'range' in actualVal && 'range' in expectedVal && 'uri' in actualVal && 'uri' in expectedVal) {
+			const actualVal = actual.value;
+			const expectedVal = expected.value;
+			if (typeof actualVal === 'object' && actualVal !== null && 'range' in actualVal && 'uri' in actualVal &&
+				typeof expectedVal === 'object' && expectedVal !== null && 'range' in expectedVal && 'uri' in expectedVal) {
 				assert.strictEqual(actualVal.uri.toString(), expectedVal.uri.toString());
 				assert.strictEqual(actualVal.range.start.line, expectedVal.range.start.line);
 			} else {

--- a/src/extension/linkify/test/node/util.ts
+++ b/src/extension/linkify/test/node/util.ts
@@ -83,7 +83,11 @@ export function assertPartsEqual(actualParts: readonly LinkifiedPart[], expected
 			if (typeof actualVal === 'object' && actualVal !== null && 'range' in actualVal && 'uri' in actualVal &&
 				typeof expectedVal === 'object' && expectedVal !== null && 'range' in expectedVal && 'uri' in expectedVal) {
 				assert.strictEqual(actualVal.uri.toString(), expectedVal.uri.toString());
-				assert.strictEqual(actualVal.range.start.line, expectedVal.range.start.line);
+				// Compare full range, not just start line, so tests fail if columns or end positions diverge.
+				assert.strictEqual(actualVal.range.start.line, expectedVal.range.start.line, 'start line mismatch');
+				assert.strictEqual(actualVal.range.start.character, expectedVal.range.start.character, 'start character mismatch');
+				assert.strictEqual(actualVal.range.end.line, expectedVal.range.end.line, 'end line mismatch');
+				assert.strictEqual(actualVal.range.end.character, expectedVal.range.end.character, 'end character mismatch');
 			} else {
 				assert.strictEqual(actual.value.toString(), expected.value.toString());
 			}

--- a/src/extension/linkify/test/node/util.ts
+++ b/src/extension/linkify/test/node/util.ts
@@ -78,7 +78,14 @@ export function assertPartsEqual(actualParts: readonly LinkifiedPart[], expected
 			assert.strictEqual(actual, expected);
 		} else if (actual instanceof LinkifyLocationAnchor) {
 			assert(expected instanceof LinkifyLocationAnchor, "Expected LinkifyLocationAnchor");
-			assert.strictEqual(actual.value.toString(), expected.value.toString());
+			const actualVal: any = actual.value as any;
+			const expectedVal: any = expected.value as any;
+			if (actualVal && expectedVal && 'range' in actualVal && 'range' in expectedVal && 'uri' in actualVal && 'uri' in expectedVal) {
+				assert.strictEqual(actualVal.uri.toString(), expectedVal.uri.toString());
+				assert.strictEqual(actualVal.range.start.line, expectedVal.range.start.line);
+			} else {
+				assert.strictEqual(actual.value.toString(), expected.value.toString());
+			}
 		} else {
 			assert(actual instanceof LinkifySymbolAnchor);
 			assert(expected instanceof LinkifySymbolAnchor, "Expected LinkifySymbolAnchor");


### PR DESCRIPTION
When chat response mentions a file with a line hint, for example:

utils/logger.ts (line 42)
in lines 10–12 of server.py
config.json, lines 5 through 9
at line 7 in README.md

this change now upgrades that file reference so clicking it opens the file directly at the specified line (first line of a range for now). This works whether the line annotation appears after the filename or before it.

<img width="630" height="230" alt="image" src="https://github.com/user-attachments/assets/cf4ab1cd-e676-4c7e-9069-9ca4e60a9882" />

