### PR TITLE
Add onExp tag to largeToolResultsToDisk settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4000,7 +4000,8 @@
 						"markdownDescription": "%github.copilot.config.agent.largeToolResultsToDisk.enabled%",
 						"tags": [
 							"advanced",
-							"experimental"
+							"experimental",
+							"onExp"
 						]
 					},
 					"github.copilot.chat.agent.largeToolResultsToDisk.thresholdBytes": {
@@ -4009,7 +4010,8 @@
 						"markdownDescription": "%github.copilot.config.agent.largeToolResultsToDisk.thresholdBytes%",
 						"tags": [
 							"advanced",
-							"experimental"
+							"experimental",
+							"onExp"
 						]
 					},
 					"github.copilot.chat.instantApply.shortContextModelName": {


### PR DESCRIPTION
This adds the `onExp` tag to the `github.copilot.chat.agent.largeToolResultsToDisk.enabled` and `github.copilot.chat.agent.largeToolResultsToDisk.thresholdBytes` settings.

Without this tag, the VS Code Settings UI always shows the package.json default value, even when an experiment overrides it at runtime. Adding `onExp` enables the Settings UI to display experiment-controlled values.