### PR TITLE
Add a `/terminal` command that will launch Claude's CLI but using Copilot endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -2136,6 +2136,11 @@
 				"category": "Claude Agent"
 			},
 			{
+				"command": "copilot.claude.terminal",
+				"title": "%github.copilot.command.claude.terminal%",
+				"category": "Claude Agent"
+			},
+			{
 				"command": "github.copilot.cli.sessions.delete",
 				"title": "%github.copilot.command.deleteAgentSession%",
 				"icon": "$(close)",
@@ -5346,6 +5351,10 @@
 					{
 						"name": "memory",
 						"description": "Open memory files (CLAUDE.md) for editing"
+					},
+					{
+						"name": "terminal",
+						"description": "Launch Claude Code CLI using your GitHub Copilot subscription"
 					}
 				]
 			},

--- a/package.nls.json
+++ b/package.nls.json
@@ -365,6 +365,7 @@
 	"github.copilot.config.tools.defaultToolsGrouped": "Group default tools in prompts.",
 	"github.copilot.config.claudeAgent.enabled": "Enable Claude Agent sessions in VS Code. Start and resume agentic coding sessions powered by Anthropic's Claude Agent SDK directly in the editor. Uses your existing Copilot subscription.",
 	"github.copilot.config.claudeAgent.allowDangerouslySkipPermissions": "Allow bypass permissions mode. Recommended only for sandboxes with no internet access.",
+	"github.copilot.command.claude.terminal": "New CLI Session",
 	"github.copilot.config.cli.customAgents.enabled": "Enable Custom Agents for Background Agents.",
 	"github.copilot.config.cli.mcp.enabled": "Enable Model Context Protocol (MCP) server for Background Agents.",
 	"github.copilot.config.backgroundAgent.enabled": "Enable the Background Agent. When disabled, the Background Agent will not be available in 'Continue In' context menus.",

--- a/src/extension/agents/claude/AGENTS.md
+++ b/src/extension/agents/claude/AGENTS.md
@@ -242,8 +242,10 @@ Slash commands often need to present choices or gather input from users. When do
 The `show*` APIs are sufficient for most slash command use cases and result in cleaner, more maintainable code. Only use `create*` APIs when you need advanced features like dynamic item updates, multi-step wizards, or custom event handling.
 
 **Current Slash Commands:**
-- `/hooks` - Display information about registered hooks (from `hooksCommand.ts`)
-- `/memory` - Memory management commands (from `memoryCommand.ts`)
+- `/hooks` - Configure Claude Agent hooks for tool execution and events (from `hooksCommand.ts`)
+- `/memory` - Open memory files (CLAUDE.md) for editing (from `memoryCommand.ts`)
+- `/agents` - Create and manage specialized Claude agents (from `agentsCommand.ts`)
+- `/terminal` - Create a terminal with Claude CLI configured to use Copilot Chat endpoints (from `terminalCommand.ts`)
 
 ### Tool Permission Handlers
 
@@ -260,7 +262,7 @@ Tool permission handlers control what actions Claude can take without user confi
 - **Common handlers** (`common/toolPermissionHandlers/`):
   - `bashToolHandler.ts` - Controls bash/shell command execution
   - `exitPlanModeHandler.ts` - Manages plan mode transitions
-  
+
 - **Node handlers** (`node/toolPermissionHandlers/`):
   - `editToolHandler.ts` - Handles file edit operations (Edit, Write, MultiEdit)
 

--- a/src/extension/agents/claude/vscode-node/slashCommands/index.ts
+++ b/src/extension/agents/claude/vscode-node/slashCommands/index.ts
@@ -9,6 +9,7 @@
 import './agentsCommand';
 import './hooksCommand';
 import './memoryCommand';
+import './terminalCommand';
 
 // Future commands can be added here:
 // import './settingsCommand';

--- a/src/extension/agents/claude/vscode-node/slashCommands/terminalCommand.ts
+++ b/src/extension/agents/claude/vscode-node/slashCommands/terminalCommand.ts
@@ -1,0 +1,156 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as vscode from 'vscode';
+import { ILogService } from '../../../../../platform/log/common/logService';
+import { ITerminalService } from '../../../../../platform/terminal/common/terminalService';
+import { CancellationToken } from '../../../../../util/vs/base/common/cancellation';
+import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
+import { ClaudeLanguageModelServer } from '../../node/claudeLanguageModelServer';
+import { IClaudeSlashCommandHandler, registerClaudeSlashCommand } from './claudeSlashCommandRegistry';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Slash command handler for creating a terminal session with Claude CLI configured
+ * to use Copilot Chat's endpoints.
+ *
+ * This command starts a ClaudeLanguageModelServer instance (if not already running)
+ * and creates a new terminal with ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY environment
+ * variables set to proxy requests through Copilot Chat's chat endpoints.
+ *
+ * ## Usage
+ * 1. In a Claude Agent chat session, type `/terminal`
+ * 2. A new terminal will be created with the environment variables configured
+ * 3. Run `claude` in the terminal to start Claude Code
+ * 4. Claude Code will use Copilot Chat's endpoints for all LLM requests
+ *
+ * ## Requirements
+ * - Claude CLI (`claude`) must be installed and available in PATH
+ * - The terminal inherits the environment with ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY set
+ * - The language model server runs on localhost with a random available port
+ */
+export class TerminalSlashCommand implements IClaudeSlashCommandHandler {
+	readonly commandName = 'terminal';
+	readonly description = vscode.l10n.t('Launch Claude Code CLI using your GitHub Copilot subscription');
+	readonly commandId = 'copilot.claude.terminal';
+
+	private _langModelServer: ClaudeLanguageModelServer | undefined;
+
+	constructor(
+		@ILogService private readonly logService: ILogService,
+		@ITerminalService private readonly terminalService: ITerminalService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+	) { }
+
+	async handle(
+		_args: string,
+		stream: vscode.ChatResponseStream | undefined,
+		_token: CancellationToken
+	): Promise<vscode.ChatResult> {
+		stream?.markdown(vscode.l10n.t('Creating Claude Code CLI instance...'));
+
+		try {
+			// Check which CLI is available
+			const cliCommand = await this._getClaudeCliCommand();
+			if (!cliCommand) {
+				const installUrl = 'https://code.claude.com';
+				const downloadLabel = vscode.l10n.t('Download Claude Code CLI');
+				if (stream) {
+					stream.markdown(vscode.l10n.t('Claude Code CLI is not installed. Download Claude Code CLI to get started.'));
+					stream.button({ command: 'vscode.open', arguments: [vscode.Uri.parse(installUrl)], title: downloadLabel });
+				} else {
+					vscode.window.showErrorMessage(
+						vscode.l10n.t('Claude Code CLI is not installed.'),
+						downloadLabel
+					).then(selection => {
+						if (selection === downloadLabel) {
+							vscode.env.openExternal(vscode.Uri.parse(installUrl));
+						}
+					});
+				}
+				return {};
+			}
+
+			// Get or create the language model server
+			const server = await this._getLanguageModelServer();
+			const config = server.getConfig();
+
+			// Create terminal with environment variables configured
+			const terminal = this.terminalService.createTerminal({
+				name: 'Claude',
+				message: '\n\x1b[1;36m▸ ' + vscode.l10n.t('This instance of Claude Code CLI is configured to use your GitHub Copilot subscription.') + '\x1b[0m\n',
+				env: {
+					ANTHROPIC_BASE_URL: `http://localhost:${config.port}`,
+					ANTHROPIC_AUTH_TOKEN: config.nonce
+				}
+			});
+
+			// Show the terminal
+			terminal.show();
+
+			// Send the appropriate command to the terminal
+			terminal.sendText(cliCommand);
+
+			this.logService.info(`[TerminalSlashCommand] Created terminal with Claude CLI configured on port ${config.port}, command: ${cliCommand}`);
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			this.logService.error('[TerminalSlashCommand] Error creating terminal:', error);
+			if (stream) {
+				stream.markdown(vscode.l10n.t('Error creating terminal: {0}', errorMessage));
+			} else {
+				vscode.window.showErrorMessage(vscode.l10n.t('Error creating terminal: {0}', errorMessage));
+			}
+		}
+
+		return {};
+	}
+
+	/**
+	 * Check which Claude CLI command is available.
+	 * Returns 'claude' if available, 'agency claude' if agency is available, or undefined if neither.
+	 */
+	private async _getClaudeCliCommand(): Promise<string | undefined> {
+		const whichCommand = process.platform === 'win32' ? 'where' : 'which';
+
+		// Check if 'claude' is available
+		if (await this._isCommandAvailable(whichCommand, 'claude')) {
+			return 'claude';
+		}
+
+		// Check if 'agency' is available (fallback)
+		if (await this._isCommandAvailable(whichCommand, 'agency')) {
+			return 'agency claude';
+		}
+
+		return undefined;
+	}
+
+	/**
+	 * Check if a command is available in PATH
+	 */
+	private async _isCommandAvailable(whichCommand: string, command: string): Promise<boolean> {
+		try {
+			await execFileAsync(whichCommand, [command]);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	private async _getLanguageModelServer(): Promise<ClaudeLanguageModelServer> {
+		if (!this._langModelServer) {
+			this._langModelServer = this.instantiationService.createInstance(ClaudeLanguageModelServer);
+			await this._langModelServer.start();
+		}
+
+		return this._langModelServer;
+	}
+}
+
+// Self-register the terminal command
+registerClaudeSlashCommand(TerminalSlashCommand);

--- a/src/extension/agents/claude/vscode-node/slashCommands/test/terminalCommand.spec.ts
+++ b/src/extension/agents/claude/vscode-node/slashCommands/test/terminalCommand.spec.ts
@@ -1,0 +1,239 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as childProcess from 'child_process';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Terminal, TerminalOptions } from 'vscode';
+import { ILogService } from '../../../../../../platform/log/common/logService';
+import { ITerminalService, NullTerminalService } from '../../../../../../platform/terminal/common/terminalService';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../util/common/test/testUtils';
+import { CancellationToken } from '../../../../../../util/vs/base/common/cancellation';
+import { IInstantiationService } from '../../../../../../util/vs/platform/instantiation/common/instantiation';
+import { createExtensionUnitTestingServices } from '../../../../../test/node/services';
+import { MockChatResponseStream } from '../../../../../test/node/testHelpers';
+import { ClaudeLanguageModelServer } from '../../../node/claudeLanguageModelServer';
+import { TerminalSlashCommand } from '../terminalCommand';
+
+// Mock child_process.execFile
+vi.mock('child_process', () => ({
+	execFile: vi.fn(),
+}));
+
+interface MockTerminal extends Pick<Terminal, 'show' | 'sendText' | 'dispose'> {
+	show: ReturnType<typeof vi.fn>;
+	sendText: ReturnType<typeof vi.fn>;
+	dispose: ReturnType<typeof vi.fn>;
+}
+
+class TestTerminalService extends NullTerminalService {
+	public mockTerminal: MockTerminal;
+	public createTerminalSpy: ReturnType<typeof vi.fn>;
+
+	constructor() {
+		super();
+		this.mockTerminal = {
+			show: vi.fn(),
+			sendText: vi.fn(),
+			dispose: vi.fn(),
+		};
+		this.createTerminalSpy = vi.fn().mockReturnValue(this.mockTerminal);
+	}
+
+	override createTerminal(): Terminal {
+		return this.createTerminalSpy(...arguments);
+	}
+}
+
+interface MockLanguageModelServer extends Pick<ClaudeLanguageModelServer, 'start' | 'getConfig'> {
+	start: ReturnType<typeof vi.fn>;
+	getConfig: ReturnType<typeof vi.fn>;
+}
+
+describe('TerminalSlashCommand', () => {
+	let terminalCommand: TerminalSlashCommand;
+	let testTerminalService: TestTerminalService;
+	let mockLogService: ILogService;
+	let mockLanguageModelServer: MockLanguageModelServer;
+	let execFileMock: ReturnType<typeof vi.fn>;
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	beforeEach(() => {
+		// Setup execFile mock - default to claude being available
+		execFileMock = vi.fn((cmd: string, args: string[], callback: (error: Error | null) => void) => {
+			if (args[0] === 'claude') {
+				callback(null);
+			} else {
+				callback(new Error('not found'));
+			}
+		});
+		vi.mocked(childProcess.execFile).mockImplementation(execFileMock);
+
+		// Create test terminal service
+		testTerminalService = store.add(new TestTerminalService());
+
+		// Create mock language model server
+		mockLanguageModelServer = {
+			start: vi.fn().mockResolvedValue(undefined),
+			getConfig: vi.fn().mockReturnValue({
+				port: 12345,
+				nonce: 'test-nonce-123',
+			}),
+		};
+
+		// Create testing services
+		const serviceCollection = store.add(createExtensionUnitTestingServices(store));
+		serviceCollection.set(ITerminalService, testTerminalService);
+
+		const accessor = serviceCollection.createTestingAccessor();
+		mockLogService = accessor.get(ILogService);
+
+		terminalCommand = accessor.get(IInstantiationService).createInstance(TerminalSlashCommand);
+		// Set the mock language model server directly using defineProperty to bypass type checking
+		Object.defineProperty(terminalCommand, '_langModelServer', {
+			value: mockLanguageModelServer,
+			writable: true,
+		});
+	});
+
+	describe('command properties', () => {
+		it('has correct command name', () => {
+			expect(terminalCommand.commandName).toBe('terminal');
+		});
+
+		it('has correct description', () => {
+			expect(terminalCommand.description).toBe('Launch Claude Code CLI using your GitHub Copilot subscription');
+		});
+
+		it('has correct command ID', () => {
+			expect(terminalCommand.commandId).toBe('copilot.claude.terminal');
+		});
+	});
+
+	describe('handle', () => {
+		it('creates a terminal with correct environment variables', async () => {
+			const mockStream = new MockChatResponseStream();
+
+			await terminalCommand.handle('', mockStream, CancellationToken.None);
+
+			expect(testTerminalService.createTerminalSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: 'Claude',
+					env: {
+						ANTHROPIC_BASE_URL: 'http://localhost:12345',
+						ANTHROPIC_AUTH_TOKEN: 'test-nonce-123',
+					}
+				})
+			);
+		});
+
+		it('creates a terminal with styled message', async () => {
+			const mockStream = new MockChatResponseStream();
+
+			await terminalCommand.handle('', mockStream, CancellationToken.None);
+
+			const createTerminalCall = testTerminalService.createTerminalSpy.mock.calls[0][0] as TerminalOptions;
+			expect(createTerminalCall.message).toContain('\x1b[1;36m');
+			expect(createTerminalCall.message).toContain('GitHub Copilot subscription');
+		});
+
+		it('shows the terminal after creation', async () => {
+			const mockStream = new MockChatResponseStream();
+
+			await terminalCommand.handle('', mockStream, CancellationToken.None);
+
+			expect(testTerminalService.mockTerminal.show).toHaveBeenCalled();
+		});
+
+		it('sends claude command to terminal when claude is available', async () => {
+			const mockStream = new MockChatResponseStream();
+
+			await terminalCommand.handle('', mockStream, CancellationToken.None);
+
+			expect(testTerminalService.mockTerminal.sendText).toHaveBeenCalledWith('claude');
+		});
+
+		it('sends agency claude command when only agency is available', async () => {
+			// Mock: claude not available, agency available
+			execFileMock.mockImplementation((cmd: string, args: string[], callback: (error: Error | null) => void) => {
+				if (args[0] === 'agency') {
+					callback(null);
+				} else {
+					callback(new Error('not found'));
+				}
+			});
+
+			const mockStream = new MockChatResponseStream();
+
+			await terminalCommand.handle('', mockStream, CancellationToken.None);
+
+			expect(testTerminalService.mockTerminal.sendText).toHaveBeenCalledWith('agency claude');
+		});
+
+		it('shows download button when neither CLI is available', async () => {
+			// Mock: neither claude nor agency available
+			execFileMock.mockImplementation((cmd: string, args: string[], callback: (error: Error | null) => void) => {
+				callback(new Error('not found'));
+			});
+
+			const mockStream = new MockChatResponseStream();
+			const buttonSpy = vi.spyOn(mockStream, 'button');
+
+			await terminalCommand.handle('', mockStream, CancellationToken.None);
+
+			expect(mockStream.output.some(o => o.includes('not installed'))).toBe(true);
+			expect(buttonSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: 'vscode.open',
+					title: expect.stringContaining('Download'),
+				})
+			);
+			expect(testTerminalService.createTerminalSpy).not.toHaveBeenCalled();
+		});
+
+		it('handles undefined stream gracefully', async () => {
+			await expect(terminalCommand.handle('', undefined, CancellationToken.None)).resolves.toBeDefined();
+
+			expect(testTerminalService.createTerminalSpy).toHaveBeenCalled();
+			expect(testTerminalService.mockTerminal.show).toHaveBeenCalled();
+		});
+
+		it('handles errors gracefully with stream', async () => {
+			// Make createTerminal throw an error
+			testTerminalService.createTerminalSpy.mockImplementation(() => {
+				throw new Error('Failed to create terminal');
+			});
+
+			const mockStream = new MockChatResponseStream();
+
+			await terminalCommand.handle('', mockStream, CancellationToken.None);
+
+			expect(mockStream.output.some(o => o.includes('Error creating terminal'))).toBe(true);
+		});
+
+		it('logs terminal creation info', async () => {
+			const mockStream = new MockChatResponseStream();
+			const infoSpy = vi.spyOn(mockLogService, 'info');
+
+			await terminalCommand.handle('', mockStream, CancellationToken.None);
+
+			expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Created terminal with Claude CLI configured on port 12345'));
+		});
+
+		it('logs errors when terminal creation fails', async () => {
+			// Make createTerminal throw an error
+			testTerminalService.createTerminalSpy.mockImplementation(() => {
+				throw new Error('Failed to create terminal');
+			});
+
+			const mockStream = new MockChatResponseStream();
+			const errorSpy = vi.spyOn(mockLogService, 'error');
+
+			await terminalCommand.handle('', mockStream, CancellationToken.None);
+
+			expect(errorSpy).toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
This way you can use your Copilot Subscription with the Claude Code CLI.

fixes https://github.com/microsoft/vscode/issues/291384