### PR TITLE
Fix diagnostics context provider

### DIFF
--- a/src/extension/diagnosticsContext/vscode/diagnosticsContextProvider.ts
+++ b/src/extension/diagnosticsContext/vscode/diagnosticsContextProvider.ts
@@ -118,7 +118,7 @@ function diagnosticsToTraits(diagnostics: Diagnostic[]): Copilot.Trait[] {
 	if (diagnostics.length > 0) {
 		traits.push({
 			name: "Problems near the user's cursor",
-			value: diagnostics.map(d => `\t${diagnosticsToString(d)}`).join('\n'),
+			value: diagnostics.map(d => `\n\t${diagnosticsToString(d)}`).join(''),
 		});
 	}
 

--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -373,9 +373,8 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		cancellationToken: CancellationToken,
 	): Promise<LanguageContextResponse | undefined> {
 		const recordingEnabled = this.configService.getConfig<boolean>(ConfigKey.TeamInternal.InlineEditsLogContextRecorderEnabled);
-		const diagnosticsContextProviderEnabled = this.configService.getExperimentBasedConfig<boolean>(ConfigKey.Advanced.DiagnosticsContextProvider, this.expService);
 
-		if (!promptOptions.languageContext.enabled && !recordingEnabled && !diagnosticsContextProviderEnabled) {
+		if (!promptOptions.languageContext.enabled && !recordingEnabled) {
 			return Promise.resolve(undefined);
 		}
 
@@ -998,6 +997,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			languageContext: this.determineLanguageContextOptions(activeDocument.languageId, {
 				enabled: this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabLanguageContextEnabled, this.expService),
 				enabledLanguages: this.configService.getConfig(ConfigKey.TeamInternal.InlineEditsXtabLanguageContextEnabledLanguages),
+				enabledDiagnostics: this.configService.getExperimentBasedConfig<boolean>(ConfigKey.Advanced.DiagnosticsContextProvider, this.expService),
 				maxTokens: this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabLanguageContextMaxTokens, this.expService),
 			}),
 			diffHistory: {
@@ -1084,10 +1084,13 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		}
 	}
 
-	private determineLanguageContextOptions(languageId: LanguageId, { enabled, enabledLanguages, maxTokens }: { enabled: boolean; enabledLanguages: LanguageContextLanguages; maxTokens: number }): LanguageContextOptions {
-		// Some languages are
+	private determineLanguageContextOptions(languageId: LanguageId, { enabled, enabledLanguages, maxTokens, enabledDiagnostics: diagnosticsEnabled }: { enabled: boolean; enabledLanguages: LanguageContextLanguages; maxTokens: number; enabledDiagnostics: boolean }): LanguageContextOptions {
 		if (languageId in enabledLanguages) {
 			return { enabled: enabledLanguages[languageId], maxTokens };
+		}
+
+		if (diagnosticsEnabled) {
+			return { enabled: true, maxTokens };
 		}
 
 		return { enabled, maxTokens };


### PR DESCRIPTION
```Copilot Generated Description:``` Update the diagnostics context provider logic by removing its dependency from the prompt options and adjusting the language context options to include diagnostics enabling.