### PR TITLE
fetcherService: `Response#body` to have more precise type

### DIFF
--- a/src/extension/completions-core/vscode-node/lib/src/test/fetcher.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/test/fetcher.ts
@@ -21,7 +21,7 @@ export function createFakeResponse(statusCode: number, response?: string, header
 		fakeHeaders,
 		() => Promise.resolve(response ?? ''),
 		() => Promise.resolve(response ? JSON.parse(response) : {}),
-		() => Promise.resolve(null),
+		() => null,
 		'test-stub'
 	);
 }
@@ -43,7 +43,7 @@ export function createFakeStreamResponse(body: string): Response {
 		new FakeHeaders(),
 		() => Promise.resolve(body),
 		() => Promise.resolve(JSON.parse(body.replace(/^data: /gm, '').replace(/\n\[DONE\]\n$/, ''))),
-		() => Promise.resolve(toStream(body)),
+		() => toStream(body),
 		'test-stub'
 	);
 }

--- a/src/platform/networking/common/fetcherService.ts
+++ b/src/platform/networking/common/fetcherService.ts
@@ -29,7 +29,7 @@ export class Response {
 		readonly headers: IHeaders,
 		private readonly getText: () => Promise<string>,
 		private readonly getJson: () => Promise<any>,
-		private readonly getBody: () => Promise<unknown | null>,
+		private readonly getBody: () => NodeJS.ReadableStream | null,
 		readonly fetcher: FetcherId
 	) { }
 
@@ -42,7 +42,7 @@ export class Response {
 	}
 
 	/** Async version of the standard .body field. */
-	async body(): Promise<unknown | null> {
+	body(): NodeJS.ReadableStream | null {
 		return this.getBody();
 	}
 }

--- a/src/platform/networking/node/baseFetchFetcher.ts
+++ b/src/platform/networking/node/baseFetchFetcher.ts
@@ -89,7 +89,7 @@ export abstract class BaseFetchFetcher implements IFetcher {
 			resp.headers,
 			() => resp.text(),
 			() => resp.json(),
-			async () => {
+			() => {
 				if (!resp.body) {
 					return Readable.from([]);
 				}

--- a/src/platform/networking/node/fetcherFallback.ts
+++ b/src/platform/networking/node/fetcherFallback.ts
@@ -109,10 +109,10 @@ async function tryFetch(fetcher: IFetcher, url: string, options: FetchOptions, l
 		try {
 			const json = JSON.parse(text); // Verify JSON
 			logService.debug(`FetcherService: ${fetcher.getUserAgentLibrary()} succeeded (JSON)`);
-			return { ok: true, response: new Response(response.status, response.statusText, response.headers, async () => text, async () => json, async () => Readable.from([text]), response.fetcher) };
+			return { ok: true, response: new Response(response.status, response.statusText, response.headers, async () => text, async () => json, () => Readable.from([text]), response.fetcher) };
 		} catch (err) {
 			logService.info(`FetcherService: ${fetcher.getUserAgentLibrary()} failed to parse JSON: ${err.message}`);
-			return { ok: false, err, response: new Response(response.status, response.statusText, response.headers, async () => text, async () => { throw err; }, async () => Readable.from([text]), response.fetcher) };
+			return { ok: false, err, response: new Response(response.status, response.statusText, response.headers, async () => text, async () => { throw err; }, () => Readable.from([text]), response.fetcher) };
 		}
 	} catch (err) {
 		logService.info(`FetcherService: ${fetcher.getUserAgentLibrary()} failed with error: ${err.message}`);

--- a/src/platform/networking/node/nodeFetcher.ts
+++ b/src/platform/networking/node/nodeFetcher.ts
@@ -103,7 +103,7 @@ export class NodeFetcher implements IFetcher {
 					nodeFetcherResponse.headers,
 					async () => nodeFetcherResponse.text(),
 					async () => nodeFetcherResponse.json(),
-					async () => nodeFetcherResponse.body(),
+					() => nodeFetcherResponse.body(),
 					NodeFetcher.ID
 				));
 			});
@@ -194,7 +194,7 @@ class NodeFetcherResponse {
 		return JSON.parse(text);
 	}
 
-	public async body(): Promise<NodeJS.ReadableStream | null> {
+	public body(): NodeJS.ReadableStream | null {
 		this.signal.addEventListener('abort', () => {
 			this.res.emit('error', makeAbortError(this.signal));
 			this.res.destroy();

--- a/src/platform/networking/test/node/fetcherFallback.spec.ts
+++ b/src/platform/networking/test/node/fetcherFallback.spec.ts
@@ -192,7 +192,7 @@ function createFakeResponse(statusCode: number, content: string) {
 		new FakeHeaders(),
 		() => Promise.resolve(content),
 		() => Promise.resolve(JSON.parse(content)),
-		async () => Readable.from([content]),
+		() => Readable.from([content]),
 		'test-stub'
 	);
 }

--- a/src/platform/test/node/fetcher.ts
+++ b/src/platform/test/node/fetcher.ts
@@ -15,7 +15,7 @@ export function createFakeResponse(statusCode: number, response: any = 'body') {
 		new FakeHeaders(),
 		() => Promise.resolve(JSON.stringify(response)),
 		() => Promise.resolve(response),
-		async () => null,
+		() => null,
 		'test-stub'
 	);
 }
@@ -28,7 +28,7 @@ export function createFakeStreamResponse(body: string | string[] | { chunk: stri
 		new FakeHeaders(),
 		async () => chunks.join(''),
 		async () => null,
-		async () => toStream(chunks, cts),
+		() => toStream(chunks, cts),
 		'test-stub'
 	);
 }


### PR DESCRIPTION
I think `#body` being a promise is not needed, so let's not have it. I would appreciate your insights