### PR TITLE
Revert "Update convo feature to properly follow comments (#1835)"

### DIFF
--- a/src/extension/conversation/vscode-node/conversationFeature.ts
+++ b/src/extension/conversation/vscode-node/conversationFeature.ts
@@ -85,6 +85,7 @@ export class ConversationFeature implements IExtensionContribution {
 		// Register Copilot token listener
 		this.registerCopilotTokenListener();
 
+		this.activated = true;
 	}
 
 	get enabled() {
@@ -303,13 +304,11 @@ export class ConversationFeature implements IExtensionContribution {
 	}
 
 	private registerCopilotTokenListener() {
-		const tokenListener = () => {
+		this._disposables.add(this.authenticationService.onDidAuthenticationChange(() => {
 			const chatEnabled = this.authenticationService.copilotToken?.isChatEnabled();
 			this.logService.info(`copilot token chat_enabled: ${chatEnabled}, sku: ${this.authenticationService.copilotToken?.sku ?? ''}`);
 			this.enabled = chatEnabled ?? false;
-		};
-		this._disposables.add(this.authenticationService.onDidAuthenticationChange(tokenListener));
-		tokenListener();
+		}));
 	}
 
 	private registerTerminalQuickFixProviders() {


### PR DESCRIPTION
This reverts commit 99ea9d61806c28c5874ad746a7aeb8909690b82f.

This breaks the assumption that the participant will be registered when the extension activates.