### PR TITLE
Disable MCP result image URL for Gemini models

### DIFF
--- a/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -147,7 +147,7 @@ export function modelShouldUseReplaceStringHealing(model: LanguageModelChat | IC
  * The model can accept image urls as the `image_url` parameter in mcp tool results.
  */
 export function modelCanUseMcpResultImageURL(model: LanguageModelChat | IChatEndpoint): boolean {
-	return !model.family.startsWith('claude') && !model.family.startsWith('Anthropic') && !!model.family.startsWith('gemini') && !isHiddenModelE(model);
+	return !model.family.startsWith('claude') && !model.family.startsWith('Anthropic') && !model.family.startsWith('gemini') && !isHiddenModelE(model);
 }
 
 /**


### PR DESCRIPTION
Seems like this was missed for Gemini 2.5 Pro as well
<img width="299" height="200" alt="image" src="https://github.com/user-attachments/assets/3e1a62c3-46c2-4fa2-adbd-f3d3ece5c61a" />

After fix
<img width="571" height="330" alt="image" src="https://github.com/user-attachments/assets/08563db8-53f8-4796-8fd9-8039005c9e15" />
