### PR TITLE
cloud agent: handle the 'rejection' for authPermissionPrompted prompt

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -6,6 +6,8 @@
 import * as pathLib from 'path';
 import * as vscode from 'vscode';
 import { Uri } from 'vscode';
+import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
+import { IAuthenticationChatUpgradeService } from '../../../platform/authentication/common/authenticationUpgrade';
 import { IGitExtensionService } from '../../../platform/git/common/gitExtensionService';
 import { IGitService } from '../../../platform/git/common/gitService';
 import { PullRequestSearchItem, SessionInfo } from '../../../platform/github/common/githubAPI';
@@ -16,8 +18,6 @@ import { Disposable, toDisposable } from '../../../util/vs/base/common/lifecycle
 import { body_suffix, CONTINUE_TRUNCATION, extractTitle, formatBodyPlaceholder, getAuthorDisplayName, getRepoId, JOBS_API_VERSION, RemoteAgentResult, SessionIdForPr, toOpenPullRequestWebviewUri, truncatePrompt } from '../vscode/copilotCodingAgentUtils';
 import { ChatSessionContentBuilder } from './copilotCloudSessionContentBuilder';
 import { IPullRequestFileChangesService } from './pullRequestFileChangesService';
-import { IAuthenticationChatUpgradeService } from '../../../platform/authentication/common/authenticationUpgrade';
-import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
 
 export type ConfirmationResult = { step: string; accepted: boolean; metadata?: ConfirmationMetadata };
 
@@ -592,8 +592,13 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 
 	private async chatParticipantImpl(request: vscode.ChatRequest, context: vscode.ChatContext, stream: vscode.ChatResponseStream, token: vscode.CancellationToken) {
 		if (request.acceptedConfirmationData || request.rejectedConfirmationData) {
-			const findConfirmRequest = request.acceptedConfirmationData?.find(ref => ref?.authPermissionPrompted);
-			if (findConfirmRequest) {
+			const findAuthConfirmRequest = request.acceptedConfirmationData?.find(ref => ref?.authPermissionPrompted);
+			const findAuthRejectRequest = request.rejectedConfirmationData?.find(ref => ref?.authPermissionPrompted);
+			if (findAuthRejectRequest) {
+				stream.markdown(vscode.l10n.t('Cloud agent authentication requirements not met. Please allow access to proceed.'));
+				return {};
+			}
+			if (findAuthConfirmRequest) {
 				const result = await this._authenticationUpgradeService.handleConfirmationRequestWithContext(stream, request, context.history);
 				request = result.request;
 				context = result.context ?? context;


### PR DESCRIPTION
ref: https://github.com/microsoft/vscode/issues/276165
related to https://github.com/microsoft/vscode-copilot-chat/pull/1843, https://github.com/microsoft/vscode/issues/275641

fixes this: 

<img width="391" height="296" alt="image" src="https://github.com/user-attachments/assets/84e8906c-3c53-47e2-b1cd-4b77f612f143" />


