### PR TITLE
Override ApplicationInsights proxy support

### DIFF
--- a/.esbuild.ts
+++ b/.esbuild.ts
@@ -45,7 +45,10 @@ const baseNodeBuildOptions = {
 	platform: 'node',
 	mainFields: ["module", "main"], // needed for jsonc-parser,
 	define: {
-		'process.env.APPLICATIONINSIGHTS_CONFIGURATION_CONTENT': '"{}"'
+		'process.env.APPLICATIONINSIGHTS_CONFIGURATION_CONTENT': JSON.stringify(JSON.stringify({
+			proxyHttpUrl: "",
+			proxyHttpsUrl: ""
+		}))
 	},
 } satisfies esbuild.BuildOptions;
 


### PR DESCRIPTION
* AppInsights adds its proxy support here: https://github.com/microsoft/ApplicationInsights-node.js/blob/20fbcb87ff9c361cf5fdfe0e500f857c7c813373/Library/Util.ts#L321
* They use the env variables `http_proxy` and `https_proxy` by default (the env variable names must be lowercase for them to be picked up, this is more commonly case-insensitive). They only support `http` proxies, the bug doesn’t trigger for `https` proxies.
* We can use the `APPLICATIONINSIGHTS_CONFIGURATION_CONTENT` env variable to override these configs with empty strings here: https://github.com/microsoft/ApplicationInsights-node.js/blob/20fbcb87ff9c361cf5fdfe0e500f857c7c813373/Library/JsonConfig.ts#L177
