### PR TITLE
tools: update message about issue reporting for validation failures

### DIFF
--- a/src/extension/tools/common/toolSchemaNormalizer.ts
+++ b/src/extension/tools/common/toolSchemaNormalizer.ts
@@ -42,7 +42,7 @@ export function normalizeToolSchema(family: string, tools: OpenAiFunctionTool[] 
 
 			output.push(cloned);
 		} catch (e) {
-			const e2 = new Error(l10n.t`Failed to validate tool ${tool.function.name}: ${e}. Please open a Github issue for the MCP server or extension which provides this tool`);
+			const e2 = new Error(l10n.t`Failed to validate tool ${tool.function.name}: ${e}. Please open an issue for the MCP server or extension which provides this tool`);
 			e2.stack = e.stack;
 			throw e2;
 		}


### PR DESCRIPTION
This PR improves the following error message, which appears when something is wrong with MCP.

<img width="527" height="245" alt="image" src="https://github.com/user-attachments/assets/eb5585b0-6a07-431c-9b08-d2515b23e320" />

There is a typo in `Github`; it should be `GitHub`. However, not all the MCP server code is hosted on GitHub. For example, the GitLab MCP server is hosted [GitLab](https://gitlab.com/gitlab-org/cli/-/tree/main/internal/commands/mcp).

Therefore, I think we should remove the word `Github` from the error message entirely.