### PR TITLE
Don't allow search using '**'

### DIFF
--- a/src/extension/tools/node/findTextInFilesTool.tsx
+++ b/src/extension/tools/node/findTextInFilesTool.tsx
@@ -184,6 +184,10 @@ export class FindTextInFilesTool implements ICopilotTool<IFindTextInFilesToolPar
 
 	async resolveInput(input: IFindTextInFilesToolParams, _promptContext: IBuildPromptContext, mode: CopilotToolMode): Promise<IFindTextInFilesToolParams> {
 		let includePattern = input.includePattern;
+		if (includePattern === '**') {
+			includePattern = undefined;
+		}
+
 		if (includePattern && !includePattern.startsWith('**/')) {
 			includePattern = `**/${includePattern}`;
 		}


### PR DESCRIPTION
There is a model that really wants to do this. It skips all .gitignore and makes search time out.