### PR TITLE
Context Providers Support for NES vs Completions

### DIFF
--- a/src/extension/api/vscode/vscodeContextProviderApi.ts
+++ b/src/extension/api/vscode/vscodeContextProviderApi.ts
@@ -5,7 +5,7 @@
 
 import { Disposable } from 'vscode';
 import { Copilot } from '../../../platform/inlineCompletions/common/api';
-import { ILanguageContextProviderService } from '../../../platform/languageContextProvider/common/languageContextProviderService';
+import { ILanguageContextProviderService, ProviderTarget } from '../../../platform/languageContextProvider/common/languageContextProviderService';
 
 
 export class VSCodeContextProviderApiV1 implements Copilot.ContextProviderApiV1 {
@@ -16,6 +16,6 @@ export class VSCodeContextProviderApiV1 implements Copilot.ContextProviderApiV1 
 	}
 
 	registerContextProvider<T extends Copilot.SupportedContextItem>(provider: Copilot.ContextProvider<T>): Disposable {
-		return this.contextProviderService.registerContextProvider(provider);
+		return this.contextProviderService.registerContextProvider(provider, [ProviderTarget.Completions]);
 	}
 }

--- a/src/extension/completions-core/vscode-node/lib/src/prompt/contextProviderRegistry.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/prompt/contextProviderRegistry.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken, CancellationTokenSource, DocumentSelector } from 'vscode-languageserver-protocol';
-import { ILanguageContextProviderService } from '../../../../../../platform/languageContextProvider/common/languageContextProviderService';
+import { ILanguageContextProviderService, ProviderTarget } from '../../../../../../platform/languageContextProvider/common/languageContextProviderService';
 import { createServiceIdentifier } from '../../../../../../util/common/services';
 import { isCancellationError } from '../../../../../../util/vs/base/common/errors';
 import { IInstantiationService, ServicesAccessor } from '../../../../../../util/vs/platform/instantiation/common/instantiation';
@@ -124,7 +124,7 @@ export class CoreContextProviderRegistry implements ICompletionsContextProviderR
 	}
 
 	get providers(): ContextProvider<SupportedContextItem>[] {
-		return this.registryService.getAllProviders().slice() as ContextProvider<SupportedContextItem>[];
+		return this.registryService.getAllProviders([ProviderTarget.Completions]).slice() as ContextProvider<SupportedContextItem>[];
 	}
 
 	/**

--- a/src/extension/promptFileContext/vscode-node/promptFileContextService.ts
+++ b/src/extension/promptFileContext/vscode-node/promptFileContextService.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { Copilot } from '../../../platform/inlineCompletions/common/api';
-import { ILanguageContextProviderService } from '../../../platform/languageContextProvider/common/languageContextProviderService';
+import { ILanguageContextProviderService, ProviderTarget } from '../../../platform/languageContextProvider/common/languageContextProviderService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { PromptFileLangageId, PromptHeaderAttributes } from '../../../platform/promptFiles/common/promptsService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
@@ -89,7 +89,7 @@ export class PromptFileContextContribution extends Disposable {
 			if (copilotAPI) {
 				disposables.add(copilotAPI.registerContextProvider(provider));
 			}
-			disposables.add(this.languageContextProviderService.registerContextProvider(provider));
+			disposables.add(this.languageContextProviderService.registerContextProvider(provider, [ProviderTarget.NES, ProviderTarget.Completions]));
 		} catch (error) {
 			this.logService.error('Error regsistering prompt file context provider:', error);
 		}

--- a/src/extension/typescriptContext/vscode-node/languageContextService.ts
+++ b/src/extension/typescriptContext/vscode-node/languageContextService.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { LRUCache } from 'lru-cache';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { Copilot } from '../../../platform/inlineCompletions/common/api';
-import { ILanguageContextProviderService } from '../../../platform/languageContextProvider/common/languageContextProviderService';
+import { ILanguageContextProviderService, ProviderTarget } from '../../../platform/languageContextProvider/common/languageContextProviderService';
 import { ContextKind, ILanguageContextService, KnownSources, TriggerKind, type ContextItem, type RequestContext } from '../../../platform/languageServer/common/languageContextService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
@@ -1942,7 +1942,7 @@ export class InlineCompletionContribution implements vscode.Disposable, TokenBud
 			}
 
 			// Register with chat always.
-			this.registrations.add(this.languageContextProviderService.registerContextProvider(provider));
+			this.registrations.add(this.languageContextProviderService.registerContextProvider(provider, [ProviderTarget.Completions]));
 			this.telemetrySender.sendInlineCompletionProviderTelemetry(KnownSources.completion, true);
 			logService.info('Registered TypeScript context provider with Copilot inline completions.');
 		} catch (error) {

--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -24,7 +24,7 @@ import { InlineEditRequestLogContext } from '../../../platform/inlineEdits/commo
 import { ResponseProcessor } from '../../../platform/inlineEdits/common/responseProcessor';
 import { IStatelessNextEditProvider, NoNextEditReason, PushEdit, ShowNextEditPreference, StatelessNextEditDocument, StatelessNextEditRequest, StatelessNextEditResult, StatelessNextEditTelemetryBuilder } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { editWouldDeleteWhatWasJustInserted, editWouldDeleteWhatWasJustInserted2, IgnoreEmptyLineAndLeadingTrailingWhitespaceChanges, IgnoreWhitespaceOnlyChanges } from '../../../platform/inlineEdits/common/statelessNextEditProviders';
-import { ILanguageContextProviderService } from '../../../platform/languageContextProvider/common/languageContextProviderService';
+import { ILanguageContextProviderService, ProviderTarget } from '../../../platform/languageContextProvider/common/languageContextProviderService';
 import { ILanguageDiagnosticsService } from '../../../platform/languages/common/languageDiagnosticsService';
 import { ContextKind, SnippetContext } from '../../../platform/languageServer/common/languageContextService';
 import { ILogService } from '../../../platform/log/common/logService';
@@ -486,7 +486,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 				return undefined;
 			}
 
-			const providers = this.langCtxService.getContextProviders(textDoc);
+			const providers = this.langCtxService.getContextProviders(textDoc, ProviderTarget.NES);
 			if (providers.length < 1) {
 				return undefined;
 			}

--- a/src/platform/languageContextProvider/common/languageContextProviderService.ts
+++ b/src/platform/languageContextProvider/common/languageContextProviderService.ts
@@ -8,16 +8,21 @@ import { Copilot } from '../../../platform/inlineCompletions/common/api';
 import { createServiceIdentifier } from '../../../util/common/services';
 import { ContextItem } from '../../languageServer/common/languageContextService';
 
+export enum ProviderTarget {
+	NES = 'nes',
+	Completions = 'completions',
+}
+
 export const ILanguageContextProviderService = createServiceIdentifier<ILanguageContextProviderService>('ILanguageContextProviderService');
 
 export interface ILanguageContextProviderService {
 	readonly _serviceBrand: undefined;
 
-	registerContextProvider<T extends Copilot.SupportedContextItem>(provider: Copilot.ContextProvider<T>): Disposable;
+	registerContextProvider<T extends Copilot.SupportedContextItem>(provider: Copilot.ContextProvider<T>, targets: ProviderTarget[]): Disposable;
 
-	getAllProviders(): readonly Copilot.ContextProvider<Copilot.SupportedContextItem>[];
+	getAllProviders(target: ProviderTarget[]): readonly Copilot.ContextProvider<Copilot.SupportedContextItem>[];
 
-	getContextProviders(doc: TextDocument): Copilot.ContextProvider<Copilot.SupportedContextItem>[];
+	getContextProviders(doc: TextDocument, target: ProviderTarget): Copilot.ContextProvider<Copilot.SupportedContextItem>[];
 
 	getContextItems(doc: TextDocument, request: Copilot.ResolveRequest, cancellationToken: CancellationToken): AsyncIterable<ContextItem>;
 

--- a/src/platform/languageContextProvider/common/nullLanguageContextProviderService.ts
+++ b/src/platform/languageContextProvider/common/nullLanguageContextProviderService.ts
@@ -7,12 +7,12 @@ import type { CancellationToken, TextDocument, Disposable as VscodeDisposable } 
 import { Copilot } from '../../../platform/inlineCompletions/common/api';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { ContextItem } from '../../languageServer/common/languageContextService';
-import { ILanguageContextProviderService } from './languageContextProviderService';
+import { ILanguageContextProviderService, ProviderTarget } from './languageContextProviderService';
 
 export class NullLanguageContextProviderService implements ILanguageContextProviderService {
 	_serviceBrand: undefined;
 
-	registerContextProvider<T extends Copilot.SupportedContextItem>(provider: Copilot.ContextProvider<T>): VscodeDisposable {
+	registerContextProvider<T extends Copilot.SupportedContextItem>(provider: Copilot.ContextProvider<T>, targets: ProviderTarget[]): VscodeDisposable {
 		return Disposable.None;
 	}
 


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce support for context providers targeting both NES and Completions by modifying the registration and retrieval methods in the language context provider service. This includes the addition of a `ProviderTarget` enum to differentiate between the two targets.