### PR TITLE
Fix up for the GitDiffService

### DIFF
--- a/src/extension/prompt/vscode-node/gitDiffService.ts
+++ b/src/extension/prompt/vscode-node/gitDiffService.ts
@@ -124,7 +124,7 @@ export class GitDiffService implements IGitDiffService {
 			patch.push('new file mode 100644');
 			patch.push('--- /dev/null', `+++ b/${relativePath}`);
 
-			// For non-empty files, add range header and content (empty file omit this)
+			// For non-empty files, add range header and content (empty files omit this)
 			if (content.length > 0) {
 				const lines = content.split('\n');
 				if (content.endsWith('\n')) {

--- a/src/extension/prompt/vscode-node/test/gitDiffService.spec.ts
+++ b/src/extension/prompt/vscode-node/test/gitDiffService.spec.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MockInstance, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { IGitExtensionService } from '../../../../platform/git/common/gitExtensionService';
 import { API, Change, Repository } from '../../../../platform/git/vscode/git';
@@ -14,7 +14,7 @@ import { createExtensionUnitTestingServices } from '../../../test/node/services'
 import { GitDiffService } from '../gitDiffService';
 
 describe('GitDiffService', () => {
-	let readFileSpy: any;
+	let readFileSpy: MockInstance<typeof vscode.workspace.fs.readFile>;
 	let accessor: ITestingServicesAccessor;
 	let gitDiffService: GitDiffService;
 	let mockRepository: Partial<Repository>;
@@ -22,7 +22,8 @@ describe('GitDiffService', () => {
 	beforeEach(() => {
 		// Create mock workspace.fs.readFile if it doesn't exist
 		if (!vscode.workspace?.fs?.readFile) {
-			(vscode as any).workspace = {
+			const workspaceWithFs = vscode as unknown as { workspace: typeof vscode.workspace };
+			workspaceWithFs.workspace = {
 				...vscode.workspace,
 				fs: {
 					...vscode.workspace?.fs,


### PR DESCRIPTION
The repoInfoTelemetry service was being used by the science team for some model development. This telemetry uses the gitDiffService to provide diffs and there were some git diff patches that were not able to be applied coming specifically from new untracked files.

These new untracked files are actually handled a bit differently as the main git services doesn't pick up these changes. Instead a synthetic patch is created via _getUntrackedChangePatch. This function had some issue with generating an actual synthetic patch that could be applied without fixup.

Fixes:

- [x] For a totally empty file, correctly omit range / lines
- [x] For the range header correctly use lines and not byte length
- [x] Add 'new file mode' header
- [x] Correctly add 'no newline' footer when needed
- [x] Add unit tests for this function

Note: This fix is specifically for the usage of this code path for repoInfoTelemetry, but this existing function was used already by gitCommitMessageService and scmChanges tool. In both those changes the git diffs look to be just handled as a string and passed to an LLM, so improving the accuracy here should not cause any issues. But that is why I avoided added in extra (possibly risky) work for checking file permissions or calculating the SHA1 hash (which are not required to apply the patch) into this work.

Manually tested with pulling the telemetry locally and creating and applying a diff patch for:
1. New untracked file with content and no end new line
2. New untracked file with content and an ending new line
3. New fully empty untracked file
4. New file with just a new line

Patch applied and created the file as it existed before in all four cases.