### PR TITLE
fix: improve Markdown formatting instructions for system prompts

### DIFF
--- a/src/extension/prompts/node/agent/openai/gpt51Prompt.tsx
+++ b/src/extension/prompts/node/agent/openai/gpt51Prompt.tsx
@@ -185,10 +185,10 @@ class Gpt51Prompt extends PromptElement<DefaultAgentPromptProps> {
 				The messages you send before tool calls should describe what is immediately about to be done next in very concise language. If there was previous work done, this preamble message should also include a note about the work done so far to bring the user along.
 			</Tag>
 			<Tag name='special_formatting'>
-				When referring to a filename or symbol in the user's workspace, wrap it in backticks.<br />
-				<Tag name='example'>
-					The class `Person` is in `src/models/person.ts`.
-				</Tag>
+				Use proper Markdown formatting:
+				- Wrap symbol names (classes, methods, variables) in backticks: `MyClass`, `handleClick()`<br />
+				- When mentioning files or line numbers, always follow the rules in fileLinkification section below:
+				<FileLinkificationInstructions />
 				<MathIntegrationRules />
 			</Tag>
 			{this.props.availableTools && <McpToolInstructions tools={this.props.availableTools} />}
@@ -262,7 +262,6 @@ class Gpt51Prompt extends PromptElement<DefaultAgentPromptProps> {
 				Generally, ensure your final answers adapt their shape and depth to the request. For example, answers to code explanations should have a precise, structured explanation with code references that answer the question directly. For tasks with a simple implementation, lead with the outcome and supplement only with what's needed for clarity. Larger changes can be presented as a logical walkthrough of your approach, grouping related steps, explaining rationale where it adds value, and highlighting next actions to accelerate the user. Your answers should provide the right level of detail while being easily scannable.<br />
 				<br />
 				For casual greetings, acknowledgements, or other one-off conversational messages that are not delivering substantive information or structured results, respond naturally without section headers or bullet formatting.
-				<FileLinkificationInstructions />
 			</Tag>
 			<ResponseTranslationRules />
 		</InstructionMessage >;

--- a/src/extension/prompts/node/agent/openai/gpt5CodexPrompt.tsx
+++ b/src/extension/prompts/node/agent/openai/gpt5CodexPrompt.tsx
@@ -63,7 +63,7 @@ class CodexStyleGpt5CodexPrompt extends PromptElement<DefaultAgentPromptProps> {
 			* If there are natural next steps the user may want to take, suggest them at the end of your response. Do not make suggestions if there are no natural next steps.<br />
 			* When suggesting multiple options, use numeric lists for the suggestions so the user can quickly respond with a single number.<br />
 			- The user does not command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.<br />
-			- Use proper Markdown formatting in your answers. When referring to a filename or symbol in the user's workspace, wrap it in backticks.<br />
+			- Use proper Markdown formatting in your answers.<br />
 			<br />
 			### Final answer structure and style guidelines<br />
 			<br />

--- a/src/extension/prompts/node/agent/openai/gpt5Prompt.tsx
+++ b/src/extension/prompts/node/agent/openai/gpt5Prompt.tsx
@@ -294,7 +294,6 @@ class Gpt5ReminderInstructions extends PromptElement<ReminderInstructionsProps> 
 				Do NOT volunteer your model name unless the user explicitly asks you about it. <br />
 				{this.props.hasTodoTool && <>You MUST use the todo list tool to plan and track your progress. NEVER skip this step, and START with this step whenever the task is multi-step. This is essential for maintaining visibility and proper execution of large tasks.<br /></>}
 				{!this.props.hasTodoTool && <>Break down the request into clear, actionable steps and present them at the beginning of your response before proceeding with implementation. This helps maintain visibility and ensures all requirements are addressed systematically.<br /></>}
-				When referring to a filename or symbol in the user's workspace, wrap it in backticks.<br />
 			</Tag>
 		</>;
 	}


### PR DESCRIPTION
fix: improve Markdown formatting instructions for system prompts. Fix https://github.com/microsoft/vscode/issues/283488

The new prompt copied from https://github.com/microsoft/vscode-copilot-chat/blob/fcf50dfbb37968a3af38ae9c0bf3431f24c3c9bb/src/extension/prompts/node/agent/openai/gpt51CodexPrompt.tsx#L110-L116