### PR TITLE
Add command to review patches in inline chat

### DIFF
--- a/src/extension/inlineChat/vscode-node/inlineChatCommands.ts
+++ b/src/extension/inlineChat/vscode-node/inlineChatCommands.ts
@@ -292,6 +292,9 @@ ${message}`,
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.unstagedFileChange', (resource: vscode.SourceControlResourceState) => {
 		return instaService.createInstance(ReviewSession).review({ group: 'workingTree', file: resource.resourceUri }, vscode.ProgressLocation.Notification);
 	}));
+	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.patches', (group: { repositoryRoot: string; commitMessages: string[]; patches: { patch: string; fileUri: string; previousFileUri?: string }[] }) => {
+		return instaService.createInstance(ReviewSession).review(group, vscode.ProgressLocation.Notification);
+	}));
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.apply', doApplyReview));
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.applyAndNext', (commentThread: vscode.CommentThread) => doApplyReview(commentThread, true)));
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.applyShort', (commentThread: vscode.CommentThread) => doApplyReview(commentThread, true)));


### PR DESCRIPTION
This pull request adds a new command to the inline chat extension, enabling users to review patches directly from the chat interface. This enhances the review workflow by allowing batch patch review in addition to existing file and change review commands.

**New feature: Patch review command**
- Added a new command, `github.copilot.chat.review.patches`, which allows reviewing a group of patches (with repository root, commit messages, and file patch details) via the `ReviewSession` service. This command can be triggered from the chat interface, improving support for reviewing multiple changes at once.