### PR TITLE
tools: skip diff display when content is identical after trim

### DIFF
--- a/src/extension/tools/node/editFileToolUtils.tsx
+++ b/src/extension/tools/node/editFileToolUtils.tsx
@@ -102,6 +102,10 @@ function escapeRegex(str: string): string {
  * This outputs the entire file with all changes marked.
  */
 export async function formatDiffAsUnified(accessor: ServicesAccessor, uri: URI, oldContent: string, newContent: string): Promise<string> {
+	if (oldContent.trim() === newContent.trim()) {
+		return '```\n<' + t('contents are identical') + '>\n```';
+	}
+
 	const diffService = accessor.get(IDiffService);
 	const diff = await diffService.computeDiff(oldContent, newContent, {
 		ignoreTrimWhitespace: false,


### PR DESCRIPTION
Improves file edit confirmation notifications by skipping diff display
when the only difference between old and new content is whitespace. This
prevents showing overly large diffs (e.g., >2500 lines) when the actual
changes are minimal or non-existent, making it clearer to users what
changes the agent is making.

- Adds early return in formatDiffAsUnified when content is identical
  after trimming whitespace
- Displays a brief 'contents are identical' message instead of a large
  diff

Fixes https://github.com/microsoft/vscode/issues/288781

(Commit message generated by Copilot)