### PR TITLE
Fix @vscode/chat-lib install script and package

### DIFF
--- a/chat-lib/package-lock.json
+++ b/chat-lib/package-lock.json
@@ -16,6 +16,7 @@
 				"@vscode/l10n": "^0.0.18",
 				"@vscode/prompt-tsx": "^0.4.0-alpha.5",
 				"@vscode/tree-sitter-wasm": "0.0.5-php.2",
+				"applicationinsights": "^2.9.7",
 				"jsonc-parser": "^3.3.1",
 				"monaco-editor": "0.44.0",
 				"openai": "^6.7.0",
@@ -29,7 +30,6 @@
 				"@octokit/types": "^14.1.0",
 				"@types/node": "^22.16.3",
 				"@types/vscode": "^1.102.0",
-				"applicationinsights": "^2.9.7",
 				"copyfiles": "^2.4.1",
 				"dotenv": "^17.2.0",
 				"npm-run-all": "^4.1.5",
@@ -68,7 +68,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
 			"integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -81,7 +80,6 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.9.0.tgz",
 			"integrity": "sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@azure/abort-controller": "^2.0.0",
@@ -96,7 +94,6 @@
 			"version": "1.16.3",
 			"resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.3.tgz",
 			"integrity": "sha512-VxLk4AHLyqcHsfKe4MZ6IQ+D+ShuByy+RfStKfSjxJoL3WBWq17VNmrz8aT8etKzqc2nAeIyLxScjpzsS4fz8w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@azure/abort-controller": "^2.0.0",
@@ -116,7 +113,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.2.0.tgz",
 			"integrity": "sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -129,7 +125,6 @@
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.11.0.tgz",
 			"integrity": "sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@azure/abort-controller": "^2.0.0",
@@ -143,7 +138,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.4.tgz",
 			"integrity": "sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -156,7 +150,6 @@
 			"version": "1.0.0-beta.5",
 			"resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.5.tgz",
 			"integrity": "sha512-fsUarKQDvjhmBO4nIfaZkfNSApm1hZBzcvpNbSrXdcUBxu7lRvKsV5DnwszX7cnhLyVOW9yl1uigtRQ1yDANjA==",
-			"dev": true,
 			"dependencies": {
 				"@azure/core-tracing": "^1.0.0",
 				"@azure/logger": "^1.0.0",
@@ -173,7 +166,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
 			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -717,8 +709,7 @@
 		"node_modules/@microsoft/applicationinsights-web-snippet": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
-			"integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ==",
-			"dev": true
+			"integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ=="
 		},
 		"node_modules/@microsoft/tiktokenizer": {
 			"version": "1.0.10",
@@ -750,7 +741,6 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8.0.0"
@@ -760,7 +750,6 @@
 			"version": "1.30.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
 			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "1.28.0"
@@ -776,7 +765,6 @@
 			"version": "1.28.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
 			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -786,7 +774,6 @@
 			"version": "0.41.2",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.41.2.tgz",
 			"integrity": "sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==",
-			"dev": true,
 			"dependencies": {
 				"@types/shimmer": "^1.0.2",
 				"import-in-the-middle": "1.4.2",
@@ -805,7 +792,6 @@
 			"version": "1.30.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
 			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
@@ -822,7 +808,6 @@
 			"version": "1.28.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
 			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -832,7 +817,6 @@
 			"version": "1.30.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
 			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
@@ -850,7 +834,6 @@
 			"version": "1.28.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
 			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -860,7 +843,6 @@
 			"version": "1.30.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
 			"integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -1189,8 +1171,7 @@
 		"node_modules/@types/shimmer": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.3.tgz",
-			"integrity": "sha512-F/IjUGnV6pIN7R4ZV4npHJVoNtaLZWvb+2/9gctxjb99wkpI7Ozg8VPogwDiTRyjLwZXAYxjvdg1KS8LTHKdDA==",
-			"dev": true
+			"integrity": "sha512-F/IjUGnV6pIN7R4ZV4npHJVoNtaLZWvb+2/9gctxjb99wkpI7Ozg8VPogwDiTRyjLwZXAYxjvdg1KS8LTHKdDA=="
 		},
 		"node_modules/@types/vscode": {
 			"version": "1.102.0",
@@ -1327,7 +1308,6 @@
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1341,7 +1321,6 @@
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
 			"integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
 			"deprecated": "package has been renamed to acorn-import-attributes",
-			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8"
@@ -1351,7 +1330,6 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
 			"integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
@@ -1385,7 +1363,6 @@
 			"version": "2.9.7",
 			"resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.9.7.tgz",
 			"integrity": "sha512-dxIVB2AAEMec3FDiYThgEbc9R4u1TatrzL+kFgOf+ABaEgHm8+i8ngVLHfKObjHvy2HHPf810OLWTrqyeWT/oA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@azure/core-auth": "1.7.2",
@@ -1417,7 +1394,6 @@
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.7.2.tgz",
 			"integrity": "sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@azure/abort-controller": "^2.0.0",
@@ -1491,7 +1467,6 @@
 			"version": "1.7.6",
 			"resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
 			"integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-			"dev": true,
 			"dependencies": {
 				"stack-chain": "^1.3.7"
 			},
@@ -1503,7 +1478,6 @@
 			"version": "0.6.10",
 			"resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
 			"integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-			"dev": true,
 			"dependencies": {
 				"semver": "^5.3.0",
 				"shimmer": "^1.1.0"
@@ -1516,7 +1490,6 @@
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
 			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
@@ -1645,14 +1618,12 @@
 		"node_modules/cjs-module-lexer": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
-			"dev": true
+			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
 		},
 		"node_modules/cls-hooked": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
 			"integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-			"dev": true,
 			"dependencies": {
 				"async-hook-jl": "^1.7.6",
 				"emitter-listener": "^1.0.1",
@@ -1666,7 +1637,6 @@
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
 			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
@@ -1700,7 +1670,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
 			"integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-			"dev": true,
 			"dependencies": {
 				"async-listener": "^0.6.0",
 				"emitter-listener": "^1.1.1"
@@ -1930,7 +1899,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
 			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -1993,7 +1961,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
 			"integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.5.3"
@@ -2003,7 +1970,6 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.8.tgz",
 			"integrity": "sha512-HmSm9hXxSPxA9BaLGY98QU1zsdjeCk113KjAYGPCen1ZP6mhVaTPzHd6UYv5r21DnWANi+f+NyPOHruGT9jpqQ==",
-			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"diagnostic-channel": "*"
@@ -2013,7 +1979,6 @@
 			"version": "7.7.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
 			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -2060,7 +2025,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
 			"integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-			"dev": true,
 			"dependencies": {
 				"shimmer": "^1.2.0"
 			}
@@ -2367,7 +2331,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -2627,7 +2590,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
 			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -2640,7 +2602,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
 			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"dev": true,
 			"dependencies": {
 				"agent-base": "^7.1.0",
 				"debug": "^4.3.4"
@@ -2653,7 +2614,6 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
 			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"agent-base": "^7.1.2",
@@ -2667,7 +2627,6 @@
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
 			"integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
-			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.2",
 				"acorn-import-assertions": "^1.9.0",
@@ -2800,7 +2759,6 @@
 			"version": "2.16.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
 			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hasown": "^2.0.2"
@@ -3229,8 +3187,7 @@
 		"node_modules/module-details-from-path": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-			"integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==",
-			"dev": true
+			"integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
 		},
 		"node_modules/monaco-editor": {
 			"version": "0.44.0",
@@ -3242,7 +3199,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
@@ -3649,8 +3605,7 @@
 		"node_modules/path-parse": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
 		},
 		"node_modules/path-scurry": {
 			"version": "2.0.0",
@@ -3878,7 +3833,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
 			"integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
-			"dev": true,
 			"dependencies": {
 				"debug": "^4.1.1",
 				"module-details-from-path": "^1.0.3",
@@ -3892,7 +3846,6 @@
 			"version": "1.22.6",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
 			"integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
-			"dev": true,
 			"dependencies": {
 				"is-core-module": "^2.13.0",
 				"path-parse": "^1.0.7",
@@ -4053,7 +4006,6 @@
 			"version": "7.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
 			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -4144,8 +4096,7 @@
 		"node_modules/shimmer": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-			"dev": true
+			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
 		},
 		"node_modules/side-channel": {
 			"version": "1.1.0",
@@ -4286,8 +4237,7 @@
 		"node_modules/stack-chain": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-			"integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==",
-			"dev": true
+			"integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
 		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
@@ -4533,7 +4483,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -4624,7 +4573,6 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"dev": true,
 			"license": "0BSD"
 		},
 		"node_modules/tsx": {

--- a/chat-lib/package.json
+++ b/chat-lib/package.json
@@ -20,6 +20,7 @@
 		"@vscode/l10n": "^0.0.18",
 		"@vscode/prompt-tsx": "^0.4.0-alpha.5",
 		"@vscode/tree-sitter-wasm": "0.0.5-php.2",
+		"applicationinsights": "^2.9.7",
 		"jsonc-parser": "^3.3.1",
 		"monaco-editor": "0.44.0",
 		"openai": "^6.7.0",
@@ -33,7 +34,6 @@
 		"@octokit/types": "^14.1.0",
 		"@types/node": "^22.16.3",
 		"@types/vscode": "^1.102.0",
-		"applicationinsights": "^2.9.7",
 		"copyfiles": "^2.4.1",
 		"dotenv": "^17.2.0",
 		"npm-run-all": "^4.1.5",
@@ -55,7 +55,8 @@
 		"README.md",
 		"LICENSE.txt",
 		"!**/test/**",
-		"dist/src/_internal/util/common/test/shims"
+		"dist/src/_internal/util/common/test/shims",
+		"script"
 	],
 	"scripts": {
 		"clean": "rimraf dist",

--- a/chat-lib/script/postinstall.ts
+++ b/chat-lib/script/postinstall.ts
@@ -52,15 +52,21 @@ async function platformDir(): Promise<string> {
 	}
 }
 
+function treeSitterWasmDir(): string {
+	const modulePath = path.dirname(require.resolve('@vscode/tree-sitter-wasm'));
+	return path.relative(REPO_ROOT, modulePath);
+}
+
 async function main() {
 	const platform = await platformDir();
 	const vendoredTiktokenFiles = [`${platform}/tokenizer/node/cl100k_base.tiktoken`, `${platform}/tokenizer/node/o200k_base.tiktoken`];
+	const wasm = treeSitterWasmDir();
 
 	// copy static assets to dist
 	await copyStaticAssets([
 		...vendoredTiktokenFiles,
-		...treeSitterGrammars.map(grammar => `node_modules/@vscode/tree-sitter-wasm/wasm/${grammar}.wasm`),
-		'node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter.wasm',
+		...treeSitterGrammars.map(grammar => `${wasm}/${grammar}.wasm`),
+		`${wasm}/tree-sitter.wasm`,
 	], 'dist');
 
 }


### PR DESCRIPTION
This fixes a few problems with the @vscode/chat-lib package after the addition of inline completions:

 - script/postinstall.ts was omitted from the package
 - The install script didn't handle the different ways npm might install the `@vscode/tree-sitter-wasm` package
 - applicationinsights must be listed as a standard dependency, not a dev dependency
