### PR TITLE
Retain opaque reasoning in past conversation messages

### DIFF
--- a/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/src/extension/prompts/node/panel/toolCalling.tsx
@@ -56,7 +56,8 @@ export class ChatToolCalls extends PromptElement<ChatToolCallsProps, void> {
 		props: PromptElementProps<ChatToolCallsProps>,
 		@IToolsService private readonly toolsService: IToolsService,
 		@IPromptEndpoint private readonly promptEndpoint: IPromptEndpoint,
-		@IInstantiationService private readonly instantiationService: IInstantiationService
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super(props);
 	}
@@ -104,7 +105,8 @@ export class ChatToolCalls extends PromptElement<ChatToolCallsProps, void> {
 
 		// Don't include this when rendering and triggering summarization
 		const statefulMarker = round.statefulMarker && <StatefulMarkerContainer statefulMarker={{ modelId: this.promptEndpoint.model, marker: round.statefulMarker }} />;
-		const thinking = (!this.props.isHistorical) && round.thinking && <ThinkingDataContainer thinking={round.thinking} />;
+		const pastReasoningTextDisabled = !!this.configurationService.getNonExtensionConfig('chat.pastReasoningTextDisabled');
+		const thinking = (!this.props.isHistorical || !pastReasoningTextDisabled) && round.thinking && <ThinkingDataContainer thinking={round.thinking} />;
 		children.push(
 			<AssistantMessage toolCalls={assistantToolCalls}>
 				{statefulMarker}


### PR DESCRIPTION
An openai doc led me to do it this way originally, but it seems like this might be wrong, esp for Gemini. We will see what the impact is of doing it this way.