### PR TITLE
Make diagnostics context provider experiment configurable by language

### DIFF
--- a/src/extension/diagnosticsContext/vscode/diagnosticsContextProvider.ts
+++ b/src/extension/diagnosticsContext/vscode/diagnosticsContextProvider.ts
@@ -79,7 +79,7 @@ class ContextResolver implements Copilot.ContextResolver<Copilot.SupportedContex
 		}
 
 		const languageId = request.documentContext.languageId;
-		const languageEnablement = this.experimentationService.getTreatmentVariable<boolean>(`config.github.copilot.chat.advanced.inlineEdits.diagnosticsContextProvider.${languageId}`);
+		const languageEnablement = this.experimentationService.getTreatmentVariable<boolean>(`config.github.copilot.chat.inlineEdits.diagnosticsContextProvider.${languageId}`);
 		if (!languageEnablement) {
 			return [];
 		}


### PR DESCRIPTION
```Copilot Generated Description:``` Make the diagnostics context provider experiment configurable based on the language used in the document. Change the name for clarity.