### PR TITLE
Chat session context provider for scm

### DIFF
--- a/src/extension/chatSessionContext/vscode-node/chatSessionContextProvider.ts
+++ b/src/extension/chatSessionContext/vscode-node/chatSessionContextProvider.ts
@@ -90,12 +90,18 @@ export class ChatSessionContextContribution extends Disposable {
 				() => this._summaryCache,
 				(cache) => { this._summaryCache = cache; }
 			);
-			const provider: Copilot.ContextProvider<Copilot.SupportedContextItem> = {
+			const nesProvider: Copilot.ContextProvider<Copilot.SupportedContextItem> = {
 				id: 'chat-session-context-provider',
 				selector: '*',
 				resolver: resolver
 			};
-			disposables.add(this.languageContextProviderService.registerContextProvider(provider, [ProviderTarget.NES]));
+			const scmProvider: Copilot.ContextProvider<Copilot.SupportedContextItem> = {
+				id: 'chat-session-context-provider',
+				selector: { language: 'scminput' },
+				resolver: resolver
+			};
+			disposables.add(this.languageContextProviderService.registerContextProvider(nesProvider, [ProviderTarget.NES]));
+			disposables.add(this.languageContextProviderService.registerContextProvider(scmProvider, [ProviderTarget.Completions]));
 		} catch (error) {
 			this.logService.error('Error registering chat session context provider:', error);
 		}

--- a/src/extension/completions-core/vscode-node/completionsServiceBridges.ts
+++ b/src/extension/completions-core/vscode-node/completionsServiceBridges.ts
@@ -139,6 +139,7 @@ export function setup(serviceAccessor: ServicesAccessor, disposables: Disposable
 	const defaultContextProviders = serviceAccessor.get(ICompletionsDefaultContextProviders);
 	defaultContextProviders.add('ms-vscode.cpptools');
 	defaultContextProviders.add('promptfile-ai-context-provider');
+	defaultContextProviders.add('chat-session-context-provider');
 
 	disposables.add(setupCompletionsExperimentationService(serviceAccessor));
 }

--- a/src/extension/completions-core/vscode-node/lib/src/prompt/completionsPromptFactory/cascadingPromptFactory.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/prompt/completionsPromptFactory/cascadingPromptFactory.ts
@@ -42,6 +42,7 @@ import {
 	_promptError,
 	getPromptOptions,
 	MIN_PROMPT_CHARS,
+	MIN_PROMPT_EXCLUDED_LANGUAGE_IDS,
 	PromptResponse,
 	trimLastLine,
 } from '../prompt';
@@ -248,7 +249,7 @@ export abstract class CascadingPromptFactory implements ICompletionsPromptFactor
 			return _copilotContentExclusion;
 		}
 
-		if (textDocument.getText().length < MIN_PROMPT_CHARS) {
+		if (textDocument.getText().length < MIN_PROMPT_CHARS && !MIN_PROMPT_EXCLUDED_LANGUAGE_IDS.includes(textDocument.detectedLanguageId)) {
 			// Too short context
 			return _contextTooShort;
 		}

--- a/src/extension/completions-core/vscode-node/lib/src/prompt/completionsPromptFactory/componentsCompletionsPromptFactory.tsx
+++ b/src/extension/completions-core/vscode-node/lib/src/prompt/completionsPromptFactory/componentsCompletionsPromptFactory.tsx
@@ -61,6 +61,7 @@ import {
 	_promptError,
 	getPromptOptions,
 	MIN_PROMPT_CHARS,
+	MIN_PROMPT_EXCLUDED_LANGUAGE_IDS,
 	PromptResponse,
 	trimLastLine,
 } from '../prompt';
@@ -389,7 +390,7 @@ abstract class BaseComponentsCompletionsPromptFactory implements IPromptFactory 
 		}
 
 		const eligibleChars = suffixPercent > 0 ? textDocument.getText().length : textDocument.offsetAt(position);
-		if (eligibleChars < MIN_PROMPT_CHARS) {
+		if (eligibleChars < MIN_PROMPT_CHARS && !MIN_PROMPT_EXCLUDED_LANGUAGE_IDS.includes(textDocument.detectedLanguageId)) {
 			// Too short context
 			return _contextTooShort;
 		}

--- a/src/extension/completions-core/vscode-node/lib/src/prompt/prompt.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/prompt/prompt.ts
@@ -23,6 +23,7 @@ import { NeighboringFileType, considerNeighborFile } from './similarFiles/neighb
 
 // The minimum number of prompt-eligible characters before we offer a completion
 export const MIN_PROMPT_CHARS = 10;
+export const MIN_PROMPT_EXCLUDED_LANGUAGE_IDS = ['scminput'];
 
 export interface Prompt {
 	prefix: string;


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a chat session context provider specifically for the SCM language, allowing for improved context handling in completions. Additionally, update the minimum prompt character check to exclude the SCM language from the prompt eligibility criteria.