### PR TITLE
Remove maxComputationTimeMs timeout in diff computation

### DIFF
--- a/src/extension/tools/node/editFileToolUtils.tsx
+++ b/src/extension/tools/node/editFileToolUtils.tsx
@@ -105,7 +105,7 @@ export async function formatDiffAsUnified(accessor: ServicesAccessor, uri: URI, 
 	const diffService = accessor.get(IDiffService);
 	const diff = await diffService.computeDiff(oldContent, newContent, {
 		ignoreTrimWhitespace: false,
-		maxComputationTimeMs: 20000,
+		// maxComputationTimeMs: 20000,
 		computeMoves: false,
 	});
 


### PR DESCRIPTION
This change comments out the `maxComputationTimeMs: 20000` timeout in the `diffService.computeDiff` call within `src/extension/tools/node/editFileToolUtils.tsx`. 

The timeout was limiting diff computations for large files. By removing it, the diff can compute fully without timing out.

This addresses performance issues with large file diffs in the VS Code Copilot Chat extension.