### PR TITLE
Copilot CLI - do not open repository to compute worktree statistics

### DIFF
--- a/src/platform/git/common/gitService.ts
+++ b/src/platform/git/common/gitService.ts
@@ -49,7 +49,7 @@ export interface IGitService extends IDisposable {
 	readonly repositories: Array<RepoContext>;
 	readonly isInitialized: boolean;
 
-	getRepository(uri: URI): Promise<RepoContext | undefined>;
+	getRepository(uri: URI, forceOpen?: boolean): Promise<RepoContext | undefined>;
 	getRepositoryFetchUrls(uri: URI): Promise<Pick<RepoContext, 'rootUri' | 'remoteFetchUrls'> | undefined>;
 	initialize(): Promise<void>;
 	add(uri: URI, paths: string[]): Promise<void>;

--- a/src/platform/test/node/simulationWorkspaceServices.ts
+++ b/src/platform/test/node/simulationWorkspaceServices.ts
@@ -674,7 +674,7 @@ export class TestingGitService implements IGitService {
 	}
 
 	// TODO implement later if tests use this, only used by ignore service
-	getRepository(uri: URI): Promise<RepoContext | undefined> {
+	getRepository(uri: URI, forceOpen?: boolean): Promise<RepoContext | undefined> {
 		return Promise.resolve(undefined);
 	}
 


### PR DESCRIPTION
* `getRepository()` waits until the initial repository discovery is complete
* `getRepository()` now takes an option to open the repository if is not found
* Computing worktree statistics takes advantage of the new option to not open a repository if not found