### PR TITLE
Do not filter out timeout context items

### DIFF
--- a/src/extension/xtab/common/promptCrafting.ts
+++ b/src/extension/xtab/common/promptCrafting.ts
@@ -117,7 +117,6 @@ function getRelatedInformation(langCtx: LanguageContextResponse | undefined): st
 
 	const traits = langCtx.items
 		.filter(ctx => ctx.context.kind === ContextKind.Trait)
-		.filter(t => !t.onTimeout)
 		.map(t => t.context) as TraitContext[];
 
 	if (traits.length === 0) {


### PR DESCRIPTION
```Copilot Generated Description:``` Remove the filter that excludes items with the `onTimeout` property from the traits collection.