### PR TITLE
BYOK: Show error message when there is no provider

### DIFF
--- a/src/extension/byok/vscode-node/byokContribution.ts
+++ b/src/extension/byok/vscode-node/byokContribution.ts
@@ -53,10 +53,10 @@ export class BYOKContrib extends Disposable implements IExtensionContribution {
 			}
 
 			// Show quick pick for Azure and CustomOAI providers
-			if (provider && (vendor === AzureBYOKModelProvider.providerName.toLowerCase() || vendor === CustomOAIBYOKModelProvider.providerName.toLowerCase())) {
+			if (vendor === AzureBYOKModelProvider.providerName.toLowerCase() || vendor === CustomOAIBYOKModelProvider.providerName.toLowerCase()) {
 				const configurator = new CustomOAIModelConfigurator(this._configurationService, vendor, provider);
 				await configurator.configureModelOrUpdateAPIKey();
-			} else if (provider) {
+			} else {
 				// For all other providers, directly go to API key management
 				await provider.updateAPIKey();
 			}


### PR DESCRIPTION
If BYOK provider is undefined, currently it fails silently and there is no indicator to the user.
This change adds log and shows msg.