### PR TITLE
Ensure the Plan custom agent only targets VS Code

### DIFF
--- a/src/extension/agents/vscode-node/planAgentProvider.ts
+++ b/src/extension/agents/vscode-node/planAgentProvider.ts
@@ -31,6 +31,7 @@ interface PlanAgentConfig {
 	argumentHint: string;
 	tools: string[];
 	model?: string;
+	target?: string;
 	handoffs: PlanAgentHandoff[];
 	body: string;
 }
@@ -43,6 +44,7 @@ const BASE_PLAN_AGENT_CONFIG: PlanAgentConfig = {
 	name: 'Plan',
 	description: 'Researches and outlines multi-step plans',
 	argumentHint: 'Outline the goal or problem to research',
+	target: 'vscode',
 	tools: [
 		'github/issue_read',
 		'agent',
@@ -150,6 +152,9 @@ export function buildAgentMarkdown(config: PlanAgentConfig): string {
 	// Model (optional)
 	if (config.model) {
 		lines.push(`model: ${config.model}`);
+	}
+	if (config.target) {
+		lines.push(`target: ${config.target}`);
 	}
 
 	// Tools array - flow style for readability


### PR DESCRIPTION
Given Background agents can now use the agent picker, we need to ensure we have a target property to filter out contributed custom agents
Background agent can see all Custom Agents that have `target = empty | github-copilot`

Currently, I'm ignoring all contributed custom agents, but would like to get that in as well.
However our custom agent doesn't specifically target `vscode`

Once we do this we can include custom agents contributed via extensions in background agent sessions as well.

(this is background agent session that filters out all built-in and contributed custom agents, thats why `Plan` is missing)

<img width="760" height="439" alt="Screenshot 2026-01-23 at 15 16 04" src="https://github.com/user-attachments/assets/7f705cc3-5ed1-4781-9dfa-e36eb5da91b7" />

