### PR TITLE
Disable filtering workspace CLI sessions

### DIFF
--- a/src/extension/agents/copilotcli/node/copilotcliSessionService.ts
+++ b/src/extension/agents/copilotcli/node/copilotcliSessionService.ts
@@ -6,11 +6,9 @@
 import type { internal, Session, SessionEvent, SessionOptions, SweCustomAgent } from '@github/copilot/sdk';
 import type { CancellationToken, ChatRequest, Uri } from 'vscode';
 import { INativeEnvService } from '../../../../platform/env/common/envService';
-import { IVSCodeExtensionContext } from '../../../../platform/extContext/common/extensionContext';
 import { IFileSystemService } from '../../../../platform/filesystem/common/fileSystemService';
 import { RelativePattern } from '../../../../platform/filesystem/common/fileTypes';
 import { ILogService } from '../../../../platform/log/common/logService';
-import { IWorkspaceService } from '../../../../platform/workspace/common/workspaceService';
 import { createServiceIdentifier } from '../../../../util/common/services';
 import { coalesce } from '../../../../util/vs/base/common/arrays';
 import { disposableTimeout, raceCancellation, raceCancellationError, Sequencer } from '../../../../util/vs/base/common/async';
@@ -25,8 +23,6 @@ import { CopilotCLISessionOptions, ICopilotCLIAgents, ICopilotCLISDK } from './c
 import { CopilotCLISession, ICopilotCLISession } from './copilotcliSession';
 import { getCopilotLogger } from './logger';
 import { ICopilotCLIMCPHandler } from './mcpHandler';
-
-const COPILOT_CLI_WORKSPACE_SPECIFIC_SESSIONS_KEY = 'github.copilot.cli.workspaceSpecificSessions';
 
 export interface ICopilotCLISessionItem {
 	readonly id: string;
@@ -80,8 +76,6 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 		@IFileSystemService private readonly fileSystem: IFileSystemService,
 		@ICopilotCLIMCPHandler private readonly mcpHandler: ICopilotCLIMCPHandler,
 		@ICopilotCLIAgents private readonly agents: ICopilotCLIAgents,
-		@IVSCodeExtensionContext private readonly context: IVSCodeExtensionContext,
-		@IWorkspaceService private readonly workspaceService: IWorkspaceService,
 	) {
 		super();
 		this.monitorSessionFiles();
@@ -205,7 +199,6 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 		const sessionManager = await raceCancellationError(this.getSessionManager(), token);
 		const sdkSession = await sessionManager.createSession(options.toSessionOptions());
 		this.logService.trace(`[CopilotCLISession] Created new CopilotCLI session ${sdkSession.sessionId}.`);
-		void this.updateSessionInWorkspace(sdkSession.sessionId, 'add');
 
 		return this.createCopilotSession(sdkSession, options, sessionManager);
 	}
@@ -290,7 +283,6 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 	}
 
 	public async deleteSession(sessionId: string): Promise<void> {
-		void this.updateSessionInWorkspace(sessionId, 'delete');
 		try {
 			{
 				const session = this._sessionWrappers.get(sessionId);
@@ -311,28 +303,6 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 			// Possible the session was deleted in another vscode session or the like.
 			this._onDidChangeSessions.fire();
 		}
-	}
-
-	private async updateSessionInWorkspace(sessionId: string, operation: 'add' | 'delete'): Promise<void> {
-		// If we're not in a workspace, do not track sessions as these are global sessions.
-		if (this.workspaceService.getWorkspaceFolders().length === 0) {
-			return;
-		}
-		this._mementoUpdator.queue(async () => {
-			let trackedSessions = this.context.workspaceState.get<Record<string, { createdDateTime: number }>>(COPILOT_CLI_WORKSPACE_SPECIFIC_SESSIONS_KEY, {});
-			if (operation === 'add') {
-				trackedSessions[sessionId] = { createdDateTime: Date.now() };
-			} else {
-				delete trackedSessions[sessionId];
-			}
-
-			// If we have 100 entries or more, sort by created time and keep the recent 100 and drop the rest.
-			if (Object.keys(trackedSessions).length >= 100) {
-				const sortedSessions = Object.entries(trackedSessions).sort((a, b) => b[1].createdDateTime - a[1].createdDateTime);
-				trackedSessions = Object.fromEntries(sortedSessions.slice(0, 100));
-			}
-			await this.context.workspaceState.update(COPILOT_CLI_WORKSPACE_SPECIFIC_SESSIONS_KEY, trackedSessions);
-		});
 	}
 }
 

--- a/src/extension/agents/copilotcli/node/test/copilotCliSessionService.spec.ts
+++ b/src/extension/agents/copilotcli/node/test/copilotCliSessionService.spec.ts
@@ -5,12 +5,11 @@
 
 import type { SessionOptions, SweCustomAgent } from '@github/copilot/sdk';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ChatContext, Memento } from 'vscode';
+import type { ChatContext } from 'vscode';
 import { CancellationToken } from 'vscode-languageserver-protocol';
 import { IAuthenticationService } from '../../../../../platform/authentication/common/authentication';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
 import { NullNativeEnvService } from '../../../../../platform/env/common/nullEnvService';
-import { IVSCodeExtensionContext } from '../../../../../platform/extContext/common/extensionContext';
 import { MockFileSystemService } from '../../../../../platform/filesystem/node/test/mockFileSystemService';
 import { IGitService } from '../../../../../platform/git/common/gitService';
 import { ILogService } from '../../../../../platform/log/common/logService';
@@ -121,25 +120,8 @@ describe('CopilotCLISessionService', () => {
 				return disposables.add(new CopilotCLISession(options, sdkSession, gitService, logService, workspaceService, sdk, instantiationService, delegationService));
 			}
 		} as unknown as IInstantiationService;
-		const state: Record<string, unknown> = {};
-		const workspaceState: Memento = {
-			keys: () => Object.keys(state),
-			get: <T>(key: string, defaultValue?: T): T => {
-				if (key in state) {
-					return state[key] as T;
-				}
-				state[key] = defaultValue;
-				return defaultValue as T;
-			},
-			update: async (key: string, value: unknown) => {
-				state[key] = value;
-			}
-		};
-		const context: IVSCodeExtensionContext = new class extends mock<IVSCodeExtensionContext>() {
-			override workspaceState: Memento = workspaceState;
-		}();
 		const configurationService = accessor.get(IConfigurationService);
-		service = disposables.add(new CopilotCLISessionService(logService, sdk, instantiationService, new NullNativeEnvService(), new MockFileSystemService(), new CopilotCLIMCPHandler(logService, new TestWorkspaceService(), authService, configurationService), cliAgents, context, new TestWorkspaceService()));
+		service = disposables.add(new CopilotCLISessionService(logService, sdk, instantiationService, new NullNativeEnvService(), new MockFileSystemService(), new CopilotCLIMCPHandler(logService, new TestWorkspaceService(), authService, configurationService), cliAgents));
 		manager = await service.getSessionManager() as unknown as MockCliSdkSessionManager;
 	});
 

--- a/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
+++ b/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
@@ -177,24 +177,7 @@ describe('CopilotCLIChatSessionParticipant.handleRequest', () => {
 				return disposables.add(session);
 			}
 		} as unknown as IInstantiationService;
-		const state: Record<string, unknown> = {};
-		const workspaceState: vscode.Memento = {
-			keys: () => Object.keys(state),
-			get: <T>(key: string, defaultValue?: T): T => {
-				if (key in state) {
-					return state[key] as T;
-				}
-				state[key] = defaultValue;
-				return defaultValue as T;
-			},
-			update: async (key: string, value: unknown) => {
-				state[key] = value;
-			}
-		};
-		const context: IVSCodeExtensionContext = new class extends mock<IVSCodeExtensionContext>() {
-			override workspaceState: vscode.Memento = workspaceState;
-		}();
-		sessionService = disposables.add(new CopilotCLISessionService(logService, sdk, instantiationService, new NullNativeEnvService(), new MockFileSystemService(), mcpHandler, new NullCopilotCLIAgents(), context, workspaceService));
+		sessionService = disposables.add(new CopilotCLISessionService(logService, sdk, instantiationService, new NullNativeEnvService(), new MockFileSystemService(), mcpHandler, new NullCopilotCLIAgents()));
 
 		manager = await sessionService.getSessionManager() as unknown as MockCliSdkSessionManager;
 


### PR DESCRIPTION
Fixes a bug that hides all of the old background sessiions
Needs a some more work (what do we do with old sessions?)

For https://github.com/microsoft/vscode/issues/280511