### PR TITLE
clean up replay related participants

### DIFF
--- a/src/extension/common/constants.ts
+++ b/src/extension/common/constants.ts
@@ -31,7 +31,6 @@ export const enum Intent {
 	SearchPanel = 'searchPanel',
 	SearchKeywords = 'searchKeywords',
 	AskAgent = 'askAgent',
-	ChatReplay = 'chatReplay'
 }
 
 export const GITHUB_PLATFORM_AGENT = 'github.copilot-dynamic.platform';
@@ -63,9 +62,6 @@ export const agentsToCommands: Partial<Record<Intent, Record<string, Intent>>> =
 		'tests': Intent.Tests,
 		'edit': Intent.Edit,
 		'generate': Intent.Generate
-	},
-	[Intent.ChatReplay]: {
-		'chatReplay': Intent.ChatReplay
 	}
 };
 

--- a/src/extension/conversation/vscode-node/chatParticipants.ts
+++ b/src/extension/conversation/vscode-node/chatParticipants.ts
@@ -33,7 +33,6 @@ export class ChatAgentService implements IChatAgentService {
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) { }
-
 	public debugGetCurrentChatAgents(): ChatAgents | undefined {
 		return this._lastChatAgents;
 	}
@@ -87,7 +86,6 @@ class ChatAgents implements IDisposable {
 		this._disposables.add(this.registerVSCodeAgent());
 		this._disposables.add(this.registerTerminalAgent());
 		this._disposables.add(this.registerTerminalPanelAgent());
-		this._disposables.add(this.registerReplayAgent());
 	}
 
 	private createAgent(name: string, defaultIntentIdOrGetter: IntentOrGetter, options?: { id?: string }): vscode.ChatParticipant {
@@ -245,13 +243,6 @@ Learn more about [GitHub Copilot](https://docs.github.com/copilot/using-github-c
 
 	private registerNotebookDefaultAgent(): IDisposable {
 		const defaultAgent = this.createAgent(notebookEditorAgentName, Intent.notebookEditor);
-		defaultAgent.iconPath = new vscode.ThemeIcon('copilot');
-
-		return defaultAgent;
-	}
-
-	private registerReplayAgent(): IDisposable {
-		const defaultAgent = this.createAgent('chatReplay', Intent.ChatReplay);
 		defaultAgent.iconPath = new vscode.ThemeIcon('copilot');
 
 		return defaultAgent;

--- a/src/extension/intents/node/allIntents.ts
+++ b/src/extension/intents/node/allIntents.ts
@@ -9,7 +9,6 @@ import { InlineChatIntent } from '../../inlineChat/node/inlineChatIntent';
 import { IntentRegistry } from '../../prompt/node/intentRegistry';
 import { AgentIntent } from './agentIntent';
 import { AskAgentIntent } from './askAgentIntent';
-import { ChatReplayIntent } from './chatReplayIntent';
 import { InlineDocIntent } from './docIntent';
 import { EditCodeIntent } from './editCodeIntent';
 import { EditCode2Intent } from './editCodeIntent2';
@@ -54,6 +53,5 @@ IntentRegistry.setIntents([
 	new SyncDescriptor(SearchKeywordsIntent),
 	new SyncDescriptor(AskAgentIntent),
 	new SyncDescriptor(NotebookEditorIntent),
-	new SyncDescriptor(InlineChatIntent),
-	new SyncDescriptor(ChatReplayIntent)
+	new SyncDescriptor(InlineChatIntent)
 ]);

--- a/src/extension/replay/vscode-node/chatReplayContrib.ts
+++ b/src/extension/replay/vscode-node/chatReplayContrib.ts
@@ -6,6 +6,7 @@ import { CancellationToken, chat, commands, debug, DebugAdapterDescriptor, Debug
 import { IRequestLogger } from '../../../platform/requestLogger/node/requestLogger';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { ChatReplayParticipant } from './chatReplayParticipant';
 import { ChatReplaySessionProvider } from './chatReplaySessionProvider';
 import { ChatReplayDebugSession } from './replayDebugSession';
 
@@ -20,10 +21,8 @@ export class ChatReplayContribution extends Disposable {
 
 		this._sessionProvider = this._register(new ChatReplaySessionProvider());
 
-		const chatParticipant = chat.createChatParticipant('chat-replay', async (request, context, response, token) => {
-			// Chat replays are readonly, so the participant does nothing
-			return {};
-		});
+		const replayParticipant = this._instantiationService.createInstance(ChatReplayParticipant);
+		const chatParticipant = chat.createChatParticipant('github.copilot.chatReplay', replayParticipant.handleRequest.bind(replayParticipant));
 		this._register(chat.registerChatSessionContentProvider('chat-replay', this._sessionProvider, chatParticipant));
 
 		const provider = new ChatReplayConfigProvider();


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/277477

We were creating a dummy participant for the replay session, which we should eventually adopt fully, but we can just re-use the participant instead of creating another one. 

This also makes the participant a more standard contribution from an extension, instead of tying into the special intent system that we don't need, so we can keep this isolated a bit more.