### PR TITLE
Remove WebSearch tool

### DIFF
--- a/src/extension/agents/claude/node/claudeCodeAgent.ts
+++ b/src/extension/agents/claude/node/claudeCodeAgent.ts
@@ -299,6 +299,9 @@ export class ClaudeCodeSession extends Disposable {
 			cwd: this.workspaceService.getWorkspaceFolders().at(0)?.fsPath,
 			abortController: this._abortController,
 			executable: process.execPath as 'node', // get it to fork the EH node process
+			// TODO: CAPI does not yet support the WebSearch tool
+			// Once it does, we can re-enable it.
+			disallowedTools: ['WebSearch'],
 			env: {
 				...process.env,
 				ANTHROPIC_BASE_URL: `http://localhost:${this.serverConfig.port}`,


### PR DESCRIPTION
CAPI doesn't support it yet. It's a server-side tool