### PR TITLE
Ask questions tool: add free text mode and improve UX/prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1144,13 +1144,12 @@
 					}
 				}
 			},
-
 			{
 				"name": "copilot_askQuestions",
 				"toolReferenceName": "askQuestions",
 				"displayName": "%copilot.tools.askQuestions.name%",
 				"userDescription": "%copilot.tools.askQuestions.description%",
-				"modelDescription": "Ask the user questions when progress is blocked or a decision carries significant risk. Prefer proposing a sensible default so users can confirm quickly.\n\nWhen to use:\n- Clarify ambiguous requirements before proceeding\n- Get user preferences on implementation choices\n- Confirm high-impact decisions\n\nQuestion guidelines:\n- Batch related questions into a single call to minimize interruption\n- Provide brief context explaining what is being decided and why it matters\n- Mark one option as `recommended` with a short justification\n- Keep options mutually exclusive for single-select; use `multiSelect: true` only when choices are additive\n\nAfter receiving answers:\n- Restate the chosen decisions briefly and proceed\n- Do not re-ask unless requirements change\n\n- An \"Other\" option is automatically shown to users for custom input—do not add your own \"Something else\" or similar option.",
+				"modelDescription": "Ask the user questions to clarify intent, validate assumptions, or choose between implementation approaches. Prefer proposing a sensible default so users can confirm quickly.\n\nOnly use this tool when the user's answer provides information you cannot determine or reasonably assume yourself. This tool is for gathering information, not for reporting status or problems. If a question has an obvious best answer, take that action instead of asking.\n\nWhen to use:\n- Clarify ambiguous requirements before proceeding\n- Get user preferences on implementation choices\n- Confirm decisions that meaningfully affect outcome\n\nWhen NOT to use:\n- The answer is determinable from code or context\n- Asking for permission to continue or abort\n- Confirming something you can reasonably decide yourself\n- Reporting a problem (instead, attempt to resolve it)\n\nQuestion guidelines:\n- Batch related questions into a single call (max 4 questions, 2-6 options each; omit options for free text input)\n- Provide brief context explaining what is being decided and why\n- Mark one option as `recommended` with a short justification\n- Keep options mutually exclusive for single-select; use `multiSelect: true` only when choices are additive and phrase the question accordingly\n\nAfter receiving answers:\n- Incorporate decisions and continue without re-asking unless requirements change\n\nAn \"Other\" option is automatically shown to users—do not add your own.",
 				"icon": "$(question)",
 				"canBeReferencedInPrompt": true,
 				"when": "config.github.copilot.chat.askQuestions.enabled",
@@ -1181,9 +1180,9 @@
 									},
 									"options": {
 										"type": "array",
-										"description": "2-4 options for the user to choose from",
-										"minItems": 2,
-										"maxItems": 4,
+										"description": "0-6 options for the user to choose from. If empty or omitted, shows a free text input instead.",
+										"minItems": 0,
+										"maxItems": 6,
 										"items": {
 											"type": "object",
 											"properties": {
@@ -1208,8 +1207,7 @@
 								},
 								"required": [
 									"header",
-									"question",
-									"options"
+									"question"
 								]
 							}
 						}


### PR DESCRIPTION
## Summary

Enhances the AskQuestions tool with free text input mode and improved user experience for custom answers.

## Changes

### Free Text Input Mode
- Questions can now omit `options` to show a simple input box for free text responses
- Updated schema: `options` minItems changed from 2 to 0, no longer required
- Added validation: questions with exactly 1 option are rejected (need 0 for free text or 2+ for choice)

### Improved Custom Answer UX
- Added dynamic "Use X" option that appears when typing non-matching text
- Renamed `isFreeText` to `isCustomTextOption` and `isOtherOption` for clarity
- "Other..." option now has edit icon prefix for visual consistency

### Model Description Updates
- Clearer guidance on when to use vs when NOT to use the tool
- Expanded options limit from 4 to 6 per question
- Better phrasing for multiSelect usage

### Other Improvements
- Invocation messages now include question headers for better context
- Extracted `IQuestionAnswer` and `AskQuestionResult` types for cleaner code
- Fixed edge case handling when no selection is made