### PR TITLE
Add warning for Claude Opus model in conversation summarization prompt

### DIFF
--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -168,7 +168,6 @@ export class ConversationHistorySummarizationPrompt extends PromptElement<Conver
 						<br />
 						IMPORTANT: Do NOT call any tools. Your only task is to generate a text summary of the conversation. Do not attempt to execute any actions or make any tool calls.<br />
 					</>}
-					<br />
 					Focus particularly on:<br />
 					- The specific agent commands/tools that were just executed<br />
 					- The results returned from these recent tool calls (truncate if very long but preserve key information)<br />


### PR DESCRIPTION
Fixes:
https://github.com/microsoft/vscode/issues/279585

Verified this behavior with the messages API -> Send a bunch of tools, set tool_choice:none and ask the model to use some tool -> Model errors out.
Added guidance in the system prompt to NOT call any tools during summarization and that seems to help.