### PR TITLE
Anthropic ONLY: update conversation summarization with thinking data support 

### DIFF
--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -226,7 +226,7 @@ class ConversationHistory extends PromptElement<SummarizedAgentHistoryProps> {
 
 			// For Anthropic models with thinking enabled, set the thinking on the first round
 			// so it gets rendered as the first thinking block after summarization
-			if (thinkingForFirstRoundAfterSummarization && toolCallRounds.length > 0 && !toolCallRounds[0].thinking) {
+			if ((this.props.endpoint.model.startsWith('claude') || this.props.endpoint.model.startsWith('Anthropic')) && thinkingForFirstRoundAfterSummarization && toolCallRounds.length > 0 && !toolCallRounds[0].thinking) {
 				toolCallRounds[0].thinking = thinkingForFirstRoundAfterSummarization;
 			}
 
@@ -741,7 +741,6 @@ export class SummarizedConversationHistoryPropsBuilder {
 			for (let i = props.promptContext.toolCallRounds.length - 1; i >= 0; i--) {
 				const round = props.promptContext.toolCallRounds[i];
 				if (round.thinking) {
-					console.log('saving thinking 1`');
 					return round.thinking;
 				}
 			}


### PR DESCRIPTION
## Problem

When using Anthropic/Claude models with **extended thinking** enabled, the API requires:

> *When `thinking` is enabled, a final `assistant` message must start with a thinking block (preceeding the lastmost set of `tool_use` and `tool_result` blocks)*

After **conversation summarization**, this requirement fails because:
- The conversation history is truncated and replaced with a summary
- If the last thing before summarization was a **tool call**, the first assistant message after the summary needs a thinking block
- The thinking data from the original conversation is lost during summarization

**Result:** Anthropic API rejects the request with an error.

```
## FAILED: Request Failed: 400 {"error":{"message":"messages.1.content.0.type: Expected `thinking` or `redacted_thinking`, but found `text`. When `thinking` is enabled, a final `assistant` message must start with a thinking block (preceeding the lastmost set of `tool_use` and `tool_result` blocks). We recommend you include thinking blocks from previous turns. To avoid this requirement, disable `thinking`. Please consult our documentation at https://docs.claude.com/en/docs/build-with-claude/extended-thinking","code":"invalid_request_body"}}
```

---

Fix: Preserve thinking data across summarization boundaries (Anthropic/Claude models only) as recommended by Anthropic `We recommend you include thinking blocks from previous turns.`

1. **Find the last thinking** — Search all rounds (current  in reverse order to find the most recent thinking data
2. **Store on summarized round** — Save the thinking in `SummarizedConversationHistoryMetadata` and on the round itself
3. **Transfer to first round after summary** — When rendering, set the thinking on the first tool call round that follows the summary
4. **Render in assistant message** — The thinking block is included in the first assistant message after summarization


Tested:
Summarization—with and without Thinking—across the following scenarios:
	•	Summarization with no prior tool calls
	•	Summarization immediately after a tool call
	•	Summarization immediately after a tool call and tool result
