### PR TITLE
Fix isolation option handling in chat sessions

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
@@ -347,8 +347,13 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 			const worktreeRelativePath = this.worktreeManager.getWorktreeRelativePath(copilotcliSessionId);
 			if (worktreeRelativePath) {
 				options[ISOLATION_OPTION_ID] = getLockedIsolationOption(worktreeRelativePath);
+			} else {
+				options[ISOLATION_OPTION_ID] = disabledIsolationLocked;
 			}
+		} else if (existingSession) {
+			options[ISOLATION_OPTION_ID] = disabledIsolationLocked;
 		}
+
 		const history = existingSession?.object?.getChatHistory() || [];
 		existingSession?.dispose();
 		// Always keep track of this in memory.


### PR DESCRIPTION
Improve the handling of the isolation option in chat sessions by ensuring it is correctly set when no worktree relative path exists or when an existing session is present.

fix #281147