### PR TITLE
Add client_deviceid to telemetry properties

### DIFF
--- a/src/platform/env/common/envService.ts
+++ b/src/platform/env/common/envService.ts
@@ -34,6 +34,7 @@ export interface IEnvService {
 	readonly language: string | undefined;
 	readonly sessionId: string;
 	readonly machineId: string;
+	readonly devDeviceId: string;
 	readonly vscodeVersion: string;
 	/**
 	 * Whether the current session is considered active
@@ -76,6 +77,7 @@ export abstract class AbstractEnvService implements IEnvService {
 	abstract get vscodeVersion(): string;
 	abstract get extensionId(): string;
 	abstract get machineId(): string;
+	abstract get devDeviceId(): string;
 	abstract get remoteName(): string | undefined;
 	abstract get uiKind(): 'desktop' | 'web';
 	abstract get OS(): OperatingSystem;

--- a/src/platform/env/common/nullEnvService.ts
+++ b/src/platform/env/common/nullEnvService.ts
@@ -34,6 +34,10 @@ export class NullEnvService extends AbstractEnvService {
 		return 'test-machine';
 	}
 
+	override get devDeviceId(): string {
+		return 'test-dev-device';
+	}
+
 	override get remoteName(): string | undefined {
 		return undefined;
 	}

--- a/src/platform/env/vscode/envServiceImpl.ts
+++ b/src/platform/env/vscode/envServiceImpl.ts
@@ -22,6 +22,9 @@ export class EnvServiceImpl implements IEnvService {
 	public get machineId(): string {
 		return vscode.env.machineId;
 	}
+	public get devDeviceId(): string {
+		return vscode.env.devDeviceId;
+	}
 	public get vscodeVersion(): string {
 		return vscode.version;
 	}

--- a/src/platform/telemetry/node/azureInsightsReporter.ts
+++ b/src/platform/telemetry/node/azureInsightsReporter.ts
@@ -121,6 +121,7 @@ function decorateWithCommonProperties(properties: TelemetryProperties, envServic
 	// We have editor-agnostic fields but keep the vs-specific ones for backward compatibility
 	properties['common_vscodemachineid'] = envService.machineId;
 	properties['common_vscodesessionid'] = envService.sessionId;
+	properties['client_deviceid'] = envService.devDeviceId;
 
 	properties['common_uikind'] = envService.uiKind;
 	properties['common_remotename'] = envService.remoteName ?? 'none';


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a new property `devDeviceId` in the environment service interface and its implementations. Update the telemetry reporter to include `client_deviceid` in the reported properties.

https://github.com/microsoft/vscode/issues/277473