### PR TITLE
Include error in telemetry and separate `FailedToGetToken` into `RequestFailed` and `ParseFailed`

### DIFF
--- a/src/platform/authentication/common/copilotToken.ts
+++ b/src/platform/authentication/common/copilotToken.ts
@@ -289,7 +289,22 @@ export type ExtendedTokenInfo = TokenInfo & { username: string; isVscodeTeamMemb
 
 export type TokenEnvelope = Omit<TokenInfo, 'token' | 'organization_list'>;
 
-export type TokenErrorReason = 'NotAuthorized' | 'FailedToGetToken' | 'TokenInvalid' | 'GitHubLoginFailed' | 'HTTP401' | 'RateLimited';
+/**
+ * Reasons for token retrieval failures.
+ */
+export type TokenErrorReason =
+	/** User doesn't have Copilot access or authorization failed. Includes detailed error_details from server with notification_id specifying the specific authorization issue. */
+	'NotAuthorized' |
+	/** Network request failed - no response received from the server (connection failed, endpoint unreachable, etc.). */
+	'RequestFailed' |
+	/** Server response could not be parsed as JSON (malformed or unexpected response format). */
+	'ParseFailed' |
+	/** User not authenticated with GitHub through VS Code. Only returned from VS Code integration layer, not from platform token minting. */
+	'GitHubLoginFailed' |
+	/** Server returned 401 Unauthorized HTTP status. */
+	'HTTP401' |
+	/** GitHub API rate limit exceeded (403 status with rate limit message). */
+	'RateLimited';
 
 export enum TokenErrorNotificationId {
 	EnterPriseManagedUserAccount = 'enterprise_managed_user_account',

--- a/src/platform/authentication/node/copilotTokenManager.ts
+++ b/src/platform/authentication/node/copilotTokenManager.ts
@@ -154,7 +154,7 @@ export abstract class BaseCopilotTokenManager extends Disposable implements ICop
 		if (!response) {
 			this._logService.warn('Failed to get copilot token');
 			this._telemetryService.sendGHTelemetryErrorEvent('auth.request_failed');
-			return { kind: 'failure', reason: 'FailedToGetToken' };
+			return { kind: 'failure', reason: 'RequestFailed' };
 		}
 
 		// FIXME: Unverified type after inputting response
@@ -162,7 +162,7 @@ export abstract class BaseCopilotTokenManager extends Disposable implements ICop
 		if (!tokenInfo) {
 			this._logService.warn('Failed to get copilot token');
 			this._telemetryService.sendGHTelemetryErrorEvent('auth.request_read_failed');
-			return { kind: 'failure', reason: 'FailedToGetToken' };
+			return { kind: 'failure', reason: 'ParseFailed' };
 		}
 
 		if (response.status === 401) {

--- a/src/platform/authentication/vscode-node/copilotTokenManager.ts
+++ b/src/platform/authentication/vscode-node/copilotTokenManager.ts
@@ -90,6 +90,7 @@ export class VSCodeCopilotTokenManager extends BaseCopilotTokenManager {
 
 	private async _authShowWarnings(): Promise<ExtendedTokenInfo> {
 		const tokenResult = await this._taskSingler.getOrCreate('auth', () => this._auth());
+		this.sendTokenResultErrorTelemetry(tokenResult);
 
 		if (tokenResult.kind === 'failure' && tokenResult.reason === 'NotAuthorized') {
 			const message = tokenResult.message;
@@ -127,7 +128,7 @@ export class VSCodeCopilotTokenManager extends BaseCopilotTokenManager {
 		}
 
 		if (tokenResult.kind === 'failure') {
-			throw Error('Failed to get copilot token');
+			throw Error('Failed to get copilot token. reason: ' + tokenResult.reason);
 		}
 
 		if (tokenResult.kind === 'success' && tokenResult.chat_enabled === false) {
@@ -135,5 +136,24 @@ export class VSCodeCopilotTokenManager extends BaseCopilotTokenManager {
 		}
 
 		return tokenResult;
+	}
+
+	private sendTokenResultErrorTelemetry(tokenResult: TokenInfoOrError): void {
+		if (tokenResult.kind === 'success') {
+			return;
+		}
+
+		/* __GDPR__
+			"copilotTokenFetching.error" : {
+				"owner": "TylerLeonhardt",
+				"comment": "Report on the frequency of token retrieval failures.",
+				"reason": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "The reason for the token retrieval failure" },
+				"notification_id": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "The notification ID associated with the failure, if any" }
+			}
+		*/
+		this._telemetryService.sendMSFTTelemetryEvent('copilotTokenFetching.error', {
+			reason: tokenResult.reason,
+			notification_id: tokenResult.notification_id,
+		});
 	}
 }


### PR DESCRIPTION
Hopefully to help us get to the bottom of issues like https://github.com/microsoft/vscode/issues/284350