### PR TITLE
Use correct reduced toolset, not full toolset, when computing tool tokens

### DIFF
--- a/src/extension/intents/node/agentIntent.ts
+++ b/src/extension/intents/node/agentIntent.ts
@@ -204,7 +204,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 			variables = new ChatVariablesCollection([...this.request.references, ...toolReferences]);
 		}
 
-		const tools = await this.getAvailableTools();
+		const tools = promptContext.tools?.availableTools;
 		const toolTokens = tools?.length ? await this.endpoint.acquireTokenizer().countToolTokens(tools) : 0;
 
 		const summarizeThresholdOverride = this.configurationService.getConfig<number | undefined>(ConfigKey.Advanced.SummarizeAgentConversationHistoryThreshold);


### PR DESCRIPTION
This would cause us to reserve too much of the context window and summarize more often, when there are a very large number of tools present. Fix microsoft/vscode#278935