### PR TITLE
sessions: remove usage of non-diff session representation

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -795,19 +795,12 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 				}
 
 				const multiDiffPart = await this._prFileChangesService.getFileChangesMultiDiffPart(pr);
-				const changes = multiDiffPart
-					? multiDiffPart.value
-						.map(change => new vscode.ChatSessionChangedFile2(
-							change.goToFileUri!,
-							change.originalUri,
-							change.modifiedUri,
-							change.added ?? 0,
-							change.removed ?? 0))
-					: {
-						files: pr.files.totalCount,
-						insertions: pr.additions,
-						deletions: pr.deletions
-					};
+				const changes = multiDiffPart?.value?.map(change => new vscode.ChatSessionChangedFile2(
+					change.goToFileUri!,
+					change.originalUri,
+					change.modifiedUri,
+					change.added ?? 0,
+					change.removed ?? 0));
 
 				const session = {
 					resource: vscode.Uri.from({ scheme: CopilotCloudSessionsProvider.TYPE, path: '/' + pr.number }),

--- a/src/extension/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/extension/vscode.proposed.chatSessionsProvider.d.ts
@@ -233,22 +233,7 @@ declare module 'vscode' {
 		/**
 		 * Statistics about the chat session.
 		 */
-		changes?: readonly ChatSessionChangedFile[] | readonly ChatSessionChangedFile2[] | {
-			/**
-			 * Number of files edited during the session.
-			 */
-			files: number;
-
-			/**
-			 * Number of insertions made during the session.
-			 */
-			insertions: number;
-
-			/**
-			 * Number of deletions made during the session.
-			 */
-			deletions: number;
-		};
+		changes?: readonly ChatSessionChangedFile[] | readonly ChatSessionChangedFile2[];
 
 		/**
 		 * Optional repository information for the chat session.


### PR DESCRIPTION
Removes support for non-diff session representation in ChatSessionItem, 
simplifying the API to only support ChatSessionChangedFile and 
ChatSessionChangedFile2 types.

- Removes fallback to summary format (files, insertions, deletions object)
  from ChatSessionItem.changes property type definition
- Updates copilotCloudSessionsProvider to only emit ChatSessionChangedFile2 
  objects, removing conditional logic for summary fallback

Refs https://github.com/microsoft/vscode/issues/289936

(Commit message generated by Copilot)