### PR TITLE
Do not provide NES when suggest widget is visible

### DIFF
--- a/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
+++ b/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
@@ -174,6 +174,13 @@ export class InlineCompletionProviderImpl implements InlineCompletionItemProvide
 			return undefined;
 		}
 
+		const ignoreWhenSuggestVisible = this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsIgnoreWhenSuggestVisible, this._expService);
+
+		if (ignoreWhenSuggestVisible && context.selectedCompletionInfo && !unification) {
+			tracer.returns('suggest widget is showing, not providing NES');
+			return undefined;
+		}
+
 		const doc = this.model.workspace.getDocumentByTextDocument(document);
 		if (!doc) {
 			tracer.returns('document not found in workspace');

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -763,6 +763,7 @@ export namespace ConfigKey {
 		export const InlineEditsXtabMaxMergeConflictLines = defineTeamInternalSetting<number | undefined>('chat.advanced.inlineEdits.xtabProvider.maxMergeConflictLines', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsXtabOnlyMergeConflictLines = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.xtabProvider.onlyMergeConflictLines', ConfigType.ExperimentBased, false);
 		export const InlineEditsUndoInsertionFiltering = defineTeamInternalSetting<'v1' | 'v2' | undefined>('chat.advanced.inlineEdits.undoInsertionFiltering', ConfigType.ExperimentBased, 'v1');
+		export const InlineEditsIgnoreWhenSuggestVisible = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.ignoreWhenSuggestVisible', ConfigType.ExperimentBased, false);
 		export const InstantApplyModelName = defineTeamInternalSetting<string>('chat.advanced.instantApply.modelName', ConfigType.ExperimentBased, 'gpt-4o-instant-apply-full-ft-v66');
 		export const VerifyTextDocumentChanges = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.verifyTextDocumentChanges', ConfigType.ExperimentBased, false);
 


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a configuration option to ignore providing NES when the suggest widget is visible. This includes adding a new setting in the configuration service and implementing the logic in the inline completion provider.

cc @ulugbekna 