### PR TITLE
Make sure we re-init the workspace index status on initial auth

### DIFF
--- a/src/platform/workspaceChunkSearch/node/workspaceChunkSearchService.ts
+++ b/src/platform/workspaceChunkSearch/node/workspaceChunkSearchService.ts
@@ -126,6 +126,10 @@ export class WorkspaceChunkSearchService extends Disposable implements IWorkspac
 		super();
 
 		this.tryInit(true);
+
+		this._register(this._authenticationService.onDidAuthenticationChange(() => {
+			this.tryInit(true);
+		}));
 	}
 
 	private async tryInit(silent: boolean): Promise<WorkspaceChunkSearchServiceImpl | undefined> {


### PR DESCRIPTION
Fixes microsoft/vscode#277489

Fallout of not blocking extension init on initial auth