### PR TITLE
Rename Completions to Inline Suggestions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2293,19 +2293,19 @@
 			},
 			{
 				"command": "github.copilot.chat.completions.disable",
-				"title": "Disable Completions",
+				"title": "Disable Inline Suggestions",
 				"enablement": "github.copilot.extensionUnification.activated && github.copilot.activated && config.editor.inlineSuggest.enabled && github.copilot.completions.enabled",
 				"category": "GitHub Copilot"
 			},
 			{
 				"command": "github.copilot.chat.completions.enable",
-				"title": "Enable Completions",
+				"title": "Enable Inline Suggestions",
 				"enablement": "github.copilot.extensionUnification.activated && github.copilot.activated && !(config.editor.inlineSuggest.enabled && github.copilot.completions.enabled)",
 				"category": "GitHub Copilot"
 			},
 			{
 				"command": "github.copilot.chat.completions.toggle",
-				"title": "Toggle (Enable/Disable) Completions",
+				"title": "Toggle (Enable/Disable) Inline Suggestions",
 				"enablement": "github.copilot.extensionUnification.activated && github.copilot.activated",
 				"category": "GitHub Copilot"
 			}

--- a/src/extension/completions-core/vscode-node/extension/src/statusBar.ts
+++ b/src/extension/completions-core/vscode-node/extension/src/statusBar.ts
@@ -115,7 +115,7 @@ export class CopilotStatusBar extends StatusReporter implements IDisposable {
 				break;
 		}
 		this.item.accessibilityInformation = {
-			label: 'Copilot Completions',
+			label: 'Inline Suggestions',
 		};
 		if (this.state.command) {
 			this.item.command = this.state.command;

--- a/src/extension/completions-core/vscode-node/extension/src/statusBarPicker.ts
+++ b/src/extension/completions-core/vscode-node/extension/src/statusBarPicker.ts
@@ -7,7 +7,7 @@ import { isWeb } from '../../../../../util/vs/base/common/platform';
 import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
 import { ICompletionsContextService } from '../../lib/src/context';
 import { isCompletionEnabled, isInlineSuggestEnabled } from './config';
-import { CMDCollectDiagnosticsChat, CMDDisableCompletionsChat, CMDEnableCompletionsChat, CMDOpenDocumentationClient, CMDOpenLogsClient } from './constants';
+import { CMDCollectDiagnosticsChat, CMDDisableCompletionsChat, CMDEnableCompletionsChat, CMDOpenDocumentationClient, CMDOpenLogsClient, CMDOpenPanelClient } from './constants';
 import { CopilotExtensionStatus } from './extensionStatus';
 import { Icon } from './icon';
 
@@ -24,7 +24,7 @@ export class CopilotStatusBarPickMenu {
 	showStatusMenu() {
 		const quickpickList = window.createQuickPick();
 		quickpickList.placeholder = 'Select an option';
-		quickpickList.title = 'Configure Copilot Completions';
+		quickpickList.title = 'Configure Inline Suggestions';
 		quickpickList.items = this.collectQuickPickItems();
 		quickpickList.onDidAccept(() => this.handleItemSelection(quickpickList));
 		quickpickList.show();
@@ -64,10 +64,8 @@ export class CopilotStatusBarPickMenu {
 		if (!this.hasActiveStatus()) { return items; }
 
 		const editor = window.activeTextEditor;
-		//if (!isWeb && editor) { items.push(this.newPanelItem()); }
+		if (!isWeb && editor) { items.push(this.newPanelItem()); }
 		// Always show the model picker even if only one model is available
-		// Except on web where the model picker is not available pending CORS
-		// support from CAPI https://github.com/github/copilot-api/pull/12233
 		//if (!isWeb) { items.push(this.newChangeModelItem()); }
 		if (editor) { items.push(...this.newEnableLanguageItem()); }
 		if (items.length) { items.push(this.newSeparator()); }
@@ -86,9 +84,9 @@ export class CopilotStatusBarPickMenu {
 	private newEnableLanguageItem() {
 		const isEnabled = this.isCompletionEnabled();
 		if (isEnabled) {
-			return [this.newCommandItem('Disable Completions', CMDDisableCompletionsChat)];
+			return [this.newCommandItem('Disable Inline Suggestions', CMDDisableCompletionsChat)];
 		} else if (isEnabled === false) {
-			return [this.newCommandItem('Enable Completions', CMDEnableCompletionsChat)];
+			return [this.newCommandItem('Enable Inline Suggestions', CMDEnableCompletionsChat)];
 		} else {
 			return [];
 		}
@@ -138,11 +136,11 @@ export class CopilotStatusBarPickMenu {
 			'GitHub Copilot',
 		]);
 	}
-	/* 	private newPanelItem() {
-	private newPanelItem() {
-		return this.newCommandItem('Open Completions Panel...', CMDOpenPanel);
-	}
 
+	private newPanelItem() {
+		return this.newCommandItem('Open Completions Panel...', CMDOpenPanelClient);
+	}
+	/*
 	private newChangeModelItem() {
 		return this.newCommandItem('Change Completions Model...', CMDOpenModelPicker);
 	}


### PR DESCRIPTION
```Copilot Generated Description:``` Update all references from "Completions" to "Inline Suggestions" in the codebase, including command titles and accessibility labels.

closes https://github.com/microsoft/vscode/issues/275443