### PR TITLE
completions: keep instantiated ghost text provider in a service such that it can be shared between joint and normal providers

### DIFF
--- a/src/extension/completions/common/copilotInlineCompletionItemProviderService.ts
+++ b/src/extension/completions/common/copilotInlineCompletionItemProviderService.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { InlineCompletionItemProvider } from 'vscode';
+import { createServiceIdentifier } from '../../../util/common/services';
+import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
+
+export interface ICopilotInlineCompletionItemProviderService {
+	readonly _serviceBrand: undefined;
+
+	getOrCreateInstantiationService(): IInstantiationService;
+	getOrCreateProvider(): InlineCompletionItemProvider;
+}
+
+export const ICopilotInlineCompletionItemProviderService = createServiceIdentifier<ICopilotInlineCompletionItemProviderService>('ICopilotInlineCompletionItemProviderService');
+
+export class NullCopilotInlineCompletionItemProviderService implements ICopilotInlineCompletionItemProviderService {
+	readonly _serviceBrand: undefined;
+
+	getOrCreateInstantiationService(): IInstantiationService {
+		throw new Error('Not implemented');
+	}
+	getOrCreateProvider(): InlineCompletionItemProvider {
+		throw new Error('Not implemented');
+	}
+}

--- a/src/extension/completions/vscode-node/completionsCoreContribution.ts
+++ b/src/extension/completions/vscode-node/completionsCoreContribution.ts
@@ -7,23 +7,18 @@ import { commands, languages } from 'vscode';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
-import { Disposable, DisposableStore } from '../../../util/vs/base/common/lifecycle';
+import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { autorun, observableFromEvent } from '../../../util/vs/base/common/observableInternal';
-import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
-import { createContext, registerUnificationCommands, setup } from '../../completions-core/vscode-node/completionsServiceBridges';
-import { CopilotInlineCompletionItemProvider } from '../../completions-core/vscode-node/extension/src/inlineCompletion';
+import { registerUnificationCommands } from '../../completions-core/vscode-node/completionsServiceBridges';
+import { ICopilotInlineCompletionItemProviderService } from '../common/copilotInlineCompletionItemProviderService';
 import { unificationStateObservable } from './completionsUnificationContribution';
 
 export class CompletionsCoreContribution extends Disposable {
 
-	private _provider: CopilotInlineCompletionItemProvider | undefined;
-
 	private readonly _copilotToken = observableFromEvent(this, this.authenticationService.onDidAuthenticationChange, () => this.authenticationService.copilotToken);
 
-	private _completionsInstantiationService: IInstantiationService | undefined;
-
 	constructor(
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@ICopilotInlineCompletionItemProviderService _copilotInlineCompletionItemProviderService: ICopilotInlineCompletionItemProviderService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IExperimentationService experimentationService: IExperimentationService,
 		@IAuthenticationService private readonly authenticationService: IAuthenticationService
@@ -37,8 +32,9 @@ export class CompletionsCoreContribution extends Disposable {
 			const configEnabled = configurationService.getExperimentBasedConfigObservable<boolean>(ConfigKey.TeamInternal.InlineEditsEnableGhCompletionsProvider, experimentationService).read(reader);
 			const extensionUnification = unificationStateValue?.extensionUnification ?? false;
 
+			let hasInstantiatedProvider = false;
 			if (unificationStateValue?.codeUnification || extensionUnification || configEnabled || this._copilotToken.read(reader)?.isNoAuthUser) {
-				const provider = this._getOrCreateProvider();
+				const provider = _copilotInlineCompletionItemProviderService.getOrCreateProvider();
 				reader.store.add(
 					languages.registerInlineCompletionItemProvider(
 						{ pattern: '**' },
@@ -50,12 +46,14 @@ export class CompletionsCoreContribution extends Disposable {
 						}
 					)
 				);
+				hasInstantiatedProvider = true;
 			}
 
 			void commands.executeCommand('setContext', 'github.copilot.extensionUnification.activated', extensionUnification);
 
-			if (extensionUnification && this._completionsInstantiationService) {
-				reader.store.add(this._completionsInstantiationService.invokeFunction(registerUnificationCommands));
+			if (extensionUnification && hasInstantiatedProvider) {
+				const completionsInstaService = _copilotInlineCompletionItemProviderService.getOrCreateInstantiationService();
+				reader.store.add(completionsInstaService.invokeFunction(registerUnificationCommands));
 			}
 		}));
 
@@ -63,15 +61,5 @@ export class CompletionsCoreContribution extends Disposable {
 			const token = this._copilotToken.read(reader);
 			void commands.executeCommand('setContext', 'github.copilot.activated', token !== undefined);
 		}));
-	}
-
-	private _getOrCreateProvider() {
-		if (!this._provider) {
-			const disposables = this._register(new DisposableStore());
-			this._completionsInstantiationService = this._instantiationService.invokeFunction(createContext, disposables);
-			this._completionsInstantiationService.invokeFunction(setup, disposables);
-			this._provider = disposables.add(this._completionsInstantiationService.createInstance(CopilotInlineCompletionItemProvider));
-		}
-		return this._provider;
 	}
 }

--- a/src/extension/completions/vscode-node/copilotInlineCompletionItemProviderService.ts
+++ b/src/extension/completions/vscode-node/copilotInlineCompletionItemProviderService.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { InlineCompletionItemProvider } from 'vscode';
+import { Disposable } from '../../../util/vs/base/common/lifecycle';
+import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { createContext, setup } from '../../completions-core/vscode-node/completionsServiceBridges';
+import { CopilotInlineCompletionItemProvider } from '../../completions-core/vscode-node/extension/src/inlineCompletion';
+import { ICopilotInlineCompletionItemProviderService } from '../common/copilotInlineCompletionItemProviderService';
+
+export class CopilotInlineCompletionItemProviderService extends Disposable implements ICopilotInlineCompletionItemProviderService {
+	readonly _serviceBrand: undefined;
+
+	private _provider: InlineCompletionItemProvider | undefined;
+	private _completionsInstantiationService: IInstantiationService | undefined;
+
+	constructor(
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+	) {
+		super();
+	}
+
+	getOrCreateInstantiationService(): IInstantiationService {
+		if (!this._completionsInstantiationService) {
+			this._completionsInstantiationService = this._instantiationService.invokeFunction(createContext, this._store);
+		}
+		return this._completionsInstantiationService;
+	}
+
+	getOrCreateProvider(): InlineCompletionItemProvider {
+		if (!this._provider) {
+			this._completionsInstantiationService = this.getOrCreateInstantiationService();
+			this._completionsInstantiationService.invokeFunction(setup, this._store);
+			this._provider = this._register(this._completionsInstantiationService.createInstance(CopilotInlineCompletionItemProvider));
+		}
+		return this._provider;
+	}
+}

--- a/src/extension/extension/vscode-node/services.ts
+++ b/src/extension/extension/vscode-node/services.ts
@@ -111,6 +111,8 @@ import { LanguageContextServiceImpl } from '../../typescriptContext/vscode-node/
 import { IWorkspaceListenerService } from '../../workspaceRecorder/common/workspaceListenerService';
 import { WorkspacListenerService } from '../../workspaceRecorder/vscode-node/workspaceListenerService';
 import { registerServices as registerCommonServices } from '../vscode/services';
+import { ICopilotInlineCompletionItemProviderService } from '../../completions/common/copilotInlineCompletionItemProviderService';
+import { CopilotInlineCompletionItemProviderService } from '../../completions/vscode-node/copilotInlineCompletionItemProviderService';
 
 // ###########################################################################################
 // ###                                                                                     ###
@@ -210,6 +212,7 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 	builder.define(IRerankerService, new SyncDescriptor(RerankerService));
 	builder.define(IProxyModelsService, new SyncDescriptor(ProxyModelsService));
 	builder.define(IInlineEditsModelService, new SyncDescriptor(InlineEditsModelService));
+	builder.define(ICopilotInlineCompletionItemProviderService, new SyncDescriptor(CopilotInlineCompletionItemProviderService));
 }
 
 function setupMSFTExperimentationService(builder: IInstantiationServiceBuilder, extensionContext: ExtensionContext) {

--- a/src/extension/test/vscode-node/services.ts
+++ b/src/extension/test/vscode-node/services.ts
@@ -89,6 +89,7 @@ import { ExtensionTextDocumentManager } from '../../../platform/workspace/vscode
 import { GithubAvailableEmbeddingTypesService, IGithubAvailableEmbeddingTypesService } from '../../../platform/workspaceChunkSearch/common/githubAvailableEmbeddingTypes';
 import { SyncDescriptor } from '../../../util/vs/platform/instantiation/common/descriptors';
 import { CommandServiceImpl, ICommandService } from '../../commands/node/commandService';
+import { ICopilotInlineCompletionItemProviderService, NullCopilotInlineCompletionItemProviderService } from '../../completions/common/copilotInlineCompletionItemProviderService';
 import { IPromptWorkspaceLabels, PromptWorkspaceLabels } from '../../context/node/resolvers/promptWorkspaceLabels';
 import { IUserFeedbackService, UserFeedbackService } from '../../conversation/vscode-node/userActions';
 import { ConversationStore, IConversationStore } from '../../conversationStore/node/conversationStore';
@@ -192,6 +193,7 @@ export function createExtensionTestingServices(): TestingServiceCollection {
 	testingServiceCollection.define(IGithubAvailableEmbeddingTypesService, new SyncDescriptor(GithubAvailableEmbeddingTypesService));
 	testingServiceCollection.define(IProxyModelsService, new SyncDescriptor(NullProxyModelsService));
 	testingServiceCollection.define(IInlineEditsModelService, new SyncDescriptor(InlineEditsModelService));
+	testingServiceCollection.define(ICopilotInlineCompletionItemProviderService, new SyncDescriptor(NullCopilotInlineCompletionItemProviderService));
 
 	return testingServiceCollection;
 }


### PR DESCRIPTION
because ghost text provider leaks and creating two of them results in a leak