### PR TITLE
Speculative requests for chat-lib

### DIFF
--- a/chat-lib/test/getInlineCompletions.spec.ts
+++ b/chat-lib/test/getInlineCompletions.spec.ts
@@ -28,6 +28,8 @@ import { ChatRequest } from '../src/_internal/vscodeTypes';
 import { createInlineCompletionsProvider, IActionItem, IAuthenticationService, ICompletionsStatusChangedEvent, ICompletionsTextDocumentManager, IEndpointProvider, ILogTarget, ITelemetrySender, LogLevel } from '../src/main';
 
 class TestFetcher implements IFetcher {
+	private _fetched = new Map<string, number>();
+
 	constructor(private readonly responses: Record<string, string>) { }
 
 	getUserAgentLibrary(): string {
@@ -36,6 +38,7 @@ class TestFetcher implements IFetcher {
 
 	async fetch(url: string, options: FetchOptions): Promise<Response> {
 		const uri = URI.parse(url);
+		this._markFetched(uri.path);
 		const responseText = this.responses[uri.path];
 
 		const headers = new class implements IHeaders {
@@ -57,6 +60,15 @@ class TestFetcher implements IFetcher {
 			async () => stream.Readable.from([responseText || '']),
 			'node-http'
 		);
+	}
+
+	private _markFetched(urlPath: string): void {
+		const count = this.fetchCount(urlPath);
+		this._fetched.set(urlPath, count + 1);
+	}
+
+	fetchCount(urlPath: string): number {
+		return this._fetched.get(urlPath) || 0;
 	}
 
 	fetchWithPagination<T>(baseUrl: string, options: PaginationOptions<T>): Promise<T[]> {
@@ -199,9 +211,14 @@ class NullLogTarget implements ILogTarget {
 }
 
 describe('getInlineCompletions', () => {
-	it('should return completions for a document and position', async () => {
-		const provider = createInlineCompletionsProvider({
-			fetcher: new TestFetcher({ '/v1/engines/gpt-41-copilot/completions': await readFile(join(__dirname, 'getInlineCompletions.reply.txt'), 'utf8') }),
+	const completionsPath = '/v1/engines/gpt-41-copilot/completions';
+	let fetcher: TestFetcher;
+
+	async function getCompletionsProvider() {
+		fetcher = new TestFetcher({ [completionsPath]: await readFile(join(__dirname, 'getInlineCompletions.reply.txt'), 'utf8') });
+
+		return createInlineCompletionsProvider({
+			fetcher,
 			authService: new TestAuthService(),
 			telemetrySender: new TestTelemetrySender(),
 			logTarget: new NullLogTarget(),
@@ -225,6 +242,10 @@ describe('getInlineCompletions', () => {
 			},
 			endpointProvider: new TestEndpointProvider(),
 		});
+	}
+
+	it('should return completions for a document and position', async () => {
+		const provider = await getCompletionsProvider();
 		const doc = createTextDocument('file:///test.txt', 'javascript', 1, 'function main() {\n\n}\n');
 
 		const result = await provider.getInlineCompletions(doc, { line: 1, character: 0 });
@@ -233,5 +254,19 @@ describe('getInlineCompletions', () => {
 		expect(result.length).toBe(1);
 		expect(result[0].resultType).toBe(ResultType.Async);
 		expect(result[0].displayText).toBe('  console.log("Hello, World!");');
+	});
+
+	it('makes any pending speculative requests when a completion is shown', async () => {
+		const provider = await getCompletionsProvider();
+		const doc = createTextDocument('file:///test.txt', 'javascript', 1, 'function main() {\n\n}\n');
+
+		const result = await provider.getInlineCompletions(doc, { line: 1, character: 0 });
+
+		assert(result);
+		expect(result.length).toBe(1);
+
+		await provider.inlineCompletionShown(result[0].clientCompletionId);
+
+		expect(fetcher.fetchCount(completionsPath)).toBe(2);
 	});
 });

--- a/src/lib/node/chatLibMain.ts
+++ b/src/lib/node/chatLibMain.ts
@@ -626,6 +626,7 @@ export type IGetInlineCompletionsOptions = Exclude<Partial<GetGhostTextOptions>,
 export interface IInlineCompletionsProvider {
 	updateTreatmentVariables(variables: Record<string, boolean | number | string>): void;
 	getInlineCompletions(textDocument: ITextDocument, position: Position, token?: CancellationToken, options?: IGetInlineCompletionsOptions): Promise<CopilotCompletion[] | undefined>;
+	inlineCompletionShown(completionId: string): Promise<void>;
 	dispose(): void;
 }
 
@@ -639,6 +640,7 @@ class InlineCompletionsProvider extends Disposable implements IInlineCompletions
 	constructor(
 		@IInstantiationService private _insta: IInstantiationService,
 		@IExperimentationService private readonly _expService: IExperimentationService,
+		@ICompletionsSpeculativeRequestCache private readonly _speculativeRequestCache: ICompletionsSpeculativeRequestCache,
 
 	) {
 		super();
@@ -653,6 +655,10 @@ class InlineCompletionsProvider extends Disposable implements IInlineCompletions
 
 	async getInlineCompletions(textDocument: ITextDocument, position: Position, token?: CancellationToken, options?: IGetInlineCompletionsOptions): Promise<CopilotCompletion[] | undefined> {
 		return await this._insta.invokeFunction(getInlineCompletions, textDocument, position, token, options);
+	}
+
+	async inlineCompletionShown(completionId: string): Promise<void> {
+		return await this._speculativeRequestCache.request(completionId);
 	}
 }
 


### PR DESCRIPTION
Speculative requests for inline completions are only initiated once the completion is shown to the user.

Currently there is no way in chat-lib to indicate that a completion has been shown, which means no speculative requests are issued. This adds a method for indicating a completion has been shown, which in turn sends any pending speculative request.
