### PR TITLE
Refresh copilot token if it will expire in 5 mins

### DIFF
--- a/src/platform/authentication/node/copilotTokenManager.ts
+++ b/src/platform/authentication/node/copilotTokenManager.ts
@@ -448,7 +448,7 @@ export abstract class RefreshableCopilotTokenManager extends BaseCopilotTokenMan
 	protected abstract authenticateAndGetToken(): Promise<TokenInfoOrError & NotGitHubLoginFailed>;
 
 	async getCopilotToken(force?: boolean): Promise<CopilotToken> {
-		if (!this.copilotToken || this.copilotToken.expires_at < nowSeconds() - (60 * 5 /* 5min */) || force) {
+		if (!this.copilotToken || this.copilotToken.expires_at < nowSeconds() + (60 * 5 /* 5min */) || force) {
 			const tokenResult = await this.authenticateAndGetToken();
 			if (tokenResult.kind === 'failure') {
 				throw Error(


### PR DESCRIPTION
I asked Opus to explain a bug to me and it founds this.

We're refreshing the token once its already been expired for 5 minutes which seems wrong