### PR TITLE
fix: in logs ensure `maxResponseTokens` is shown

### DIFF
--- a/src/extension/prompt/vscode-node/requestLoggerImpl.ts
+++ b/src/extension/prompt/vscode-node/requestLoggerImpl.ts
@@ -152,7 +152,7 @@ class LoggedRequestInfo implements ILoggedRequestInfo {
 				this.entry.chatEndpoint.urlOrRequestMetadata?.type : undefined,
 			model: this.entry.chatParams.model,
 			maxPromptTokens: this.entry.chatEndpoint.modelMaxPromptTokens,
-			maxResponseTokens: this.entry.chatParams.body?.max_tokens ?? this.entry.chatParams.body?.max_output_tokens,
+			maxResponseTokens: this.entry.chatParams.body?.max_tokens ?? this.entry.chatParams.body?.max_output_tokens ?? this.entry.chatParams.body?.max_completion_tokens,
 			location: this.entry.chatParams.location,
 			reasoning: this.entry.chatParams.body?.reasoning,
 			intent: this.entry.chatParams.intent,


### PR DESCRIPTION
Fixes issue where max response tokens is shown as `undefined`
<img width="659" height="125" alt="image" src="https://github.com/user-attachments/assets/81522260-b413-4c1f-a560-f579a16c9b39" />

The request body itself has `max_output_tokens` set:
<img width="451" height="73" alt="image" src="https://github.com/user-attachments/assets/afb43a11-e16f-4223-9b7d-48c6c84a4717" />

With the fix:
<img width="677" height="118" alt="image" src="https://github.com/user-attachments/assets/7f8a7ccd-9a4d-419f-a1cf-2d9737a3b049" />

