### PR TITLE
Hook up PermissionMode to an option

### DIFF
--- a/src/extension/agents/claude/common/claudeToolPermission.ts
+++ b/src/extension/agents/claude/common/claudeToolPermission.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { PermissionMode } from '@anthropic-ai/claude-agent-sdk';
 import type * as vscode from 'vscode';
 import { ClaudeToolInputMap, ClaudeToolNames } from './claudeTools';
 
@@ -18,6 +19,7 @@ export type ClaudeToolPermissionResult =
  */
 export interface ClaudeToolPermissionContext {
 	readonly toolInvocationToken: vscode.ChatParticipantToolToken;
+	readonly permissionMode?: PermissionMode;
 }
 
 /**

--- a/src/extension/agents/claude/common/claudeToolPermissionService.ts
+++ b/src/extension/agents/claude/common/claudeToolPermissionService.ts
@@ -57,6 +57,11 @@ export class ClaudeToolPermissionService implements IClaudeToolPermissionService
 		input: Record<string, unknown>,
 		context: ClaudeToolPermissionContext
 	): Promise<ClaudeToolPermissionResult> {
+		if (context.permissionMode === 'bypassPermissions') {
+			// Bypass mode: allow all tools without confirmation
+			return { behavior: 'allow', updatedInput: input };
+		}
+
 		const handler = this._getHandler(toolName as ClaudeToolNames);
 
 		// If handler has full custom implementation, use it
@@ -64,7 +69,7 @@ export class ClaudeToolPermissionService implements IClaudeToolPermissionService
 			return handler.handle(toolName as ClaudeToolNames, input as ClaudeToolInputMap[ClaudeToolNames], context);
 		}
 
-		// Check auto-approve
+		// Check auto-approve (handler-specific or permission mode based)
 		if (handler?.canAutoApprove) {
 			const canAutoApprove = await handler.canAutoApprove(toolName as ClaudeToolNames, input as ClaudeToolInputMap[ClaudeToolNames], context);
 			if (canAutoApprove) {

--- a/src/extension/agents/claude/node/test/claudeCodeAgent.spec.ts
+++ b/src/extension/agents/claude/node/test/claudeCodeAgent.spec.ts
@@ -80,7 +80,7 @@ describe('ClaudeCodeSession', () => {
 
 	it('processes a single request correctly', async () => {
 		const serverConfig = { port: 8080, nonce: 'test-nonce' };
-		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', undefined));
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', undefined, undefined));
 		const stream = new MockChatResponseStream();
 
 		await session.invoke('Hello', {} as vscode.ChatParticipantToolToken, stream, CancellationToken.None);
@@ -90,7 +90,7 @@ describe('ClaudeCodeSession', () => {
 
 	it('queues multiple requests and processes them sequentially', async () => {
 		const serverConfig = { port: 8080, nonce: 'test-nonce' };
-		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', undefined));
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', undefined, undefined));
 
 		const stream1 = new MockChatResponseStream();
 		const stream2 = new MockChatResponseStream();
@@ -109,7 +109,7 @@ describe('ClaudeCodeSession', () => {
 
 	it('cancels pending requests when cancelled', async () => {
 		const serverConfig = { port: 8080, nonce: 'test-nonce' };
-		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', undefined));
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', undefined, undefined));
 		const stream = new MockChatResponseStream();
 		const source = new CancellationTokenSource();
 		source.cancel();
@@ -119,7 +119,7 @@ describe('ClaudeCodeSession', () => {
 
 	it('cleans up resources when disposed', async () => {
 		const serverConfig = { port: 8080, nonce: 'test-nonce' };
-		const session = instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', undefined);
+		const session = instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', undefined, undefined);
 
 		// Dispose the session immediately
 		session.dispose();
@@ -132,8 +132,8 @@ describe('ClaudeCodeSession', () => {
 
 	it('handles multiple sessions with different session IDs', async () => {
 		const serverConfig = { port: 8080, nonce: 'test-nonce' };
-		const session1 = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'session-1', undefined));
-		const session2 = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'session-2', undefined));
+		const session1 = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'session-1', undefined, undefined));
+		const session2 = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'session-2', undefined, undefined));
 
 		expect(session1.sessionId).toBe('session-1');
 		expect(session2.sessionId).toBe('session-2');
@@ -153,7 +153,7 @@ describe('ClaudeCodeSession', () => {
 
 	it('initializes with model ID from constructor', async () => {
 		const serverConfig = { port: 8080, nonce: 'test-nonce' };
-		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', 'claude-3-opus'));
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', 'claude-3-opus', undefined));
 		const stream = new MockChatResponseStream();
 
 		await session.invoke('Hello', {} as vscode.ChatParticipantToolToken, stream, CancellationToken.None);
@@ -166,7 +166,7 @@ describe('ClaudeCodeSession', () => {
 		const mockService = instantiationService.invokeFunction(accessor => accessor.get(IClaudeCodeSdkService)) as MockClaudeCodeSdkService;
 		mockService.queryCallCount = 0;
 
-		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', 'claude-3-sonnet'));
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', 'claude-3-sonnet', undefined));
 
 		// First request with initial model
 		const stream1 = new MockChatResponseStream();
@@ -184,7 +184,7 @@ describe('ClaudeCodeSession', () => {
 		const mockService = instantiationService.invokeFunction(accessor => accessor.get(IClaudeCodeSdkService)) as MockClaudeCodeSdkService;
 		mockService.queryCallCount = 0;
 
-		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', 'claude-3-sonnet'));
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, 'test-session', 'claude-3-sonnet', undefined));
 
 		// First request
 		const stream1 = new MockChatResponseStream();

--- a/src/extension/agents/claude/node/toolPermissionHandlers/editToolHandler.ts
+++ b/src/extension/agents/claude/node/toolPermissionHandlers/editToolHandler.ts
@@ -15,7 +15,7 @@ type EditToolName = ClaudeToolNames.Edit | ClaudeToolNames.Write | ClaudeToolNam
 
 /**
  * Handler for edit tools (Edit, Write, MultiEdit).
- * Auto-approves edits to files within the workspace.
+ * Auto-approves edits to files within the workspace, or when permission mode is 'acceptEdits'.
  */
 export class EditToolHandler implements IClaudeToolPermissionHandler<EditToolName> {
 	public readonly toolNames = [ClaudeToolNames.Edit, ClaudeToolNames.Write, ClaudeToolNames.MultiEdit] as const;
@@ -27,8 +27,17 @@ export class EditToolHandler implements IClaudeToolPermissionHandler<EditToolNam
 	public async canAutoApprove(
 		_toolName: EditToolName,
 		input: FileEditInput | FileWriteInput,
-		_context: ClaudeToolPermissionContext
+		context: ClaudeToolPermissionContext
 	): Promise<boolean> {
+		// Auto-approve all edits in 'acceptEdits' mode
+		if (context.permissionMode === 'acceptEdits') {
+			return true;
+		} else if (context.permissionMode === 'bypassPermissions') {
+			return true;
+		} else if (context.permissionMode === 'default') {
+			return false;
+		}
+		// Otherwise, only auto-approve files within the workspace
 		return this.instantiationService.invokeFunction(isFileOkForTool, URI.file(input.file_path));
 	}
 }


### PR DESCRIPTION
CC extenion has a similar toggle, let's replicate it for now so that at least I can use Plan mode.

The other two options feel kinda silly in 2026... That's why I made Edit automatically the default since that's what we allow in agent mode today.

So, I think this needs some reworking later... but for now at least we're consistent.