### PR TITLE
Fix cursor prediction telemetry

### DIFF
--- a/src/extension/inlineEdits/node/nextEditProviderTelemetry.ts
+++ b/src/extension/inlineEdits/node/nextEditProviderTelemetry.ts
@@ -846,7 +846,7 @@ export class TelemetrySender implements IDisposable {
 				notebookType,
 				notebookId,
 				notebookCellLines,
-				nextCursorLineError: telemetry.nextCursorLineError,
+				nextCursorLineError: telemetry.nextCursorPrediction?.nextCursorLineError,
 			},
 			{
 				requestN,
@@ -901,7 +901,7 @@ export class TelemetrySender implements IDisposable {
 				diagnosticDistanceToUnknownDiagnostic: diagnosticDistanceToUnknownDiagnostic,
 				diagnosticDistanceToAlternativeDiagnostic: diagnosticDistanceToAlternativeDiagnostic,
 				diagnosticHasAlternativeDiagnosticForSameRange: this._boolToNum(diagnosticHasAlternativeDiagnosticForSameRange),
-				nextCursorLineDistance: telemetry.nextCursorLineDistance,
+				nextCursorLineDistance: telemetry.nextCursorPrediction?.nextCursorLineDistance,
 			}
 		);
 	}

--- a/src/platform/inlineEdits/common/statelessNextEditProvider.ts
+++ b/src/platform/inlineEdits/common/statelessNextEditProvider.ts
@@ -342,10 +342,11 @@ export interface IStatelessNextEditTelemetry {
 	readonly noNextEditReasonMessage: string | undefined;
 
 	/* next cursor line info */
-
-	readonly nextCursorLineError: string | undefined;
-	/** nextCursorLineNumber - currentCursorLineNumber */
-	readonly nextCursorLineDistance: number | undefined;
+	readonly nextCursorPrediction: {
+		nextCursorLineError: string | undefined;
+		/** nextCursorLineNumber - currentCursorLineNumber */
+		nextCursorLineDistance: number | undefined;
+	};
 }
 
 export type FetchResultWithStats = {
@@ -414,8 +415,7 @@ export class StatelessNextEditTelemetryBuilder {
 			response: this._response,
 			nEditsSuggested: this._nEditsSuggested,
 			nextEditLogprob: this._nextEditLogProb,
-			nextCursorLineError: this._nextCursorLineError,
-			nextCursorLineDistance: this._nextCursorLineDistance,
+			nextCursorPrediction: this._nextCursorPrediction,
 			lineDistanceToMostRecentEdit: this._lineDistanceToMostRecentEdit,
 		};
 	}
@@ -520,18 +520,21 @@ export class StatelessNextEditTelemetryBuilder {
 		return this;
 	}
 
-	private _nextCursorLineError: string | undefined;
+	private _nextCursorPrediction: IStatelessNextEditTelemetry['nextCursorPrediction'] = {
+		nextCursorLineError: undefined,
+		nextCursorLineDistance: undefined
+	};
+
 	public setNextCursorLineError(error: string): this {
-		this._nextCursorLineError = error;
+		this._nextCursorPrediction.nextCursorLineError = error;
 		return this;
 	}
 
-	private _nextCursorLineDistance: number | undefined;
 	/**
 	 * nextCursorLineNumber - currentCursorLineNumber
 	 */
 	public setNextCursorLineDistance(distance: number): this {
-		this._nextCursorLineDistance = distance;
+		this._nextCursorPrediction.nextCursorLineDistance = distance;
 		return this;
 	}
 }


### PR DESCRIPTION
The `telemetryBuilder.build()` is called before `nextCursorLineDistance` is able to be set as the streaming code is async and not awaited. This leads to `nextCursorLineDistance` being undefined all the time. 

The fix is to set an object which can be updated after the `build()` call has been made. Not necessary ideal and I wonder if other properties also have this issue. This fix is the easiest possible fix I could come up with, without having to change a lot. You might want to look at this when you are back @ulugbekna