### PR TITLE
Revert "Retain opaque reasoning in past conversation messages (#2178)"

### DIFF
--- a/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/src/extension/prompts/node/panel/toolCalling.tsx
@@ -56,8 +56,7 @@ export class ChatToolCalls extends PromptElement<ChatToolCallsProps, void> {
 		props: PromptElementProps<ChatToolCallsProps>,
 		@IToolsService private readonly toolsService: IToolsService,
 		@IPromptEndpoint private readonly promptEndpoint: IPromptEndpoint,
-		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IConfigurationService private readonly configurationService: IConfigurationService
+		@IInstantiationService private readonly instantiationService: IInstantiationService
 	) {
 		super(props);
 	}
@@ -105,8 +104,7 @@ export class ChatToolCalls extends PromptElement<ChatToolCallsProps, void> {
 
 		// Don't include this when rendering and triggering summarization
 		const statefulMarker = round.statefulMarker && <StatefulMarkerContainer statefulMarker={{ modelId: this.promptEndpoint.model, marker: round.statefulMarker }} />;
-		const pastReasoningTextDisabled = !!this.configurationService.getNonExtensionConfig('chat.pastReasoningTextDisabled');
-		const thinking = (!this.props.isHistorical || !pastReasoningTextDisabled) && round.thinking && <ThinkingDataContainer thinking={round.thinking} />;
+		const thinking = (!this.props.isHistorical) && round.thinking && <ThinkingDataContainer thinking={round.thinking} />;
 		children.push(
 			<AssistantMessage toolCalls={assistantToolCalls}>
 				{statefulMarker}


### PR DESCRIPTION
Model switching, I thought we had model-specific reasoning
This reverts commit 1ef257d9b58c78d82307a0aed5a3afc672c8fa12.