### PR TITLE
Fix NESProvider in chat-lib

### DIFF
--- a/src/extension/extension/vscode-node/services.ts
+++ b/src/extension/extension/vscode-node/services.ts
@@ -34,8 +34,8 @@ import { IIgnoreService, NullIgnoreService } from '../../../platform/ignore/comm
 import { VsCodeIgnoreService } from '../../../platform/ignore/vscode-node/ignoreService';
 import { IImageService } from '../../../platform/image/common/imageService';
 import { ImageServiceImpl } from '../../../platform/image/node/imageServiceImpl';
-import { IInlineEditsModelService } from '../../../platform/inlineEdits/common/inlineEditsModelService';
-import { InlineEditsModelService } from '../../../platform/inlineEdits/node/inlineEditsModelService';
+import { IInlineEditsModelService, IUndesiredModelsManager } from '../../../platform/inlineEdits/common/inlineEditsModelService';
+import { InlineEditsModelService, UndesiredModels } from '../../../platform/inlineEdits/node/inlineEditsModelService';
 import { ILanguageContextProviderService } from '../../../platform/languageContextProvider/common/languageContextProviderService';
 import { ILanguageContextService } from '../../../platform/languageServer/common/languageContextService';
 import { ICompletionsFetchService } from '../../../platform/nesFetch/common/completionsFetchService';
@@ -75,6 +75,8 @@ import { IWorkspaceFileIndex, WorkspaceFileIndex } from '../../../platform/works
 import { IInstantiationServiceBuilder } from '../../../util/common/services';
 import { SyncDescriptor } from '../../../util/vs/platform/instantiation/common/descriptors';
 import { CommandServiceImpl, ICommandService } from '../../commands/node/commandService';
+import { ICopilotInlineCompletionItemProviderService } from '../../completions/common/copilotInlineCompletionItemProviderService';
+import { CopilotInlineCompletionItemProviderService } from '../../completions/vscode-node/copilotInlineCompletionItemProviderService';
 import { ApiEmbeddingsIndex, IApiEmbeddingsIndex } from '../../context/node/resolvers/extensionApi';
 import { IPromptWorkspaceLabels, PromptWorkspaceLabels } from '../../context/node/resolvers/promptWorkspaceLabels';
 import { ChatAgentService } from '../../conversation/vscode-node/chatParticipants';
@@ -111,8 +113,6 @@ import { LanguageContextServiceImpl } from '../../typescriptContext/vscode-node/
 import { IWorkspaceListenerService } from '../../workspaceRecorder/common/workspaceListenerService';
 import { WorkspacListenerService } from '../../workspaceRecorder/vscode-node/workspaceListenerService';
 import { registerServices as registerCommonServices } from '../vscode/services';
-import { ICopilotInlineCompletionItemProviderService } from '../../completions/common/copilotInlineCompletionItemProviderService';
-import { CopilotInlineCompletionItemProviderService } from '../../completions/vscode-node/copilotInlineCompletionItemProviderService';
 
 // ###########################################################################################
 // ###                                                                                     ###
@@ -212,6 +212,7 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 	builder.define(IRerankerService, new SyncDescriptor(RerankerService));
 	builder.define(IProxyModelsService, new SyncDescriptor(ProxyModelsService));
 	builder.define(IInlineEditsModelService, new SyncDescriptor(InlineEditsModelService));
+	builder.define(IUndesiredModelsManager, new SyncDescriptor(UndesiredModels.Manager));
 	builder.define(ICopilotInlineCompletionItemProviderService, new SyncDescriptor(CopilotInlineCompletionItemProviderService));
 }
 

--- a/src/extension/test/node/services.ts
+++ b/src/extension/test/node/services.ts
@@ -19,8 +19,8 @@ import { IGitExtensionService } from '../../../platform/git/common/gitExtensionS
 import { IGitService } from '../../../platform/git/common/gitService';
 import { NullGitDiffService } from '../../../platform/git/common/nullGitDiffService';
 import { NullGitExtensionService } from '../../../platform/git/common/nullGitExtensionService';
-import { IInlineEditsModelService } from '../../../platform/inlineEdits/common/inlineEditsModelService';
-import { InlineEditsModelService } from '../../../platform/inlineEdits/node/inlineEditsModelService';
+import { IInlineEditsModelService, IUndesiredModelsManager } from '../../../platform/inlineEdits/common/inlineEditsModelService';
+import { InlineEditsModelService, UndesiredModels } from '../../../platform/inlineEdits/node/inlineEditsModelService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { EditLogService, IEditLogService } from '../../../platform/multiFileEdit/common/editLogService';
 import { IMultiFileEditInternalTelemetryService, MultiFileEditInternalTelemetryService } from '../../../platform/multiFileEdit/common/multiFileEditQualityTelemetry';
@@ -99,6 +99,7 @@ export function createExtensionUnitTestingServices(disposables: Pick<DisposableS
 	testingServiceCollection.define(IEditLogService, new SyncDescriptor(EditLogService));
 	testingServiceCollection.define(IProxyModelsService, new SyncDescriptor(NullProxyModelsService));
 	testingServiceCollection.define(IInlineEditsModelService, new SyncDescriptor(InlineEditsModelService));
+	testingServiceCollection.define(IUndesiredModelsManager, new SyncDescriptor(UndesiredModels.Manager));
 	testingServiceCollection.define(IMultiFileEditInternalTelemetryService, new SyncDescriptor(MultiFileEditInternalTelemetryService));
 	testingServiceCollection.define(ICodeMapperService, new SyncDescriptor(CodeMapperService));
 	testingServiceCollection.define(IAlternativeNotebookContentService, new SyncDescriptor(SimulationAlternativeNotebookContentService));

--- a/src/extension/test/vscode-node/services.ts
+++ b/src/extension/test/vscode-node/services.ts
@@ -43,8 +43,8 @@ import { IOctoKitService } from '../../../platform/github/common/githubService';
 import { OctoKitService } from '../../../platform/github/common/octoKitServiceImpl';
 import { IIgnoreService, NullIgnoreService } from '../../../platform/ignore/common/ignoreService';
 import { IImageService, nullImageService } from '../../../platform/image/common/imageService';
-import { IInlineEditsModelService } from '../../../platform/inlineEdits/common/inlineEditsModelService';
-import { InlineEditsModelService } from '../../../platform/inlineEdits/node/inlineEditsModelService';
+import { IInlineEditsModelService, IUndesiredModelsManager } from '../../../platform/inlineEdits/common/inlineEditsModelService';
+import { InlineEditsModelService, UndesiredModels } from '../../../platform/inlineEdits/node/inlineEditsModelService';
 import { ILanguageDiagnosticsService } from '../../../platform/languages/common/languageDiagnosticsService';
 import { ILanguageFeaturesService, NoopLanguageFeaturesService } from '../../../platform/languages/common/languageFeaturesService';
 import { LanguageDiagnosticsServiceImpl } from '../../../platform/languages/vscode/languageDiagnosticsServiceImpl';
@@ -194,6 +194,7 @@ export function createExtensionTestingServices(): TestingServiceCollection {
 	testingServiceCollection.define(IGithubAvailableEmbeddingTypesService, new SyncDescriptor(GithubAvailableEmbeddingTypesService));
 	testingServiceCollection.define(IProxyModelsService, new SyncDescriptor(NullProxyModelsService));
 	testingServiceCollection.define(IInlineEditsModelService, new SyncDescriptor(InlineEditsModelService));
+	testingServiceCollection.define(IUndesiredModelsManager, new SyncDescriptor(UndesiredModels.Manager));
 	testingServiceCollection.define(ICopilotInlineCompletionItemProviderService, new SyncDescriptor(NullCopilotInlineCompletionItemProviderService));
 	testingServiceCollection.define(IRerankerService, new SyncDescriptor(RerankerService));
 

--- a/src/lib/node/chatLibMain.ts
+++ b/src/lib/node/chatLibMain.ts
@@ -80,7 +80,7 @@ import { NullGitExtensionService } from '../../platform/git/common/nullGitExtens
 import { IIgnoreService, NullIgnoreService } from '../../platform/ignore/common/ignoreService';
 import { DocumentId } from '../../platform/inlineEdits/common/dataTypes/documentId';
 import { InlineEditRequestLogContext } from '../../platform/inlineEdits/common/inlineEditLogContext';
-import { IInlineEditsModelService } from '../../platform/inlineEdits/common/inlineEditsModelService';
+import { IInlineEditsModelService, IUndesiredModelsManager, NullUndesiredModelsManager } from '../../platform/inlineEdits/common/inlineEditsModelService';
 import { ObservableGit } from '../../platform/inlineEdits/common/observableGit';
 import { IObservableDocument, ObservableWorkspace } from '../../platform/inlineEdits/common/observableWorkspace';
 import { NesHistoryContextProvider } from '../../platform/inlineEdits/common/workspaceEditTracker/nesHistoryContextProvider';
@@ -175,6 +175,7 @@ export interface INESProviderOptions {
 	 * INESProvider.updateTreatmentVariables() must be called to unblock.
 	 */
 	readonly waitForTreatmentVariables?: boolean;
+	readonly undesiredModelsManager?: IUndesiredModelsManager;
 }
 
 export interface INESResult {
@@ -373,6 +374,7 @@ function setupServices(options: INESProviderOptions) {
 	});
 	builder.define(IProxyModelsService, new SyncDescriptor(ProxyModelsService));
 	builder.define(IInlineEditsModelService, new SyncDescriptor(InlineEditsModelService));
+	builder.define(IUndesiredModelsManager, options.undesiredModelsManager || new SyncDescriptor(NullUndesiredModelsManager));
 	return builder.seal();
 }
 

--- a/src/platform/inlineEdits/common/inlineEditsModelService.ts
+++ b/src/platform/inlineEdits/common/inlineEditsModelService.ts
@@ -23,3 +23,26 @@ export interface IInlineEditsModelService {
 }
 
 export const IInlineEditsModelService = createServiceIdentifier<IInlineEditsModelService>('IInlineEditsModelService');
+
+export interface IUndesiredModelsManager {
+	readonly _serviceBrand: undefined;
+	isUndesiredModelId(modelId: string): boolean;
+	addUndesiredModelId(modelId: string): Promise<void>;
+	removeUndesiredModelId(modelId: string): Promise<void>;
+}
+
+export const IUndesiredModelsManager = createServiceIdentifier<IUndesiredModelsManager>('IUndesiredModelsManager');
+
+export class NullUndesiredModelsManager implements IUndesiredModelsManager {
+	declare _serviceBrand: undefined;
+
+	isUndesiredModelId(_modelId: string): boolean {
+		return false;
+	}
+	addUndesiredModelId(_modelId: string): Promise<void> {
+		return Promise.resolve();
+	}
+	removeUndesiredModelId(_modelId: string): Promise<void> {
+		return Promise.resolve();
+	}
+}

--- a/src/platform/inlineEdits/node/inlineEditsModelService.ts
+++ b/src/platform/inlineEdits/node/inlineEditsModelService.ts
@@ -22,7 +22,7 @@ import { IExperimentationService } from '../../telemetry/common/nullExperimentat
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { WireTypes } from '../common/dataTypes/inlineEditsModelsTypes';
 import { isPromptingStrategy, ModelConfiguration, PromptingStrategy } from '../common/dataTypes/xtabPromptOptions';
-import { IInlineEditsModelService } from '../common/inlineEditsModelService';
+import { IInlineEditsModelService, IUndesiredModelsManager } from '../common/inlineEditsModelService';
 
 const enum ModelSource {
 	LocalConfig = 'localConfig',
@@ -80,12 +80,10 @@ export class InlineEditsModelService extends Disposable implements IInlineEditsM
 
 	private _tracer = createTracer(['NES', 'ModelsService'], (msg) => this._logService.trace(msg));
 
-	private _undesiredModelsManager: UndesiredModels.Manager;
-
 	constructor(
 		@ICopilotTokenStore private readonly _tokenStore: ICopilotTokenStore,
 		@IProxyModelsService private readonly _proxyModelsService: IProxyModelsService,
-		@IVSCodeExtensionContext private readonly _vscodeExtensionContext: IVSCodeExtensionContext,
+		@IUndesiredModelsManager private readonly _undesiredModelsManager: IUndesiredModelsManager,
 		@IConfigurationService private readonly _configService: IConfigurationService,
 		@IExperimentationService private readonly _expService: IExperimentationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
@@ -94,8 +92,6 @@ export class InlineEditsModelService extends Disposable implements IInlineEditsM
 		super();
 
 		const tracer = this._tracer.sub('constructor');
-
-		this._undesiredModelsManager = new UndesiredModels.Manager(this._vscodeExtensionContext);
 
 		this._modelsObs = derived((reader) => {
 			tracer.trace('computing models');
@@ -392,15 +388,16 @@ export class InlineEditsModelService extends Disposable implements IInlineEditsM
 	}
 }
 
-namespace UndesiredModels {
+export namespace UndesiredModels {
 
 	const UNDESIRED_MODELS_KEY = 'copilot.chat.nextEdits.undesiredModelIds';
 	type UndesiredModelsValue = string[];
 
-	export class Manager {
+	export class Manager implements IUndesiredModelsManager {
+		declare _serviceBrand: undefined;
 
 		constructor(
-			private readonly _vscodeExtensionContext: IVSCodeExtensionContext,
+			@IVSCodeExtensionContext private readonly _vscodeExtensionContext: IVSCodeExtensionContext,
 		) {
 		}
 
@@ -439,3 +436,4 @@ namespace UndesiredModels {
 		}
 	}
 }
+


### PR DESCRIPTION
The addition of the `IVSCodeExtensionContext` dependency in `InlineEditsModelService` causes `NESProvider` in chat-lib to break (and publishing to fail) because of the missing dependency that shows up in a failing test:

<img width="916" height="483" alt="Screenshot 2025-12-08 at 11 14 44" src="https://github.com/user-attachments/assets/c5f72dca-c6b1-4533-a344-e7e712a5658e" />

Can we do this to get `NESProvider` working again (and with the option for library users to provide an implementation if they choose)?
