### PR TITLE
Increase diff computation timeout and add quitEarly handling

### DIFF
--- a/src/extension/tools/node/editFileToolUtils.tsx
+++ b/src/extension/tools/node/editFileToolUtils.tsx
@@ -105,9 +105,13 @@ export async function formatDiffAsUnified(accessor: ServicesAccessor, uri: URI, 
 	const diffService = accessor.get(IDiffService);
 	const diff = await diffService.computeDiff(oldContent, newContent, {
 		ignoreTrimWhitespace: false,
-		maxComputationTimeMs: 20000,
+		maxComputationTimeMs: 60000, // Increased timeout to allow more time for large diffs
 		computeMoves: false,
 	});
+
+	if (diff.quitEarly) {
+		return 'Diff computation timed out for large file changes. Consider making smaller edits.';
+	}
 
 	const result: string[] = [
 		'```diff:' + getLanguageId(uri),


### PR DESCRIPTION
## Summary
This PR addresses timeout issues when computing diffs for large files in the VS Code Copilot chat extension.

## Changes
- Increased `maxComputationTimeMs` from 20 seconds to 60 seconds to allow more time for large file diffs
- Added `diff.quitEarly` check to provide user feedback if computation still times out
- Maintains protection against indefinite UI hangs while enabling larger diff operations

## Why This Change
- Large file edits were timing out at 20 seconds
- Setting timeout to 0 (infinite) could cause UI freezes
- 60-second timeout provides a good balance
- Graceful error handling informs users when diffs are too large  
<img width="438" height="697" alt="image" src="https://github.com/user-attachments/assets/ec9ac67b-0d68-41be-818a-0db5c6ba49a9" />
 