### PR TITLE
fix any types in nullWorkspaceFileIndex

### DIFF
--- a/src/platform/workspaceChunkSearch/node/nullWorkspaceFileIndex.ts
+++ b/src/platform/workspaceChunkSearch/node/nullWorkspaceFileIndex.ts
@@ -7,7 +7,7 @@ import { GlobIncludeOptions } from '../../../util/common/glob';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
 import { Event } from '../../../util/vs/base/common/event';
 import { URI } from '../../../util/vs/base/common/uri';
-import { IWorkspaceFileIndex } from './workspaceFileIndex';
+import { FileRepresentation, IWorkspaceFileIndex } from './workspaceFileIndex';
 
 export class NullWorkspaceFileIndex implements IWorkspaceFileIndex {
 	declare readonly _serviceBrand: undefined;
@@ -30,15 +30,15 @@ export class NullWorkspaceFileIndex implements IWorkspaceFileIndex {
 		return;
 	}
 
-	values(_globPatterns?: GlobIncludeOptions): Iterable<any> {
+	values(_globPatterns?: GlobIncludeOptions): Iterable<FileRepresentation> {
 		return [];
 	}
 
-	get(_resource: URI): any | undefined {
+	get(_resource: URI): FileRepresentation | undefined {
 		return undefined;
 	}
 
-	async tryLoad(_file: URI): Promise<any | undefined> {
+	async tryLoad(_file: URI): Promise<FileRepresentation | undefined> {
 		return undefined;
 	}
 


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/276879

Fixing the any types in the test mock that I added.

If y'all don't want to deal with the multiple approvals (since I'm an external contributor) I'm fine if someone else wants to roll these four lines into one of the other no-explicit-any PRs if that's easier to do.