### PR TITLE
Skip XtabProvider requests when prediction exceeds token limit

### DIFF
--- a/src/platform/inlineEdits/common/statelessNextEditProvider.ts
+++ b/src/platform/inlineEdits/common/statelessNextEditProvider.ts
@@ -246,7 +246,7 @@ export namespace NoNextEditReason {
 	}
 	export class PromptTooLarge extends NoNextEditReason {
 		public readonly kind = 'promptTooLarge';
-		constructor(public readonly message: 'editWindow' | 'currentFile' | 'final') {
+		constructor(public readonly message: 'editWindow' | 'currentFile' | 'final' | 'prediction') {
 			super();
 		}
 		toString(): string {


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#6564

Adds a client-side check to skip requests when the prediction/speculation
content exceeds languageContext.maxTokens (default 2000). This prevents
errors of the form "User-provided speculation (X tokens) is longer than
max_tokens (2048)" which occur when large documents with static data
are sent for speculative decoding.