### PR TITLE
Remove unused services and related code

### DIFF
--- a/src/extension/completions-core/vscode-node/completionsServiceBridges.ts
+++ b/src/extension/completions-core/vscode-node/completionsServiceBridges.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { commands, env, UIKind } from 'vscode';
+import { commands, env } from 'vscode';
 import { ILogService } from '../../../platform/log/common/logService';
 import { outputChannel } from '../../../platform/log/vscode/outputChannelLogTarget';
 import { DisposableStore, IDisposable } from '../../../util/vs/base/common/lifecycle';
@@ -28,7 +28,7 @@ import { CopilotTokenManagerImpl, ICompletionsCopilotTokenManager } from './lib/
 import { ICompletionsCitationManager } from './lib/src/citationManager';
 import { CompletionNotifier, ICompletionsNotifierService } from './lib/src/completionNotifier';
 import { CompletionsObservableWorkspace, ICompletionsObservableWorkspace } from './lib/src/completionsObservableWorkspace';
-import { BuildInfo, EditorSession, ICompletionsBuildInfoService, ICompletionsConfigProvider, ICompletionsEditorAndPluginInfo, ICompletionsEditorSessionService } from './lib/src/config';
+import { ICompletionsConfigProvider, ICompletionsEditorAndPluginInfo } from './lib/src/config';
 import { registerDocumentTracker } from './lib/src/documentTracker';
 import { ICompletionsUserErrorNotifierService, UserErrorNotifier } from './lib/src/error/userErrorNotifier';
 import { setupCompletionsExperimentationService } from './lib/src/experiments/defaultExpFilters';
@@ -88,7 +88,6 @@ export function createContext(serviceAccessor: ServicesAccessor, store: Disposab
 	});
 
 	serviceCollection.set(ICompletionsRuntimeModeService, RuntimeMode.fromEnvironment(false));
-	serviceCollection.set(ICompletionsBuildInfoService, new BuildInfo());
 	serviceCollection.set(ICompletionsCacheService, new CompletionsCache());
 	serviceCollection.set(ICompletionsConfigProvider, new VSCodeConfigProvider());
 	serviceCollection.set(ICompletionsLastGhostText, new LastGhostText());
@@ -103,7 +102,6 @@ export function createContext(serviceAccessor: ServicesAccessor, store: Disposab
 	serviceCollection.set(ICompletionsCopilotTokenManager, new SyncDescriptor(CopilotTokenManagerImpl, [false]));
 	serviceCollection.set(ICompletionsTextDocumentManagerService, new SyncDescriptor(ExtensionTextDocumentManager));
 	serviceCollection.set(ICompletionsFileReaderService, new SyncDescriptor(FileReader));
-	serviceCollection.set(ICompletionsEditorSessionService, new EditorSession(env.sessionId, env.machineId, env.remoteName, uiKindToString(env.uiKind)));
 	serviceCollection.set(ICompletionsBlockModeConfig, new SyncDescriptor(ConfigBlockModeConfig));
 	serviceCollection.set(ICompletionsTelemetryService, new SyncDescriptor(CompletionsTelemetryServiceBridge));
 	serviceCollection.set(ICompletionsTelemetryUserConfigService, new SyncDescriptor(TelemetryUserConfig));
@@ -258,15 +256,6 @@ function registerDiagnosticCommands(accessor: ServicesAccessor): IDisposable {
 	}));
 
 	return disposables;
-}
-
-function uiKindToString(uiKind: UIKind): 'desktop' | 'web' {
-	switch (uiKind) {
-		case UIKind.Desktop:
-			return 'desktop';
-		case UIKind.Web:
-			return 'web';
-	}
 }
 
 export function registerCommandWrapper(accessor: ServicesAccessor, command: string, fn: (...args: unknown[]) => unknown): IDisposable {

--- a/src/extension/completions-core/vscode-node/extension/src/inlineCompletion.ts
+++ b/src/extension/completions-core/vscode-node/extension/src/inlineCompletion.ts
@@ -19,7 +19,6 @@ import {
 import { Disposable } from '../../../../../util/vs/base/common/lifecycle';
 import { IInstantiationService, ServicesAccessor } from '../../../../../util/vs/platform/instantiation/common/instantiation';
 import { ICompletionsTelemetryService } from '../../bridge/src/completionsTelemetryServiceBridge';
-import { ICompletionsBuildInfoService } from '../../lib/src/config';
 import { CopilotConfigPrefix } from '../../lib/src/constants';
 import { handleException } from '../../lib/src/defaultHandlers';
 import { Logger } from '../../lib/src/logger';
@@ -29,6 +28,7 @@ import { isCompletionEnabledForDocument } from './config';
 import { CopilotCompletionFeedbackTracker, sendCompletionFeedbackCommand } from './copilotCompletionFeedbackTracker';
 import { ICompletionsExtensionStatus } from './extensionStatus';
 import { GhostTextProvider } from './ghostText/ghostText';
+import { BuildInfo } from '../../lib/src/config';
 
 const logger = new Logger('inlineCompletionItemProvider');
 
@@ -60,7 +60,6 @@ export class CopilotInlineCompletionItemProvider extends Disposable implements I
 
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@ICompletionsBuildInfoService private readonly buildInfoService: ICompletionsBuildInfoService,
 		@ICompletionsTelemetryService private readonly telemetryService: ICompletionsTelemetryService,
 		@ICompletionsExtensionStatus private readonly extensionStatusService: ICompletionsExtensionStatus,
 	) {
@@ -125,7 +124,7 @@ export class CopilotInlineCompletionItemProvider extends Disposable implements I
 		// match it, VS Code won't show it to the user unless the completion dropdown is dismissed. Historically we've
 		// chosen to favor completion quality, but this option allows opting into or out of generating a completion that
 		// VS Code will actually show.
-		if (!copilotConfig.get('respectSelectedCompletionInfo', quickSuggestionsDisabled() || this.buildInfoService.isPreRelease())) {
+		if (!copilotConfig.get('respectSelectedCompletionInfo', quickSuggestionsDisabled() || BuildInfo.isPreRelease())) {
 			context = { ...context, selectedCompletionInfo: undefined };
 		}
 		try {

--- a/src/extension/completions-core/vscode-node/lib/src/config.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/config.ts
@@ -321,88 +321,31 @@ export function dumpForTelemetry(accessor: ServicesAccessor) {
 	}
 }
 
-export const ICompletionsBuildInfoService = createServiceIdentifier<ICompletionsBuildInfoService>('completionsBuildInfoService');
-export interface ICompletionsBuildInfoService {
-	readonly _serviceBrand: undefined;
+export class BuildInfo {
 
-	isPreRelease(): boolean;
-	isProduction(): boolean;
-	getBuildType(): BuildType;
-	getVersion(): string;
-	getDisplayVersion(): string;
-	getBuild(): string;
-	getName(): string;
-}
-
-export class BuildInfo implements ICompletionsBuildInfoService {
-	declare _serviceBrand: undefined;
-
-	// TODO for now this is just initialised from `packageJson` which is the same across agent/extension.
-	// Consider reworking this.
-	private packageJson = packageJson;
-	constructor() { }
-
-	/**
-	 * @returns true if this is a build for end users.
-	 * (for the VSCode extension this is currently either the normal extension or the nightly release)
-	 */
-
-	isPreRelease(): boolean {
+	static isPreRelease(): boolean {
 		return this.getBuildType() === BuildType.NIGHTLY;
 	}
 
-	isProduction(): boolean {
+	static isProduction(): boolean {
 		return this.getBuildType() !== BuildType.DEV;
 	}
 
-	getBuildType(): BuildType {
-		const buildType = <'dev' | 'prod'>this.packageJson.buildType;
+	static getBuildType(): BuildType {
+		const buildType = <'dev' | 'prod'>packageJson.buildType;
 		if (buildType === 'prod') {
-			return this.getVersion().length === 15 ? BuildType.NIGHTLY : BuildType.PROD;
+			return BuildInfo.getVersion().length === 15 ? BuildType.NIGHTLY : BuildType.PROD;
 		}
 		return BuildType.DEV;
 	}
 
-	getVersion(): string {
-		return this.packageJson.version;
+	static getVersion(): string {
+		return packageJson.version;
 	}
 
-	getDisplayVersion(): string {
-		if (this.getBuildType() === BuildType.DEV) {
-			return `${this.getVersion()}-dev`;
-		} else {
-			return this.getVersion();
-		}
+	static getBuild(): string {
+		return packageJson.build;
 	}
-
-	getBuild(): string {
-		return this.packageJson.build;
-	}
-
-	getName(): string {
-		return this.packageJson.name;
-	}
-}
-
-export const ICompletionsEditorSessionService = createServiceIdentifier<ICompletionsEditorSessionService>('completionsEditorSessionService');
-export interface ICompletionsEditorSessionService {
-	readonly _serviceBrand: undefined;
-
-	readonly sessionId: string;
-	readonly machineId: string;
-	readonly remoteName: string;
-	readonly uiKind: 'desktop' | 'web';
-}
-
-export class EditorSession implements ICompletionsEditorSessionService {
-	declare _serviceBrand: undefined;
-
-	constructor(
-		readonly sessionId: string,
-		readonly machineId: string,
-		readonly remoteName = 'none',
-		readonly uiKind: 'desktop' | 'web' = 'desktop'
-	) { }
 }
 
 type NameAndVersion = {
@@ -443,10 +386,9 @@ export const apiVersion = '2025-05-01';
 
 export function editorVersionHeaders(accessor: ServicesAccessor): { [key: string]: string } {
 	const info = accessor.get(ICompletionsEditorAndPluginInfo);
-	const buildInfo = accessor.get(ICompletionsBuildInfoService);
 	return {
 		'Editor-Version': formatNameAndVersion(info.getEditorInfo()),
 		'Editor-Plugin-Version': formatNameAndVersion(info.getEditorPluginInfo()),
-		'Copilot-Language-Server-Version': buildInfo.getVersion(),
+		'Copilot-Language-Server-Version': BuildInfo.getVersion(),
 	};
 }

--- a/src/extension/completions-core/vscode-node/lib/src/diagnostics.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/diagnostics.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { ServicesAccessor } from '../../../../../util/vs/platform/instantiation/common/instantiation';
-import { ICompletionsBuildInfoService, ICompletionsEditorAndPluginInfo } from './config';
+import { BuildInfo, ICompletionsEditorAndPluginInfo } from './config';
 import { TelemetryData } from './telemetry';
 
 const os = {
@@ -47,7 +47,7 @@ export function collectCompletionDiagnostics(accessor: ServicesAccessor, telemet
 			{
 				name: 'Copilot Extension',
 				items: {
-					Version: accessor.get(ICompletionsBuildInfoService).getVersion(),
+					Version: BuildInfo.getVersion(),
 					Editor: getEditorDisplayVersion(accessor),
 					...telemetryItems,
 				},

--- a/src/extension/completions-core/vscode-node/lib/src/experiments/defaultExpFilters.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/experiments/defaultExpFilters.ts
@@ -10,10 +10,10 @@ import { IInstantiationService, ServicesAccessor } from '../../../../../../util/
 import { CopilotToken } from '../auth/copilotTokenManager';
 import { getUserKind } from '../auth/orgs';
 import {
+	BuildInfo,
 	BuildType,
 	ConfigKey,
-	getConfig,
-	ICompletionsBuildInfoService
+	getConfig
 } from '../config';
 import { getEngineRequestInfo } from '../openai/config';
 import { Filter, Release } from './filters';
@@ -34,7 +34,7 @@ export function setupCompletionsExperimentationService(accessor: ServicesAccesso
 }
 
 function getPluginRelease(accessor: ServicesAccessor): Release {
-	if (accessor.get(ICompletionsBuildInfoService).getBuildType() === BuildType.NIGHTLY) {
+	if (BuildInfo.getBuildType() === BuildType.NIGHTLY) {
 		return Release.Nightly;
 	}
 	return Release.Stable;
@@ -53,7 +53,7 @@ export function createCompletionsFilters(accessor: ServicesAccessor, token: Omit
 
 	filters.set(Filter.ExtensionRelease, getPluginRelease(accessor));
 	filters.set(Filter.CopilotOverrideEngine, getConfig(accessor, ConfigKey.DebugOverrideEngine) || getConfig(accessor, ConfigKey.DebugOverrideEngineLegacy));
-	filters.set(Filter.CopilotClientVersion, accessor.get(ICompletionsBuildInfoService).isProduction() ? accessor.get(ICompletionsBuildInfoService).getVersion() : '1.999.0');
+	filters.set(Filter.CopilotClientVersion, BuildInfo.isProduction() ? BuildInfo.getVersion() : '1.999.0');
 
 	if (token) {
 		const userKind = getUserKind(token);

--- a/src/extension/completions-core/vscode-node/lib/src/experiments/expConfig.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/experiments/expConfig.ts
@@ -16,7 +16,6 @@ export enum ExpTreatmentVariables {
 
 	OverrideBlockMode = 'copilotoverrideblockmode',
 	SuffixPercent = 'CopilotSuffixPercent', // the percentage of the prompt tokens to allocate to the suffix
-	disableLogProb = 'copilotdisablelogprob', // disable logprobs
 	CppHeadersEnableSwitch = 'copilotcppheadersenableswitch', // whether to enable the inclusion of C++ headers as neighbors in the prompt
 	UseSubsetMatching = 'copilotsubsetmatching', // whether to use subset matching instead of jaccard similarity experiment
 

--- a/src/extension/completions-core/vscode-node/lib/src/experiments/features.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/experiments/features.ts
@@ -125,10 +125,6 @@ export class Features implements ICompletionsFeaturesService {
 		return this.createExpConfigAndFilters(token);
 	}
 
-	disableLogProb(telemetryWithExp: TelemetryWithExp): boolean {
-		return (telemetryWithExp.filtersAndExp.exp.variables[ExpTreatmentVariables.disableLogProb] as boolean) ?? true;
-	}
-
 	/** Override for BlockMode to send in the request. */
 	overrideBlockMode(telemetryWithExp: TelemetryWithExp): BlockMode | undefined {
 		return (
@@ -358,10 +354,6 @@ export class Features implements ICompletionsFeaturesService {
 			(telemetryWithExp.filtersAndExp.exp.variables[ExpTreatmentVariables.AsyncCompletionsTimeout] as number) ??
 			200
 		);
-	}
-
-	enablePromptContextProxyField(telemetryWithExp: TelemetryWithExp): boolean {
-		return true;
 	}
 
 	enableProgressiveReveal(telemetryWithExp: TelemetryWithExp): boolean {

--- a/src/extension/completions-core/vscode-node/lib/src/experiments/featuresService.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/experiments/featuresService.ts
@@ -31,7 +31,6 @@ export interface ICompletionsFeaturesService {
 		telemetryData?: TelemetryData
 	): Promise<TelemetryWithExp>;
 	getFallbackExpAndFilters(): Promise<{ filters: FilterSettings; exp: ExpConfig }>;
-	disableLogProb(telemetryWithExp: TelemetryWithExp): boolean;
 	overrideBlockMode(telemetryWithExp: TelemetryWithExp): BlockMode | undefined;
 	customEngine(telemetryWithExp: TelemetryWithExp): string;
 	customEngineTargetEngine(telemetryWithExp: TelemetryWithExp): string | undefined;
@@ -58,7 +57,6 @@ export interface ICompletionsFeaturesService {
 	enableElectronFetcher(telemetryWithExp: TelemetryWithExp): boolean;
 	enableFetchFetcher(telemetryWithExp: TelemetryWithExp): boolean;
 	asyncCompletionsTimeout(telemetryWithExp: TelemetryWithExp): number;
-	enablePromptContextProxyField(telemetryWithExp: TelemetryWithExp): boolean;
 	enableProgressiveReveal(telemetryWithExp: TelemetryWithExp): boolean;
 	modelAlwaysTerminatesSingleline(telemetryWithExp: TelemetryWithExp): boolean;
 	longLookaheadSize(telemetryWithExp: TelemetryWithExp): number;

--- a/src/extension/completions-core/vscode-node/lib/src/networkConfiguration.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/networkConfiguration.ts
@@ -6,7 +6,7 @@ import { IAuthenticationService } from '../../../../../platform/authentication/c
 import { ICAPIClientService } from '../../../../../platform/endpoint/common/capiClient';
 import { ServicesAccessor } from '../../../../../util/vs/platform/instantiation/common/instantiation';
 import { CopilotToken } from './auth/copilotTokenManager';
-import { ConfigKey, ConfigKeyType, getConfig, ICompletionsBuildInfoService } from './config';
+import { BuildInfo, ConfigKey, ConfigKeyType, getConfig } from './config';
 import { ICompletionsRuntimeModeService } from './util/runtimeMode';
 import { joinPath } from './util/uri';
 
@@ -57,7 +57,7 @@ function getEndpointOverrideUrl(accessor: ServicesAccessor, endpoint: keyof Serv
 				[ConfigKey.DebugTestOverrideProxyUrl, ConfigKey.DebugTestOverrideProxyUrlLegacy]
 			);
 		case 'origin-tracker':
-			if (!accessor.get(ICompletionsBuildInfoService).isProduction()) {
+			if (!BuildInfo.isProduction()) {
 				return urlConfigOverride(accessor, [ConfigKey.DebugSnippyOverrideUrl]);
 			}
 	}

--- a/src/extension/completions-core/vscode-node/lib/src/networking.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/networking.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { CancellationToken } from '../../types/src';
-import { apiVersion, editorVersionHeaders, ICompletionsEditorSessionService } from './config';
+import { apiVersion, editorVersionHeaders } from './config';
 import { telemetry, TelemetryData } from './telemetry';
 
 /**
@@ -38,6 +38,7 @@ export * from './networkingTypes';
 
 // Import what we need locally for this module's implementation
 import { ConfigKey, IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
+import { IEnvService } from '../../../../../platform/env/common/envService';
 import { IFetcherService } from '../../../../../platform/networking/common/fetcherService';
 import { IExperimentationService } from '../../../../../platform/telemetry/common/nullExperimentationService';
 import { createServiceIdentifier } from '../../../../../util/common/services';
@@ -117,8 +118,8 @@ export function postRequest(
 	if (modelProviderName === undefined) {
 		headers['Openai-Organization'] = 'github-copilot';
 		headers['X-Request-Id'] = requestId;
-		headers['VScode-SessionId'] = accessor.get(ICompletionsEditorSessionService).sessionId;
-		headers['VScode-MachineId'] = accessor.get(ICompletionsEditorSessionService).machineId;
+		headers['VScode-SessionId'] = accessor.get(IEnvService).sessionId;
+		headers['VScode-MachineId'] = accessor.get(IEnvService).machineId;
 		headers['X-GitHub-Api-Version'] = apiVersion;
 	}
 

--- a/src/extension/completions-core/vscode-node/lib/src/openai/fetch.fake.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/openai/fetch.fake.ts
@@ -9,7 +9,6 @@ import { generateUuid } from '../../../../../../util/vs/base/common/uuid';
 import { IInstantiationService } from '../../../../../../util/vs/platform/instantiation/common/instantiation';
 import { getTokenizer } from '../../../prompt/src/tokenization';
 import { ICompletionsCopilotTokenManager } from '../auth/copilotTokenManager';
-import { ICompletionsFeaturesService } from '../experiments/featuresService';
 import { ICompletionsLogTargetService } from '../logger';
 import { Response } from '../networking';
 import { ICompletionsStatusReporter } from '../progress';
@@ -167,13 +166,12 @@ export class ErrorReturningFetcher extends LiveOpenAIFetcher {
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ICompletionsRuntimeModeService runtimeModeService: ICompletionsRuntimeModeService,
-		@ICompletionsFeaturesService featuresService: ICompletionsFeaturesService,
 		@ICompletionsLogTargetService logTargetService: ICompletionsLogTargetService,
 		@ICompletionsCopilotTokenManager copilotTokenManager: ICompletionsCopilotTokenManager,
 		@ICompletionsStatusReporter statusReporter: ICompletionsStatusReporter,
 		@IAuthenticationService authenticationService: IAuthenticationService,
 	) {
-		super(instantiationService, runtimeModeService, featuresService, logTargetService, copilotTokenManager, statusReporter, authenticationService);
+		super(instantiationService, runtimeModeService, logTargetService, copilotTokenManager, statusReporter, authenticationService);
 	}
 
 	setResponse(response: Response | 'not-sent') {

--- a/src/extension/completions-core/vscode-node/lib/src/openai/fetch.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/openai/fetch.ts
@@ -10,7 +10,6 @@ import { IInstantiationService, ServicesAccessor } from '../../../../../../util/
 import { CancellationToken as ICancellationToken } from '../../../types/src';
 import { CopilotToken, ICompletionsCopilotTokenManager } from '../auth/copilotTokenManager';
 import { onCopilotToken } from '../auth/copilotTokenNotifier';
-import { ICompletionsFeaturesService } from '../experiments/featuresService';
 import { asyncIterableFilter, asyncIterableMap } from '../helpers/iterableHelpers';
 import { ICompletionsLogTargetService, Logger } from '../logger';
 import { getEndpointUrl } from '../networkConfiguration';
@@ -434,7 +433,6 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ICompletionsRuntimeModeService private readonly runtimeModeService: ICompletionsRuntimeModeService,
-		@ICompletionsFeaturesService private readonly featuresService: ICompletionsFeaturesService,
 		@ICompletionsLogTargetService private readonly logTargetService: ICompletionsLogTargetService,
 		@ICompletionsCopilotTokenManager private readonly copilotTokenManager: ICompletionsCopilotTokenManager,
 		@ICompletionsStatusReporter private readonly statusReporter: ICompletionsStatusReporter,
@@ -506,7 +504,6 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 		baseTelemetryData: TelemetryWithExp,
 		cancel?: ICancellationToken
 	): Promise<Response | 'not-sent'> {
-		const disableLogProb = this.featuresService.disableLogProb(baseTelemetryData);
 
 		const request: CompletionRequest = {
 			prompt: params.prompt.prefix,
@@ -520,7 +517,7 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 			extra: params.extra,
 		};
 
-		if (params.requestLogProbs || !disableLogProb) {
+		if (params.requestLogProbs) {
 			request.logprobs = 2; // Request that logprobs of 2 tokens (i.e. including the best alternative) be returned
 		}
 

--- a/src/extension/completions-core/vscode-node/lib/src/test/context.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/test/context.ts
@@ -15,11 +15,8 @@ import { ICompletionsCopilotTokenManager } from '../auth/copilotTokenManager';
 import { ICompletionsCitationManager, NoOpCitationManager } from '../citationManager';
 import { CompletionNotifier, ICompletionsNotifierService } from '../completionNotifier';
 import {
-	BuildInfo, DefaultsOnlyConfigProvider, EditorSession,
-	ICompletionsBuildInfoService,
-	ICompletionsConfigProvider,
+	DefaultsOnlyConfigProvider, ICompletionsConfigProvider,
 	ICompletionsEditorAndPluginInfo,
-	ICompletionsEditorSessionService,
 	InMemoryConfigProvider
 } from '../config';
 import { ICompletionsUserErrorNotifierService, UserErrorNotifier } from '../error/userErrorNotifier';
@@ -82,7 +79,6 @@ export function _createBaselineContext(serviceCollection: TestingServiceCollecti
 	serviceCollection.define(ICompletionsCacheService, new CompletionsCache());
 	serviceCollection.define(ICompletionsConfigProvider, configProvider);
 	serviceCollection.define(ICompletionsRuntimeModeService, new RuntimeMode({ debug: false, verboseLogging: false, testMode: true, simulation: false }));
-	serviceCollection.define(ICompletionsBuildInfoService, new BuildInfo());
 	serviceCollection.define(ICompletionsSpeculativeRequestCache, new SpeculativeRequestCache());
 	serviceCollection.define(ICompletionsLastGhostText, new LastGhostText());
 	serviceCollection.define(ICompletionsCurrentGhostText, new CurrentGhostText());
@@ -90,7 +86,6 @@ export function _createBaselineContext(serviceCollection: TestingServiceCollecti
 	serviceCollection.define(ICompletionsCitationManager, new NoOpCitationManager());
 	serviceCollection.define(ICompletionsNotificationSender, new TestNotificationSender());
 	serviceCollection.define(ICompletionsTelemetryReporters, new TelemetryReporters());
-	serviceCollection.define(ICompletionsEditorSessionService, new EditorSession('test-session', 'test-machine'));
 	serviceCollection.define(ICompletionsCopilotTokenManager, new FakeCopilotTokenManager());
 	serviceCollection.define(ICompletionsFeaturesService, new SyncDescriptor(Features));
 	serviceCollection.define(ICompletionsTelemetryService, new SyncDescriptor(CompletionsTelemetryServiceBridge));


### PR DESCRIPTION
```Copilot Generated Description:``` Remove references to the `ICompletionsBuildInfoService` and the `disableLogProb` method, along with other unused services and their associated logic. Clean up imports and adjust related functionality accordingly.