### PR TITLE
Fix test warnings

### DIFF
--- a/src/extension/conversation/vscode-node/test/conversationFeature.test.ts
+++ b/src/extension/conversation/vscode-node/test/conversationFeature.test.ts
@@ -9,7 +9,7 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { IAuthenticationService } from '../../../../platform/authentication/common/authentication';
 import { CopilotToken } from '../../../../platform/authentication/common/copilotToken';
-import { setCopilotToken } from '../../../../platform/authentication/common/staticGitHubAuthenticationService';
+import { setCopilotToken, StaticGitHubAuthenticationService } from '../../../../platform/authentication/common/staticGitHubAuthenticationService';
 import { FailingDevContainerConfigurationService, IDevContainerConfigurationService } from '../../../../platform/devcontainer/common/devContainerConfigurationService';
 import { ICombinedEmbeddingIndex, VSCodeCombinedIndexImpl } from '../../../../platform/embeddings/common/vscodeIndex';
 import { IVSCodeExtensionContext } from '../../../../platform/extContext/common/extensionContext';
@@ -39,6 +39,8 @@ suite('Conversation feature test suite', function () {
 		testingServiceCollection.define(IIntentService, new SyncDescriptor(IntentService));
 		testingServiceCollection.define(ISettingsEditorSearchService, new SyncDescriptor(NoopSettingsEditorSearchService));
 		testingServiceCollection.define(IMergeConflictService, new SyncDescriptor(TestMergeConflictServiceImpl));
+		// We don't need auth in these tests
+		testingServiceCollection.define(IAuthenticationService, new SyncDescriptor(StaticGitHubAuthenticationService, [() => undefined]));
 
 		accessor = testingServiceCollection.createTestingAccessor();
 		instaService = accessor.get(IInstantiationService);

--- a/src/extension/test/vscode-node/services.ts
+++ b/src/extension/test/vscode-node/services.ts
@@ -87,6 +87,7 @@ import { ITokenizerProvider, TokenizerProvider } from '../../../platform/tokeniz
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
 import { ExtensionTextDocumentManager } from '../../../platform/workspace/vscode/workspaceServiceImpl';
 import { GithubAvailableEmbeddingTypesService, IGithubAvailableEmbeddingTypesService } from '../../../platform/workspaceChunkSearch/common/githubAvailableEmbeddingTypes';
+import { IRerankerService, RerankerService } from '../../../platform/workspaceChunkSearch/common/rerankerService';
 import { SyncDescriptor } from '../../../util/vs/platform/instantiation/common/descriptors';
 import { CommandServiceImpl, ICommandService } from '../../commands/node/commandService';
 import { ICopilotInlineCompletionItemProviderService, NullCopilotInlineCompletionItemProviderService } from '../../completions/common/copilotInlineCompletionItemProviderService';
@@ -194,6 +195,7 @@ export function createExtensionTestingServices(): TestingServiceCollection {
 	testingServiceCollection.define(IProxyModelsService, new SyncDescriptor(NullProxyModelsService));
 	testingServiceCollection.define(IInlineEditsModelService, new SyncDescriptor(InlineEditsModelService));
 	testingServiceCollection.define(ICopilotInlineCompletionItemProviderService, new SyncDescriptor(NullCopilotInlineCompletionItemProviderService));
+	testingServiceCollection.define(IRerankerService, new SyncDescriptor(RerankerService));
 
 	return testingServiceCollection;
 }


### PR DESCRIPTION
Two things that we saw a lot of:

* `[createInstance] SemanticSearchTextSearchProvider depends on UNKNOWN service IRerankerService`
* `Error: Tests: either GITHUB_PAT, GITHUB_OAUTH_TOKEN, or GITHUB_OAUTH_TOKEN+VSCODE_COPILOT_CHAT_TOKEN must be set unless running from an IS_SCENARIO_AUTOMATION environment. Run "npm run get_token" to get credentials.
	at StaticGitHubAuthenticationService.tokenProvider (/mnt/vss/_work/1/s/dist/test-extension.js:53806:11)`

So I:
* registed the rerankerservice
* registered a null auth service

Fixes https://github.com/microsoft/vscode-copilot/issues/18514