### PR TITLE
Don't send top_p with responses API

### DIFF
--- a/src/platform/endpoint/node/responsesApi.ts
+++ b/src/platform/endpoint/node/responsesApi.ts
@@ -43,7 +43,6 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 		})),
 		// Only a subset of completion post options are supported, and some
 		// are renamed. Handle them manually:
-		top_p: options.postOptions.top_p,
 		max_output_tokens: options.postOptions.max_tokens,
 		tool_choice: typeof options.postOptions.tool_choice === 'object'
 			? { type: 'function', name: options.postOptions.tool_choice.function.name }


### PR DESCRIPTION
New model doesn't support it and we aren't using it anyway