### PR TITLE
Add retries on external ingest document upload

### DIFF
--- a/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestApi.ts
+++ b/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestApi.ts
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { raceCancellationError } from '../../../../util/vs/base/common/async';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
-import { ILogService } from '../../../log/common/logService';
+import { CancellationError } from '../../../../util/vs/base/common/errors';
 import { IDisposable } from '../../../../util/vs/base/common/lifecycle';
+import { ILogService } from '../../../log/common/logService';
 
 // Sliding window that holds at least N entries and all entries in the time window.
 // This allows the sliding window to always hold some entries if inserts are infrequent,
@@ -186,6 +188,10 @@ class Throttler {
 		this.sendPeriodWindow.destroy();
 	}
 }
+export const githubHeaders = Object.freeze({
+	requestId: 'x-github-request-id',
+	totalQuotaUsed: 'x-github-total-quota-used',
+});
 
 /**
  * This API client performs requests and will manage back-off when being rate limited
@@ -215,10 +221,15 @@ export class ApiClient implements IDisposable {
 			while (!this.throttler.shouldSendRequest()) {
 				// Sleep a little while so that we don't have a constantly running loop.
 				// We probably shouldn't send requests more than this frequently anyway.
-				await sleep(5);
+				await raceCancellationError(sleep(5), token);
 			}
 			this.throttler.requestStarted();
 		}
+
+		if (token.isCancellationRequested) {
+			throw new CancellationError();
+		}
+
 		try {
 			const res = await fetch(url, {
 				method,
@@ -226,22 +237,19 @@ export class ApiClient implements IDisposable {
 				body: body ? JSON.stringify(body) : undefined,
 			});
 			if (!res.ok) {
-				const requestId = res.headers.get('x-github-request-id');
+				const requestId = res.headers.get(githubHeaders.requestId);
 				const responseBody = await res.text();
-				const message = `${method} to ${url} request failed with status: '${res.status}', requestId: '${requestId}', body: ${responseBody}`;
-				this.logService.error(message);
-				throw new Error(message);
+				this.logService.error(`${method} to ${url} request failed with status: '${res.status}', requestId: '${requestId}', body: ${responseBody}`);
+				return res;
 			}
-			const quotaUsedHeader = res.headers.get('x-github-total-quota-used');
+			const quotaUsedHeader = res.headers.get(githubHeaders.totalQuotaUsed);
 			const quotaUsed = quotaUsedHeader ? parseFloat(quotaUsedHeader) : 0;
 			if (this.throttler && quotaUsed > 0) {
 				this.throttler.recordQuotaUsed(quotaUsed);
 			}
 			return res;
 		} finally {
-			if (this.throttler) {
-				this.throttler.requestFinished();
-			}
+			this.throttler?.requestFinished();
 		}
 	}
 


### PR DESCRIPTION
Service is transiently returning 500s every few hundred docs. We're fixing this but until then should retry these failures a few times instead of failing the entire ingest