### PR TITLE
debt - make inline chat feedback telemetry a little simpler

### DIFF
--- a/src/extension/inlineChat/node/promptCraftingTypes.ts
+++ b/src/extension/inlineChat/node/promptCraftingTypes.ts
@@ -138,13 +138,14 @@ export interface ICodeContextInfo {
 	above: CodeContextRegion;
 	range: CodeContextRegion;
 	below: CodeContextRegion;
-}export class CopilotInteractiveEditorResponse {
+}
+
+export class CopilotInteractiveEditorResponse {
 	constructor(
-		public readonly kind: 'ok',
-		public readonly store: ISessionTurnStorage | undefined,
-		public readonly promptQuery: PromptQuery,
-		public readonly messageId: string,
-		public readonly telemetry: ChatTelemetry | undefined,
-		public readonly editSurvivalTracker: IEditSurvivalTrackingSession
+		readonly store: ISessionTurnStorage | undefined,
+		readonly promptQuery: PromptQuery,
+		readonly messageId: string,
+		readonly telemetry: ChatTelemetry | undefined,
+		readonly editSurvivalTracker: IEditSurvivalTrackingSession
 	) { }
 }

--- a/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -266,7 +266,6 @@ export class DefaultIntentRequestHandler {
 
 		if (this.documentContext) {
 			this.turn.setMetadata(new CopilotInteractiveEditorResponse(
-				'ok',
 				interactionOutcome.store,
 				{ ...this.documentContext, intent: this.intent, query: this.request.prompt },
 				this.chatTelemetryBuilder.telemetryMessageId,

--- a/test/simulation/inlineChatSimulator.ts
+++ b/test/simulation/inlineChatSimulator.ts
@@ -507,7 +507,7 @@ export async function simulateEditingScenario(
 			{
 				// TODO@Alex: extract to host object
 				const response = requestHandler.conversation.getLatestTurn()?.getMetadata(CopilotInteractiveEditorResponse);
-				intent = (response && response.kind === 'ok' ? response.promptQuery.intent : undefined);
+				intent = (response ? response.promptQuery.intent : undefined);
 			}
 			annotations = annotations.concat(requestHandler.conversation.getLatestTurn()?.getMetadata(InteractionOutcome)?.annotations ?? []);
 


### PR DESCRIPTION
* drive inline chat feedback telemetry from `CopilotInteractiveEditorResponse`
* `CopilotInteractiveEditorResponse.kind` is always 'ok' -> remove it

fixes https://github.com/microsoft/vscode/issues/280959