### PR TITLE
nes: joint: fix ghost-text provider returning no-op edits to UI

### DIFF
--- a/src/extension/inlineEdits/vscode-node/jointInlineCompletionProvider.ts
+++ b/src/extension/inlineEdits/vscode-node/jointInlineCompletionProvider.ts
@@ -423,7 +423,7 @@ class JointCompletionsProvider extends Disposable implements vscode.InlineComple
 			tracer.trace(`no last NES suggestion to consider`);
 			const completionsP = this._invokeCompletionsProvider(tracer, document, position, context, tokens, sw);
 			const nesP = this._invokeNESProvider(tracer, document, position, true, context, tokens, sw);
-			return this._returnCompletionsOrOtherwiseNES(completionsP, nesP, sw, tracer, tokens);
+			return this._returnCompletionsOrOtherwiseNES(completionsP, nesP, docSnapshot, sw, tracer, tokens);
 		}
 
 		tracer.trace(`last NES suggestion is for the current document, checking if it agrees with the current suggestion`);
@@ -433,7 +433,7 @@ class JointCompletionsProvider extends Disposable implements vscode.InlineComple
 		if (!nesP) {
 			tracer.trace(`no NES provider`);
 			const completionsP = this._invokeCompletionsProvider(tracer, document, position, context, tokens, sw);
-			return this._returnCompletionsOrOtherwiseNES(completionsP, nesP, sw, tracer, tokens);
+			return this._returnCompletionsOrOtherwiseNES(completionsP, nesP, docSnapshot, sw, tracer, tokens);
 		}
 
 		const NES_CACHE_WAIT_MS = 10;
@@ -494,7 +494,7 @@ class JointCompletionsProvider extends Disposable implements vscode.InlineComple
 		}
 
 		tracer.trace('falling back to the default because completions came first or NES disagreed');
-		return this._returnCompletionsOrOtherwiseNES(completionsP, nesP, sw, tracer, tokens);
+		return this._returnCompletionsOrOtherwiseNES(completionsP, nesP, docSnapshot, sw, tracer, tokens);
 	}
 
 	private _invokeNESProvider(tracer: ITracer, document: vscode.TextDocument, position: vscode.Position, enforceCacheDelay: boolean, context: vscode.InlineCompletionContext, tokens: { coreToken: CancellationToken; completionsCts: CancellationTokenSource; nesCts: CancellationTokenSource }, sw: StopWatch) {
@@ -549,6 +549,7 @@ class JointCompletionsProvider extends Disposable implements vscode.InlineComple
 	private async _returnCompletionsOrOtherwiseNES(
 		completionsP: Promise<vscode.InlineCompletionList | undefined> | undefined,
 		nesP: Promise<NesCompletionList | undefined> | undefined,
+		docSnapshot: StringText,
 		sw: StopWatch,
 		tracer: ITracer,
 		tokens: { coreToken: CancellationToken; completionsCts: CancellationTokenSource; nesCts: CancellationTokenSource },
@@ -559,16 +560,26 @@ class JointCompletionsProvider extends Disposable implements vscode.InlineComple
 		tracer.trace(`completions response received`);
 
 		if (completionsR && completionsR.items.length > 0) {
-			tracer.trace(`using completions response, cancelling NES provider`);
-			return this._returnCompletions(completionsR, { kind: vscode.InlineCompletionsDisposeReasonKind.LostRace }, nesP, sw, tracer, tokens);
+			const filteredCompletionR = JointCompletionsProvider.retainOnlyMeaningfulEdits(docSnapshot, completionsR);
+			if (filteredCompletionR.items.length === 0) {
+				tracer.trace(`all completions edits are no-op, ignoring completions response`);
+			} else {
+				tracer.trace(`using completions response, cancelling NES provider`);
+				return this._returnCompletions(filteredCompletionR, { kind: vscode.InlineCompletionsDisposeReasonKind.LostRace }, nesP, sw, tracer, tokens);
+			}
 		}
 
 		const nesR = nesP ? await nesP : undefined;
 		tracer.trace(`NES response received`);
 
 		if (nesR && nesR.items.length > 0) {
-			tracer.trace(`using NES response`);
-			return this._returnNES(nesR, { kind: vscode.InlineCompletionsDisposeReasonKind.NotTaken }, completionsP, sw, tracer, tokens);
+			const filteredNesR = JointCompletionsProvider.retainOnlyMeaningfulEdits(docSnapshot, nesR);
+			if (filteredNesR.items.length === 0) {
+				tracer.trace(`all NES edits are no-op, ignoring NES response`);
+			} else {
+				tracer.trace(`using NES response`);
+				return this._returnNES(filteredNesR, { kind: vscode.InlineCompletionsDisposeReasonKind.NotTaken }, completionsP, sw, tracer, tokens);
+			}
 		}
 
 		// return empty completions
@@ -611,6 +622,29 @@ class JointCompletionsProvider extends Disposable implements vscode.InlineComple
 		}
 		const applied = applyTextEdit(doc, nesEdit.range, nesEdit.insertText);
 		return applied === docWithNesEditApplied.getValue();
+	}
+
+	private static retainOnlyMeaningfulEdits<T extends vscode.InlineCompletionList>(docSnapshot: StringText, list: T): T {
+		// meaningful = not noop
+		function isMeaningfulEdit(item: vscode.InlineCompletionItem): boolean {
+			if (item.range === undefined || // must be a completion with a side-effect, eg a command invocation or something
+				typeof item.insertText !== 'string' // shouldn't happen
+			) {
+				return true;
+			}
+			const originalSnippet = docSnapshot.getValueOfRange(new Range(
+				item.range.start.line + 1,
+				item.range.start.character + 1,
+				item.range.end.line + 1,
+				item.range.end.character + 1,
+			));
+			return originalSnippet !== item.insertText;
+		}
+		const filteredEdits = list.items.filter(isMeaningfulEdit);
+		if (filteredEdits.length === list.items.length) {
+			return list;
+		}
+		return { ...list, items: filteredEdits };
 	}
 
 	public handleDidShowCompletionItem?(completionItem: SingularCompletionItem, updatedInsertText: string): void {


### PR DESCRIPTION
this would sometimes prevent good NES edits from being shown

based on https://github.com/microsoft/vscode-copilot-chat/pull/2478