### PR TITLE
Add /plan contributed prompt for Plan agent

### DIFF
--- a/assets/prompts/plan.prompt.md
+++ b/assets/prompts/plan.prompt.md
@@ -1,0 +1,7 @@
+---
+name: plan
+description: Research and plan with the Plan agent
+agent: Plan
+argument-hint: Describe what you want to plan or research
+---
+Plan my task.

--- a/package.json
+++ b/package.json
@@ -5387,9 +5387,10 @@
 		"chatAgents": [],
 		"chatPromptFiles": [
 			{
-				"name": "savePrompt",
-				"path": "./assets/prompts/savePrompt.prompt.md",
-				"description": "Generalize the current discussion into a reusable prompt and save it as a file"
+				"path": "./assets/prompts/savePrompt.prompt.md"
+			},
+			{
+				"path": "./assets/prompts/plan.prompt.md"
 			}
 		]
 	},


### PR DESCRIPTION
Adds a `/plan` slash command as a contributed prompt that invokes the Plan agent with a helpful argument hint.

## Changes
- New `assets/prompts/plan.prompt.md` with `agent: Plan` and `argument-hint`
- Register in `chatPromptFiles` contribution point
- Removed deprecated name and description fields