### PR TITLE
Remove unused try-catch block

### DIFF
--- a/src/extension/completions-core/vscode-node/completionsServiceBridges.ts
+++ b/src/extension/completions-core/vscode-node/completionsServiceBridges.ts
@@ -118,13 +118,7 @@ export function createContext(serviceAccessor: ServicesAccessor, store: Disposab
 	serviceCollection.set(ICompletionsPromiseQueueService, new PromiseQueue());
 	serviceCollection.set(ICompletionsCitationManager, new SyncDescriptor(LoggingCitationManager));
 	serviceCollection.set(ICompletionsContextProviderService, new ContextProviderStatistics());
-
-	try {
-		serviceCollection.set(ICompletionsPromptFactoryService, new SyncDescriptor(CompletionsPromptFactory));
-	} catch (e) {
-		console.log(e);
-	}
-
+	serviceCollection.set(ICompletionsPromptFactoryService, new SyncDescriptor(CompletionsPromptFactory));
 	serviceCollection.set(ICompletionsFetcherService, new SyncDescriptor(CompletionsFetcher));
 	serviceCollection.set(ICompletionsDefaultContextProviders, new DefaultContextProvidersContainer());
 


### PR DESCRIPTION
```Copilot Generated Description:``` Remove an unused try-catch block from the context creation function.