### PR TITLE
nes: joint: tweakable yielding strategies and yield-to-completions strategy

### DIFF
--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -769,7 +769,6 @@ export namespace ConfigKey {
 		export const InlineEditsIgnoreWhenSuggestVisible = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.ignoreWhenSuggestVisible', ConfigType.ExperimentBased, false);
 		export const InlineEditsJointCompletionsProviderEnabled = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.jointCompletionsProvider.enabled', ConfigType.ExperimentBased, false);
 		export const InlineEditsJointCompletionsProviderStrategy = defineTeamInternalSetting<JointCompletionsProviderStrategy>('chat.advanced.inlineEdits.jointCompletionsProvider.strategy', ConfigType.ExperimentBased, JointCompletionsProviderStrategy.Regular);
-		export const InlineEditsJointCompletionGhostTextDelayIfLastNes = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.jointCompletionsProvider.completionsDelayIfLastNes', ConfigType.ExperimentBased, 300);
 		export const InstantApplyModelName = defineTeamInternalSetting<string>('chat.advanced.instantApply.modelName', ConfigType.ExperimentBased, 'gpt-4o-instant-apply-full-ft-v66');
 		export const VerifyTextDocumentChanges = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.verifyTextDocumentChanges', ConfigType.ExperimentBased, false);
 


### PR DESCRIPTION
nes: simplify handling of NES endOfLife

nes: joint provider: yield to NES if last suggestion was NES and it agrees with users edits

Update src/extension/inlineEdits/vscode-node/jointInlineCompletionProvider.ts

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>

nes: dispose JointCompletionsProvider

nes: rework logic

this has a bug that completions gets triggered along with NES on cursor move -- it's very bad for completions because it has no debounce AND it would get cancellation on cursor move

nes: remove unused setting

nes: update lastNesSuggestion only if latest invocation

nes: fix imports

nes: remove unused param

nes: remove redundant check

nes: fix: correctly cancel completions when NES is picked