### PR TITLE
Add important build instructions to preserve package.json during deve…

### DIFF
--- a/BUILD_INSTRUCTIONS.md
+++ b/BUILD_INSTRUCTIONS.md
@@ -1,0 +1,37 @@
+# ⚠️ Important Build Instructions
+
+## Always build with `--dev` to preserve your `package.json`
+
+```bash
+npm run build -- --dev
+```
+
+### Why `--dev` is Required
+
+The `--dev` flag is **critical** because:
+
+- **Preserves `package.json`**: Without `--dev`, the build process may overwrite or modify your `package.json` file
+- **Development mode**: Keeps the build configuration in development mode for active development
+- **Prevents data loss**: Protects your package configuration and dependencies
+
+### ⛔ Never Run
+
+```bash
+# DON'T DO THIS
+npm run build
+```
+
+This can corrupt or overwrite your `package.json` and cause dependency issues.
+
+### Quick Reference
+
+| Command | Result |
+|---------|--------|
+| `npm run build -- --dev` | ✅ Safe, preserves `package.json` |
+| `npm run build` | ❌ Dangerous, may overwrite `package.json` |
+
+### Additional Notes
+
+- Always ensure `--dev` flag is included when building locally
+- This applies to all development builds
+- For production builds, follow the dedicated production build documentation


### PR DESCRIPTION
This pull request adds important documentation to clarify the correct way to build the project during development. The new instructions emphasize the necessity of using the `--dev` flag to prevent accidental overwrites or corruption of the `package.json` file.

Documentation improvements:

* Added a new section to `BUILD_INSTRUCTIONS.md` explaining that all development builds should use `npm run build -- --dev` to preserve `package.json` and prevent data loss. The documentation also warns against running `npm run build` without the flag, provides a quick reference table, and includes additional notes for developers.