### PR TITLE
Support aggresivity level

### DIFF
--- a/src/extension/xtab/common/promptCrafting.ts
+++ b/src/extension/xtab/common/promptCrafting.ts
@@ -7,7 +7,7 @@ import { DocumentId } from '../../../platform/inlineEdits/common/dataTypes/docum
 import { RootedEdit } from '../../../platform/inlineEdits/common/dataTypes/edit';
 import { LanguageContextResponse } from '../../../platform/inlineEdits/common/dataTypes/languageContext';
 import * as xtabPromptOptions from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
-import { CurrentFileOptions, DiffHistoryOptions, PromptingStrategy, PromptOptions } from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
+import { AggresivityLevel, CurrentFileOptions, DiffHistoryOptions, PromptingStrategy, PromptOptions } from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { StatelessNextEditDocument } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { IXtabHistoryEditEntry, IXtabHistoryEntry } from '../../../platform/inlineEdits/common/workspaceEditTracker/nesXtabHistoryTracker';
 import { ContextKind, TraitContext } from '../../../platform/languageServer/common/languageContextService';
@@ -31,6 +31,7 @@ export class PromptPieces {
 		public readonly taggedCurrentDocLines: readonly string[],
 		public readonly areaAroundCodeToEdit: string,
 		public readonly langCtx: LanguageContextResponse | undefined,
+		public readonly aggresivityLevel: AggresivityLevel,
 		public readonly computeTokens: (s: string) => number,
 		public readonly opts: PromptOptions,
 	) {
@@ -39,7 +40,7 @@ export class PromptPieces {
 
 export function getUserPrompt(promptPieces: PromptPieces): string {
 
-	const { activeDoc, xtabHistory, taggedCurrentDocLines, areaAroundCodeToEdit, langCtx, computeTokens, opts } = promptPieces;
+	const { activeDoc, xtabHistory, taggedCurrentDocLines, areaAroundCodeToEdit, langCtx, aggresivityLevel, computeTokens, opts } = promptPieces;
 	const currentFileContent = taggedCurrentDocLines.join('\n');
 
 	const { codeSnippets: recentlyViewedCodeSnippets, documents: docsInPrompt } = getRecentCodeSnippets(activeDoc, xtabHistory, langCtx, computeTokens, opts);
@@ -52,7 +53,7 @@ export function getUserPrompt(promptPieces: PromptPieces): string {
 
 	const currentFilePath = toUniquePath(activeDoc.id, activeDoc.workspaceRoot?.path);
 
-	const postScript = promptPieces.opts.includePostScript ? getPostScript(opts.promptingStrategy, currentFilePath) : '';
+	const postScript = promptPieces.opts.includePostScript ? getPostScript(opts.promptingStrategy, currentFilePath, aggresivityLevel) : '';
 
 	const mainPrompt = `${PromptTags.RECENT_FILES.start}
 ${recentlyViewedCodeSnippets}
@@ -82,7 +83,7 @@ function wrapInBackticks(content: string) {
 	return `\`\`\`\n${content}\n\`\`\``;
 }
 
-function getPostScript(strategy: PromptingStrategy | undefined, currentFilePath: string) {
+function getPostScript(strategy: PromptingStrategy | undefined, currentFilePath: string, aggresivityLevel: AggresivityLevel): string {
 	let postScript: string | undefined;
 	switch (strategy) {
 		case PromptingStrategy.Codexv21NesUnified:
@@ -95,6 +96,9 @@ function getPostScript(strategy: PromptingStrategy | undefined, currentFilePath:
 			break;
 		case PromptingStrategy.Xtab275:
 			postScript = `The developer was working on a section of code within the tags \`code_to_edit\` in the file located at \`${currentFilePath}\`. Using the given \`recently_viewed_code_snippets\`, \`current_file_content\`, \`edit_diff_history\`, \`area_around_code_to_edit\`, and the cursor position marked as \`${PromptTags.CURSOR}\`, please continue the developer's work. Update the \`code_to_edit\` section by predicting and completing the changes they would have made next. Provide the revised code that was between the \`${PromptTags.EDIT_WINDOW.start}\` and \`${PromptTags.EDIT_WINDOW.end}\` tags, but do not include the tags themselves. Avoid undoing or reverting the developer's last change unless there are obvious typos or errors. Don't include the line numbers or the form #| in your response. Do not skip any lines. Do not be lazy.`;
+			break;
+		case PromptingStrategy.XtabAggresivity:
+			postScript = `<|aggressive|>${aggresivityLevel}<|/aggressive|>`;
 			break;
 		case PromptingStrategy.SimplifiedSystemPrompt:
 		default:

--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -16,7 +16,7 @@ import { LanguageContextEntry, LanguageContextResponse } from '../../../platform
 import { LanguageId } from '../../../platform/inlineEdits/common/dataTypes/languageId';
 import { NextCursorLinePrediction } from '../../../platform/inlineEdits/common/dataTypes/nextCursorLinePrediction';
 import * as xtabPromptOptions from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
-import { LanguageContextLanguages, LanguageContextOptions } from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
+import { LanguageContextLanguages, LanguageContextOptions, PromptingStrategy } from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { InlineEditRequestLogContext } from '../../../platform/inlineEdits/common/inlineEditLogContext';
 import { IInlineEditsModelService } from '../../../platform/inlineEdits/common/inlineEditsModelService';
 import { ResponseProcessor } from '../../../platform/inlineEdits/common/responseProcessor';
@@ -269,7 +269,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			areaAroundEditWindowLinesRange,
 			promptOptions,
 			XtabProvider.computeTokens,
-			{ includeLineNumbers: { areaAroundCodeToEdit: false, currentFileContent: false } }
+			{ includeLineNumbers: { areaAroundCodeToEdit: false, currentFileContent: promptOptions.promptingStrategy === PromptingStrategy.XtabAggresivity } }
 		);
 
 		if (taggedCurrentFileContentResult.isError()) {
@@ -279,6 +279,8 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		const { taggedCurrentDocLines, areaAroundCodeToEdit } = taggedCurrentFileContentResult.val;
 
 		telemetryBuilder.setNLinesOfCurrentFileInPrompt(taggedCurrentDocLines.length);
+
+		const aggresivityLevel = this.configService.getExperimentBasedConfig<xtabPromptOptions.AggresivityLevel | undefined>(ConfigKey.TeamInternal.InlineEditsXtabAggresivityLevel, this.expService) ?? xtabPromptOptions.AggresivityLevel.Medium;
 
 		const langCtx = await this.getAndProcessLanguageContext(
 			request,
@@ -304,6 +306,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			taggedCurrentDocLines,
 			areaAroundCodeToEdit,
 			langCtx,
+			aggresivityLevel,
 			XtabProvider.computeTokens,
 			promptOptions
 		);
@@ -1033,6 +1036,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			case xtabPromptOptions.PromptingStrategy.SimplifiedSystemPrompt:
 				return simplifiedPrompt;
 			case xtabPromptOptions.PromptingStrategy.Xtab275:
+			case xtabPromptOptions.PromptingStrategy.XtabAggresivity:
 				return xtab275SystemPrompt;
 			case xtabPromptOptions.PromptingStrategy.Nes41Miniv3:
 				return nes41Miniv3SystemPrompt;

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -767,6 +767,7 @@ export namespace ConfigKey {
 		export const InlineEditsXtabLanguageContextMaxTokens = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.xtabProvider.languageContext.maxTokens', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.languageContext.maxTokens);
 		export const InlineEditsXtabMaxMergeConflictLines = defineTeamInternalSetting<number | undefined>('chat.advanced.inlineEdits.xtabProvider.maxMergeConflictLines', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsXtabOnlyMergeConflictLines = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.xtabProvider.onlyMergeConflictLines', ConfigType.ExperimentBased, false);
+		export const InlineEditsXtabAggresivityLevel = defineSetting<xtabPromptOptions.AggresivityLevel | undefined>('chat.advanced.inlineEdits.xtabProvider.aggresivityLevel', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsUndoInsertionFiltering = defineTeamInternalSetting<'v1' | 'v2' | undefined>('chat.advanced.inlineEdits.undoInsertionFiltering', ConfigType.ExperimentBased, 'v1');
 		export const InlineEditsIgnoreWhenSuggestVisible = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.ignoreWhenSuggestVisible', ConfigType.ExperimentBased, false);
 		export const InlineEditsJointCompletionsProviderEnabled = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.jointCompletionsProvider.enabled', ConfigType.ExperimentBased, false);

--- a/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
+++ b/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
@@ -34,6 +34,12 @@ export type CurrentFileOptions = {
 	readonly prioritizeAboveCursor: boolean;
 }
 
+export enum AggresivityLevel {
+	Low = 'low',
+	Medium = 'medium',
+	High = 'high',
+}
+
 export type PromptOptions = {
 	readonly promptingStrategy: PromptingStrategy | undefined /* default */;
 	readonly currentFile: CurrentFileOptions;
@@ -56,6 +62,7 @@ export enum PromptingStrategy {
 	Nes41Miniv3 = 'nes41miniv3',
 	SimplifiedSystemPrompt = 'simplifiedSystemPrompt',
 	Xtab275 = 'xtab275',
+	XtabAggresivity = 'xtabAggresivity',
 }
 
 export function isPromptingStrategy(value: string): value is PromptingStrategy {
@@ -76,6 +83,7 @@ export namespace ResponseFormat {
 			case PromptingStrategy.Nes41Miniv3:
 				return ResponseFormat.UnifiedWithXml;
 			case PromptingStrategy.Xtab275:
+			case PromptingStrategy.XtabAggresivity:
 				return ResponseFormat.EditWindowOnly;
 			case PromptingStrategy.SimplifiedSystemPrompt:
 			case undefined:


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce an aggresivity level feature, allowing users to specify low, medium, or high levels of aggresivity in prompts. 