### PR TITLE
Adjust prompt for next line prediction

### DIFF
--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -1139,7 +1139,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 
 		const tracer = this.tracer.sub('predictNextCursorPosition');
 
-		const systemMessage = 'Your task is to predict the next line number in the current file where the developer is most likely to make their next edit, using the provided context.';
+		const systemMessage = `Your task is to predict the next line number in the current file where the developer is most likely to make their next edit, using the provided context. If you don't think anywhere is a good next line jump target, just output the current line number of the cursor. Make sure to just output the line number and nothing else (no explanation, reasoning, etc,).`;
 
 		const maxTokens = this.configService.getExperimentBasedConfig(ConfigKey.Advanced.InlineEditsNextCursorPredictionCurrentFileMaxTokens, this.expService);
 


### PR DESCRIPTION
```Copilot Generated Description:``` Update the system message to specify that if no suitable line is found, the current line number should be outputted, and to ensure only the line number is returned without additional explanation.

FYI @ulugbekna 