### PR TITLE
nes: /models: looking up default xtab model uses ModelService AND respects slash models if present

### DIFF
--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -976,10 +976,12 @@ export class XtabProvider implements IStatelessNextEditProvider {
 
 	private determineModelConfiguration(activeDocument: StatelessNextEditDocument): ModelConfig {
 		if (this.forceUseDefaultModel) {
-			return {
+			const defaultOptions = {
 				modelName: undefined,
 				...xtabPromptOptions.DEFAULT_OPTIONS,
 			};
+			const defaultModelConfig = this.modelService.defaultModelConfiguration();
+			return XtabProvider.overrideModelConfig(defaultOptions, defaultModelConfig);
 		}
 
 		const sourcedModelConfig = {

--- a/src/platform/inlineEdits/common/inlineEditsModelService.ts
+++ b/src/platform/inlineEdits/common/inlineEditsModelService.ts
@@ -18,6 +18,8 @@ export interface IInlineEditsModelService {
 	setCurrentModelId(modelId: string): Promise<void>;
 
 	selectedModelConfiguration(): ModelConfiguration;
+
+	defaultModelConfiguration(): ModelConfiguration;
 }
 
 export const IInlineEditsModelService = createServiceIdentifier<IInlineEditsModelService>('IInlineEditsModelService');

--- a/src/platform/inlineEdits/node/inlineEditsModelService.ts
+++ b/src/platform/inlineEdits/node/inlineEditsModelService.ts
@@ -8,7 +8,7 @@ import { filterMap } from '../../../util/common/arrays';
 import * as errors from '../../../util/common/errors';
 import { createTracer } from '../../../util/common/tracing';
 import { pushMany } from '../../../util/vs/base/common/arrays';
-import { softAssert } from '../../../util/vs/base/common/assert';
+import { assertNever, softAssert } from '../../../util/vs/base/common/assert';
 import { Event } from '../../../util/vs/base/common/event';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { derived, IObservable, observableFromEvent } from '../../../util/vs/base/common/observable';
@@ -280,6 +280,31 @@ export class InlineEditsModelService extends Disposable implements IInlineEditsM
 		}
 		tracer.trace('No selected model found, using default model.');
 		return this.determineDefaultModel(this._copilotTokenObs.get(), this._defaultModelConfigObs.get());
+	}
+
+	public defaultModelConfiguration(): ModelConfiguration {
+		const models = this._modelsObs.get();
+		if (models && models.length > 0) {
+			const defaultModels = models.filter(m => !this.isConfiguredModel(m));
+			if (defaultModels.length > 0) {
+				return defaultModels[0];
+			}
+		}
+		return this.determineDefaultModel(this._copilotTokenObs.get(), this._defaultModelConfigObs.get());
+	}
+
+	private isConfiguredModel(model: Model): boolean {
+		switch (model.source) {
+			case ModelSource.LocalConfig:
+			case ModelSource.ExpConfig:
+			case ModelSource.ExpDefaultConfig:
+				return true;
+			case ModelSource.Fetched:
+			case ModelSource.HardCodedDefault:
+				return false;
+			default:
+				assertNever(model.source);
+		}
 	}
 
 	private determineDefaultModel(copilotToken: CopilotToken | undefined, defaultModelConfigString: string | undefined): Model {


### PR DESCRIPTION
based on https://github.com/microsoft/vscode-copilot-chat/pull/2437

fixes https://github.com/microsoft/vscode/issues/281498