### PR TITLE
Fix infinite [ScmContextResolver] Cache invalidation log

### DIFF
--- a/src/extension/git/vscode/scmContextprovider.ts
+++ b/src/extension/git/vscode/scmContextprovider.ts
@@ -59,13 +59,20 @@ export class ScmContextProviderContribution extends Disposable {
 	private _registerCacheInvalidation(): IDisposable {
 		const disposables = new DisposableStore();
 
-		// Invalidate cache when workspace text documents change, excluding SCM input documents
-		disposables.add(this._workspaceService.onDidChangeTextDocument(e => {
-			const scheme = e.document.uri.scheme;
-			if (scheme === 'vscode-scm' || scheme === 'vscode-source-control') {
-				return;
+		const resourcesToConsider = this._gitService.activeRepository.map(repository => {
+			if (!repository) {
+				return new Set<string>();
 			}
-			this._resolver.invalidateCache();
+
+			const workingTreeChanges = repository.changes?.workingTree.map(change => change.uri.toString()) ?? [];
+			return new Set(workingTreeChanges);
+		});
+
+		// Invalidate cache when workspace file documents change
+		disposables.add(this._workspaceService.onDidChangeTextDocument(e => {
+			if (resourcesToConsider.get().has(e.document.uri.toString())) {
+				this._resolver.invalidateCache();
+			}
 		}));
 
 		return disposables;
@@ -89,8 +96,10 @@ class ScmContextResolver implements Copilot.ContextResolver<Copilot.SupportedCon
 	) { }
 
 	invalidateCache(): void {
-		this._cachedDiffs = undefined;
-		this._logService.trace('[ScmContextResolver] Cache invalidated');
+		if (this._cachedDiffs !== undefined) {
+			this._cachedDiffs = undefined;
+			this._logService.trace('[ScmContextResolver] Cache invalidated');
+		}
 	}
 
 	async *resolve(request: Copilot.ResolveRequest, token: CancellationToken): AsyncIterable<Copilot.SupportedContextItem> {


### PR DESCRIPTION
```Copilot Generated Description:``` Modify cache invalidation logic to prevent infinite logging by excluding SCM input documents and only invalidating the cache for relevant workspace file documents.

Fixes microsoft/vscode#290504