### PR TITLE
Update Anthropic thinking budget configuration to allow zero and normalize minimum values

### DIFF
--- a/package.json
+++ b/package.json
@@ -3319,7 +3319,7 @@
 							"null"
 						],
 						"markdownDescription": "%github.copilot.config.anthropic.thinking.budgetTokens%",
-						"minimum": 1024,
+						"minimum": 0,
 						"maximum": 32000,
 						"tags": [
 							"experimental",

--- a/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -37,7 +37,7 @@ export class AnthropicLMProvider implements BYOKModelProvider<LanguageModelChatI
 
 	private _getThinkingBudget(modelId: string, maxOutputTokens: number): number | undefined {
 		const configuredBudget = this._configurationService.getExperimentBasedConfig(ConfigKey.AnthropicThinkingBudget, this._experimentationService);
-		if (!configuredBudget) {
+		if (!configuredBudget || configuredBudget === 0) {
 			return undefined;
 		}
 
@@ -46,7 +46,8 @@ export class AnthropicLMProvider implements BYOKModelProvider<LanguageModelChatI
 		if (!modelSupportsThinking) {
 			return undefined;
 		}
-		return Math.min(32000, maxOutputTokens - 1, configuredBudget);
+		const normalizedBudget = configuredBudget < 1024 ? 1024 : configuredBudget;
+		return Math.min(32000, maxOutputTokens - 1, normalizedBudget);
 	}
 
 	/**

--- a/src/platform/endpoint/node/chatEndpoint.ts
+++ b/src/platform/endpoint/node/chatEndpoint.ts
@@ -281,9 +281,10 @@ export class ChatEndpoint implements IChatEndpoint {
 		const isAnthropicModel = this.family.startsWith('claude') || this.family.startsWith('Anthropic');
 		if (isAnthropicModel) {
 			const configuredBudget = this._configurationService.getExperimentBasedConfig(ConfigKey.AnthropicThinkingBudget, this._expService);
-			if (configuredBudget) {
+			if (configuredBudget && configuredBudget > 0) {
+				const normalizedBudget = configuredBudget < 1024 ? 1024 : configuredBudget;
 				// Cap thinking budget to Anthropic's recommended max (32000), and ensure it's less than max output tokens
-				body.thinking_budget = Math.min(32000, this._maxOutputTokens - 1, configuredBudget);
+				body.thinking_budget = Math.min(32000, this._maxOutputTokens - 1, normalizedBudget);
 			}
 		}
 		return body;

--- a/src/platform/endpoint/node/messagesApi.ts
+++ b/src/platform/endpoint/node/messagesApi.ts
@@ -74,8 +74,11 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	const experimentationService = accessor.get(IExperimentationService);
 	const configuredBudget = configurationService.getExperimentBasedConfig(ConfigKey.AnthropicThinkingBudget, experimentationService);
 	const maxTokens = options.postOptions.max_tokens ?? 1024;
-	const thinkingBudget = configuredBudget
-		? Math.min(32000, maxTokens - 1, configuredBudget)
+	const normalizedBudget = (configuredBudget && configuredBudget > 0)
+		? (configuredBudget < 1024 ? 1024 : configuredBudget)
+		: undefined;
+	const thinkingBudget = normalizedBudget
+		? Math.min(32000, maxTokens - 1, normalizedBudget)
 		: undefined;
 
 	return {

--- a/src/platform/endpoint/node/test/copilotChatEndpoint.spec.ts
+++ b/src/platform/endpoint/node/test/copilotChatEndpoint.spec.ts
@@ -501,5 +501,105 @@ describe('ChatEndpoint - Anthropic Thinking Budget', () => {
 
 			expect(body.thinking_budget).toBe(5000);
 		});
+
+		it('should disable thinking when configuredBudget is 0', () => {
+			mockServices.configurationService.setConfig(ConfigKey.AnthropicThinkingBudget, 0);
+			const modelMetadata = createAnthropicModelMetadata('claude-sonnet-4.5', 50000);
+
+			const endpoint = new ChatEndpoint(
+				modelMetadata,
+				mockServices.domainService,
+				mockServices.capiClientService,
+				mockServices.fetcherService,
+				mockServices.telemetryService,
+				mockServices.authService,
+				mockServices.chatMLFetcher,
+				mockServices.tokenizerProvider,
+				mockServices.instantiationService,
+				mockServices.configurationService,
+				mockServices.expService,
+				mockServices.logService
+			);
+
+			const options = createTestOptions([createUserMessage('Hello')]);
+			const body = endpoint.createRequestBody(options);
+
+			expect(body.thinking_budget).toBeUndefined();
+		});
+
+		it('should normalize values between 1-1023 to 1024 (Anthropic minimum)', () => {
+			mockServices.configurationService.setConfig(ConfigKey.AnthropicThinkingBudget, 500);
+			const modelMetadata = createAnthropicModelMetadata('claude-sonnet-4.5', 50000);
+
+			const endpoint = new ChatEndpoint(
+				modelMetadata,
+				mockServices.domainService,
+				mockServices.capiClientService,
+				mockServices.fetcherService,
+				mockServices.telemetryService,
+				mockServices.authService,
+				mockServices.chatMLFetcher,
+				mockServices.tokenizerProvider,
+				mockServices.instantiationService,
+				mockServices.configurationService,
+				mockServices.expService,
+				mockServices.logService
+			);
+
+			const options = createTestOptions([createUserMessage('Hello')]);
+			const body = endpoint.createRequestBody(options);
+
+			expect(body.thinking_budget).toBe(1024);
+		});
+
+		it('should normalize value of 1 to 1024', () => {
+			mockServices.configurationService.setConfig(ConfigKey.AnthropicThinkingBudget, 1);
+			const modelMetadata = createAnthropicModelMetadata('claude-sonnet-4.5', 50000);
+
+			const endpoint = new ChatEndpoint(
+				modelMetadata,
+				mockServices.domainService,
+				mockServices.capiClientService,
+				mockServices.fetcherService,
+				mockServices.telemetryService,
+				mockServices.authService,
+				mockServices.chatMLFetcher,
+				mockServices.tokenizerProvider,
+				mockServices.instantiationService,
+				mockServices.configurationService,
+				mockServices.expService,
+				mockServices.logService
+			);
+
+			const options = createTestOptions([createUserMessage('Hello')]);
+			const body = endpoint.createRequestBody(options);
+
+			expect(body.thinking_budget).toBe(1024);
+		});
+
+		it('should use exactly 1024 when configured to 1024', () => {
+			mockServices.configurationService.setConfig(ConfigKey.AnthropicThinkingBudget, 1024);
+			const modelMetadata = createAnthropicModelMetadata('claude-sonnet-4.5', 50000);
+
+			const endpoint = new ChatEndpoint(
+				modelMetadata,
+				mockServices.domainService,
+				mockServices.capiClientService,
+				mockServices.fetcherService,
+				mockServices.telemetryService,
+				mockServices.authService,
+				mockServices.chatMLFetcher,
+				mockServices.tokenizerProvider,
+				mockServices.instantiationService,
+				mockServices.configurationService,
+				mockServices.expService,
+				mockServices.logService
+			);
+
+			const options = createTestOptions([createUserMessage('Hello')]);
+			const body = endpoint.createRequestBody(options);
+
+			expect(body.thinking_budget).toBe(1024);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- Allow users to set thinking budget to `0` to disable extended thinking
- Normalize values between 1-1023 to Anthropic's minimum of 1024
- Updated setting minimum from 1024 → 0 in `package.json`
- Added unit tests for edge cases (0, 1, 500, 1024)