### PR TITLE
tracer: fix stringifying arrays

### DIFF
--- a/src/util/common/tracing.ts
+++ b/src/util/common/tracing.ts
@@ -102,16 +102,16 @@ export class Tracer implements ITracer {
 			return value;
 		}
 
-		if (typeof value === 'object') {
-			return stringifyObj(value);
-		}
-
 		if (typeof value === 'function') {
 			return value.name ? `[Function: ${value.name}]` : '[Function]';
 		}
 
 		if (Array.isArray(value)) {
 			return `[${value.map(v => this.stringify(v)).join(', ')}]`;
+		}
+
+		if (typeof value === 'object') {
+			return stringifyObj(value);
 		}
 
 		const valueToString = value.toString();


### PR DESCRIPTION
issue: The Array.isArray(value) check at line 113 will never be reached because arrays are also objects in JavaScript. The earlier check at line 105 (typeof value === 'object') will catch arrays first and pass them to stringifyObj(), making the array-specific handling code unreachable.