### PR TITLE
Send effort=medium by default in responses API

### DIFF
--- a/src/platform/endpoint/node/responsesApi.ts
+++ b/src/platform/endpoint/node/responsesApi.ts
@@ -57,7 +57,7 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 		'disabled';
 	const effortConfig = configService.getExperimentBasedConfig(ConfigKey.ResponsesApiReasoningEffort, expService);
 	const summaryConfig = configService.getExperimentBasedConfig(ConfigKey.ResponsesApiReasoningSummary, expService);
-	const effort = effortConfig === 'default' ? undefined : effortConfig;
+	const effort = effortConfig === 'default' ? 'medium' : effortConfig;
 	const summary = summaryConfig === 'off' ? undefined : summaryConfig;
 	if (effort || summary) {
 		body.reasoning = {


### PR DESCRIPTION
Because some models use effort=none by default, while we were assuming it was medium