### PR TITLE
refactor: shorten agent customization skill docs and clarify agent fields

### DIFF
--- a/assets/prompts/skills/agent-customization/SKILL.md
+++ b/assets/prompts/skills/agent-customization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-customization
-description: 'Work with VS Code agent customization files (.instructions.md, .prompt.md, .agent.md, SKILL.md, copilot-instructions.md, AGENTS.md). Use when asked to: create, update, review, fix, or debug instructions/prompts/agents/skills; save coding preferences or conventions; understand how customization files work; troubleshoot why instructions/skills are not applying or being ignored; compare customization approaches; migrate or refactor existing customizations; set up project guidelines; configure applyTo patterns; define tool restrictions; create reusable workflows; build custom agent modes or personas; package domain knowledge; add frontmatter; fix YAML syntax; or share team standards.'
+description: 'Create, update, review, fix, or debug VS Code agent customization files (.instructions.md, .prompt.md, .agent.md, SKILL.md, copilot-instructions.md, AGENTS.md). Use for: saving coding preferences; troubleshooting why instructions/skills/agents are ignored or not invoked; configuring applyTo patterns; defining tool restrictions; creating custom agent modes or specialized workflows; packaging domain knowledge; fixing YAML frontmatter syntax.'
 ---
 
 # Agent Customization
@@ -24,7 +24,7 @@ Consult the reference docs for templates, domain examples, advanced frontmatter 
 |------|------|----------|-----------|---------|
 | Workspace Instructions | `copilot-instructions.md`, `AGENTS.md` | `.github/` or root | N/A (always applies) | [Link](./primitives/workspace-instructions.md) |
 | File Instructions | `*.instructions.md` | `.github/instructions/` | `applyTo` (explicit), `description` (on-demand) | [Link](./primitives/instructions.md) |
-| Prompts | `*.prompt.md` | `.github/prompts/` | `description` (required) | [Link](./primitives/prompts.md) |
+| Prompts | `*.prompt.md` | `.github/prompts/` | `description` (user-invoked) | [Link](./primitives/prompts.md) |
 | Custom Agents | `*.agent.md` | `.github/agents/` | `description` (on-demand), `infer` (subagent) | [Link](./primitives/agents.md) |
 | Skills | `SKILL.md` | `.github/skills/<name>/` | `description` (on-demand) | [Link](./primitives/skills.md) |
 

--- a/assets/prompts/skills/agent-customization/primitives/instructions.md
+++ b/assets/prompts/skills/agent-customization/primitives/instructions.md
@@ -1,176 +1,69 @@
 # [File-Specific Instructions (.instructions.md)](https://code.visualstudio.com/docs/copilot/customization/custom-instructions)
 
-Conditional guidelines that apply to specific file types, folders, or tasks using glob patterns.
+Guidelines loaded on-demand when relevant to the current task, or explicitly when files match a pattern.
 
 ## Locations
 
 | Path | Scope |
 |------|-------|
 | `.github/instructions/*.instructions.md` | Workspace |
-| `<profile>/instructions/*.instructions.md` | User profile (cross-workspace) |
+| `<profile>/instructions/*.instructions.md` | User profile |
 
 ## Frontmatter
 
 ```yaml
 ---
-description: "<required>"    # For on-demand discovery (like skills)
+description: "<required>"    # For on-demand discovery—keyword-rich
 name: "Instruction Name"     # Optional, defaults to filename
-applyTo: "**/*.ts"           # Optional, explicit trigger for file patterns
+applyTo: "**/*.ts"           # Optional, auto-attach for matching files
 ---
 ```
 
-## applyTo Patterns
+## Discovery Modes
 
-| Pattern | Effect |
-|---------|--------|
-| `"**"` | Always include |
-| `"**/*.ts"` | Match .ts files |
-| `["src/**", "lib/**"]` | Match multiple (OR) |
-| `"**/test/**"` | Match paths containing test |
-| `"src/api/**/*.ts"` | Match specific folder + extension |
-
-**Trigger**: Applied when creating or modifying files that match the pattern. Not applied for read-only operations.
-
-**No applyTo**: Instructions can still be loaded implicitly via `description` matching, or manually attached via `Add Context > Instructions`.
+| Mode | Trigger | Use Case |
+|------|---------|----------|
+| **On-demand** (`description`) | Agent detects task relevance | Task-based: migrations, refactoring, API work |
+| **Explicit** (`applyTo`) | Files matching glob in context | File-based: language standards, framework rules |
+| **Manual** | `Add Context` → `Instructions` | Ad-hoc attachment |
 
 ## Template
 
 ```markdown
 ---
-description: "TypeScript coding standards"
-applyTo: "**/*.ts"
+description: "Use when writing database migrations, schema changes, or data transformations. Covers safety checks and rollback patterns."
 ---
-# TypeScript Guidelines
+# Migration Guidelines
 
-- Use `interface` for object shapes, `type` for unions
-- Avoid `any`, enable strict mode
-- JSDoc for public APIs
-- Reference tools with #tool:<name> syntax
+- Always create reversible migrations
+- Test rollback before merging
+- Never drop columns in the same release as code removal
 ```
 
-## Examples
+Note the "Use when..." pattern in the description—this helps on-demand discovery.
 
-### Language-Specific
+## Explicit File Matching (optional)
+
+Use `applyTo` when the instruction applies to specific file types or folders:
 
 ```yaml
-# python-standards.instructions.md
----
-description: "Python coding standards"
-applyTo: "**/*.py"
----
+applyTo: "**/*.py"                      # All Python files
+applyTo: ["src/**", "lib/**"]           # Multiple patterns (OR)
+applyTo: "src/api/**/*.ts"              # Specific folder + extension
 ```
 
-### Framework-Specific
-
-```yaml
-# react-components.instructions.md
----
-description: "React component patterns"
-applyTo: ["src/components/**", "src/pages/**"]
----
-```
-
-### Folder-Specific
-
-```yaml
-# backend-api.instructions.md
----
-description: "Backend API conventions"
-applyTo: "src/api/**"
----
-```
-
-### Task-Based (On-Demand)
-
-```yaml
-# database-migrations.instructions.md
----
-description: "Database migration patterns and best practices"
-# No applyTo—loaded implicitly when the agent detects migration-related tasks
----
-```
-
-## Invocation
-
-- **Explicit (applyTo)**: Auto-attaches when files matching the glob pattern are in context (creating/modifying)
-- **Implicit (description)**: Agent loads on-demand when the description fits the current task—like skills
-- **Manual**: Chat view → `Add Context` → `Instructions`
-- **Configure**: Chat view → gear icon → `Chat Instructions`
-- **New file**: `Chat: New Instructions File` command
-
-## Settings
-
-| Setting | Purpose |
-|---------|---------|
-| `chat.instructionsFilesLocations` | Additional folders to search for `.instructions.md` |
-
-## Task-Specific Settings (deprecated)
-
-Prefer `.instructions.md` files. Legacy settings for specific workflows:
-
-| Setting | Scenario |
-|---------|----------|
-| `github.copilot.chat.reviewSelection.instructions` | Code review |
-| `github.copilot.chat.commitMessageGeneration.instructions` | Commit messages |
-| `github.copilot.chat.pullRequestDescriptionGeneration.instructions` | PR descriptions |
-
-## When to Use
-
-- **Language-specific rules** (Python style, TypeScript patterns) → use `applyTo`
-- **Framework conventions** (React, Vue, backend frameworks) → use `applyTo`
-- **Folder-based guidelines** (frontend vs backend, tests vs source) → use `applyTo`
-- **Task-focused instructions** (API development, migrations, refactoring) → rely on `description` for on-demand loading
-
-**Key Signal**: Use `applyTo` when the instruction is file-based; use a descriptive `description` when the instruction is task-based.
-
-## Creation Process
-
-### 1. Gather Requirements
-
-- **File-based or task-based?** Use `applyTo` for file patterns; omit for task-focused instructions loaded via `description`
-- What file types, folders, or patterns should this apply to?
-- What coding standards, conventions, or guidelines are needed? Research current codebase using a subagent if needed.
-- Should this be workspace-specific or personal (user profile)?
-
-### 2. Determine Location
-
-| Scope | Path |
-|-------|------|
-| Workspace | `.github/instructions/<name>.instructions.md` |
-| User profile | `<profile>/instructions/<name>.instructions.md` |
-
-### 3. Create the File
-
-```markdown
----
-description: "<clear, concise description>"
-applyTo: "<glob pattern or array>"  # Optional—omit for task-based instructions
----
-# <Title>
-
-<Guidelines organized by topic>
-```
-
-### 4. Verify Activation
-
-- For `applyTo` patterns: Create or edit a matching file to confirm auto-attachment
-- For `description`-based: Perform a task matching the description and verify the instruction is loaded
-- For manual instructions: Add via `Add Context > Instructions` in chat
+Applied when creating or modifying matching files, not for read-only operations.
 
 ## Core Principles
 
-1. **Keyword-rich descriptions**: The `description` frontmatter is how instructions are discovered—include relevant trigger words and use cases
-2. **One concern per file**: Layer multiple instruction files for different concerns (e.g., separate files for testing, styling, documentation)
-3. **Concise and actionable**: Instructions share context window with conversation—keep them focused
-4. **Show, don't tell**: Include brief code examples over lengthy explanations
-5. **Pattern precision**: Use specific `applyTo` patterns to avoid over-matching (e.g., `src/api/**/*.ts` not `**/*.ts`)
-6. **Reference, don't duplicate**: Use `#tool:<name>` and Markdown links instead of copying content
+1. **Keyword-rich descriptions**: Include trigger words for on-demand discovery
+2. **One concern per file**: Separate files for testing, styling, documentation
+3. **Concise and actionable**: Share context window—keep focused
+4. **Show, don't tell**: Brief code examples over lengthy explanations
 
 ## Anti-patterns
 
-- **Vague descriptions**: Generic descriptions that don't help discovery (e.g., "Helpful coding tips")
-- **Overly broad patterns**: `applyTo: "**"` with content only relevant to specific files
-- **Duplicating project docs**: Copying README or CONTRIBUTING content instead of linking
-- **Mixing concerns**: Combining unrelated guidelines (testing + API design + styling) in one file
-- **Stale instructions**: Guidelines that contradict current codebase patterns
-- **Verbose prose**: Long paragraphs instead of actionable bullet points
+- **Vague descriptions**: "Helpful coding tips" doesn't enable discovery
+- **Overly broad applyTo**: `"**"` with content only relevant to specific files
+- **Duplicating docs**: Copy README instead of linking
+- **Mixing concerns**: Testing + API design + styling in one file

--- a/assets/prompts/skills/agent-customization/primitives/prompts.md
+++ b/assets/prompts/skills/agent-customization/primitives/prompts.md
@@ -1,6 +1,6 @@
 # [Prompts (.prompt.md)](https://code.visualstudio.com/docs/copilot/customization/prompt-files)
 
-Reusable task templates triggered on-demand in chat.
+Reusable task templates triggered on-demand in chat. Single focused task with parameterized inputs.
 
 ## Locations
 
@@ -13,107 +13,52 @@ Reusable task templates triggered on-demand in chat.
 
 ```yaml
 ---
-description: "<required>"    # Prompt description
+description: "<required>"    # Prompt description for discovery
 name: "Prompt Name"          # Optional, defaults to filename
 agent: "agent"               # Optional: ask, edit, agent, or custom agent
-tools: ["search", "fetch"]   # Optional: built-in, MCP (<server>/*), extension
+tools: ["search", "web"]     # Optional: built-in, MCP (<server>/*), extension
 model: "Claude Sonnet 4"     # Optional, uses picker default
-argument-hint: "Task..."     # Optional, input guidance
 ---
 ```
-
-## Variables
-
-| Syntax | Description |
-|--------|-------------|
-| `${workspaceFolder}` | Workspace path |
-| `${file}`, `${fileBasename}` | Current file |
-| `${selection}`, `${selectedText}` | Editor selection |
-| `${input:varName}` | Prompt user for input |
-| `${input:varName:placeholder}` | With placeholder text |
-
-**Context references**: Use Markdown links for files, `#tool:<name>` for tools.
 
 ## Template
 
 ```markdown
 ---
-name: "Create React Form"
-description: "Generate a React form component"
-argument-hint: "Provide form requirements"
+description: "Generate test cases for selected code"
+agent: "agent"
 ---
-Generate a React form component with the following requirements:
-- Use TypeScript and functional components
-- Include form validation
-- Follow existing patterns in #tool:codebase
+Generate comprehensive test cases for the provided code:
+- Include edge cases and error scenarios
+- Follow existing test patterns in the codebase
+- Use descriptive test names
 ```
+
+**Context references**: Use Markdown links for files (`[config](./config.json)`) and `#tool:<name>` for tools.
 
 ## Invocation
 
-- Chat: Type `/` → select prompt (add extra info: `/create-form formName=MyForm`)
-- Command: `Chat: Run Prompt...`
-- Editor: Open prompt file → play button in title bar
+- **Chat**: Type `/` → select prompt
+- **Command**: `Chat: Run Prompt...`
+- **Editor**: Open prompt file → play button
 
 **Tip**: Use `chat.promptFilesRecommendations` to show prompts as actions when starting a new chat.
 
-## Tool Priority
-
-When prompt references an agent, tools are resolved: prompt tools → agent tools → default agent tools.
-
 ## When to Use
 
-**Key Signal**: Single focused task with parameterized inputs. Reusable prompt run once per task with different inputs each time.
-
 - Generate test cases for specific code
-- Summarize metrics with custom parameters
 - Create READMEs from specs
+- Summarize metrics with custom parameters
 - One-off generation tasks
-
-## Creation Process
-
-### 1. Gather Requirements
-
-- What specific task should this prompt accomplish?
-- What inputs/variables does the user need to provide?
-- Should this be workspace-specific or personal (user profile)?
-- Does it need specific tools or a particular agent mode?
-
-### 2. Determine Location
-
-| Scope | Path |
-|-------|------|
-| Workspace | `.github/prompts/<name>.prompt.md` |
-| User profile | `<profile>/prompts/<name>.prompt.md` |
-
-### 3. Create the File
-
-```markdown
----
-description: "<what this prompt does>"
-argument-hint: "<guidance for user input>"
----
-<Clear task instructions with ${variables} for user input>
-
-<Examples of expected output if helpful>
-```
-
-### 4. Test the Prompt
-
-- Ask the user to invoke with `/prompt-name` in chat
-- Confirm output matches intended behavior
 
 ## Core Principles
 
-1. **Single task focus**: One prompt = one well-defined task; don't combine unrelated operations
-2. **Clear input contract**: Use `${input:varName:placeholder}` with descriptive placeholders
-3. **Output examples**: Show expected output format when quality depends on specific structure
-4. **Reuse over duplication**: Reference instruction files instead of copying guidelines
-5. **Appropriate tooling**: Only specify `tools` when the task requires more than defaults
+1. **Single task focus**: One prompt = one well-defined task
+2. **Output examples**: Show expected format when quality depends on structure
+3. **Reuse over duplication**: Reference instruction files instead of copying
 
 ## Anti-patterns
 
-- **Multi-task prompts**: Combining "create and test and deploy" in one prompt
-- **Missing context**: Prompts that assume knowledge not provided in variables
-- **Hardcoded values**: Embedding specific file paths or names instead of using variables
-- **Vague descriptions**: Descriptions that don't help users understand when to use the prompt
-- **Over-tooling**: Specifying many tools when the task only needs search or file access
+- **Multi-task prompts**: "create and test and deploy" in one prompt
+- **Vague descriptions**: Descriptions that don't help users understand when to use
+- **Over-tooling**: Many tools when the task only needs search or file access

--- a/assets/prompts/skills/agent-customization/primitives/skills.md
+++ b/assets/prompts/skills/agent-customization/primitives/skills.md
@@ -1,182 +1,82 @@
 # [Agent Skills (SKILL.md)](https://code.visualstudio.com/docs/copilot/customization/agent-skills)
 
-Folders of instructions, scripts, and resources that agents loads when relevant for specialized tasks.
+Folders of instructions, scripts, and resources that agents load on-demand for specialized tasks.
 
 ## Structure
 
 ```
 .github/skills/<skill-name>/
-├── SKILL.md           # Required
-├── test-template.js   # Scripts
-├── examples/          # Example scenarios
-└── docs/              # Additional docs
+├── SKILL.md           # Required (name must match folder)
+├── scripts/           # Executable code
+├── references/        # Docs loaded as needed
+└── assets/            # Templates, boilerplate
 ```
 
 ## Locations
 
 | Path | Scope |
 |------|-------|
-| `.github/skills/<name>/` | Project (recommended) |
-| `.claude/skills/<name>/` | Project (legacy) |
-| `~/.copilot/skills/<name>/` | Personal (recommended) |
-| `~/.claude/skills/<name>/` | Personal (legacy) |
+| `.github/skills/<name>/` | Project |
+| `~/.copilot/skills/<name>/` | Personal |
 
 ## SKILL.md Format
 
-### Frontmatter (required)
-
 ```yaml
 ---
-name: skill-name      # Must match parent folder name
-description: 'What the skill does and when to use it. For on-demand discovery. Max 1024 chars.'
+name: skill-name              # Required: 1-64 chars, lowercase alphanumeric + hyphens, must match folder
+description: 'What and when to use. Max 1024 chars.'
 ---
-```
-
-#### `name` field rules
-
-- **Must match the parent directory name** (e.g., `pdf-processing/SKILL.md` requires `name: pdf-processing`)
-- 1-64 characters
-- Lowercase alphanumeric and hyphens only (`a-z`, `0-9`, `-`)
-- Must not start or end with `-`
-- Must not contain consecutive hyphens (`--`)
-
-#### Optional frontmatter fields
-
-```yaml
-license: Apache-2.0                           # License name or bundled file reference
-compatibility: Requires git, docker, jq       # Environment requirements (max 500 chars)
 ```
 
 ### Body
 
 - What the skill accomplishes
-- When to use the skill
+- When to use (triggers and use cases)
 - Step-by-step procedures
-- Examples of input/output
-- References to scripts/resources via relative paths: `[test script](./test-template.js)`
+- References to resources: `[script](./scripts/test.js)`
 
 ## Template
 
 ```markdown
 ---
 name: webapp-testing
-description: 'Test web applications using Playwright. Use when verifying frontend functionality, debugging UI, capturing screenshots.'
+description: 'Test web applications using Playwright. Use for verifying frontend, debugging UI, capturing screenshots.'
 ---
 
 # Web Application Testing
 
 ## When to Use
-
 - Verify frontend functionality
 - Debug UI behavior
-- Capture browser screenshots
 
 ## Procedure
-
 1. Start the web server
-2. Run tests with `[test script](./test-template.js)`
+2. Run [test script](./scripts/test.js)
 3. Review screenshots in `./screenshots/`
-
-## References
-
-- [examples/login-test.js](./examples/login-test.js)
 ```
 
 ## Progressive Loading
 
-Skills use three-level loading for efficient context:
+1. **Discovery** (~100 tokens): Agent reads `name` and `description`
+2. **Instructions** (<5000 tokens): Loads `SKILL.md` body when relevant
+3. **Resources**: Additional files load only when referenced
 
-1. **Discovery** (~100 tokens): Agent reads `name` and `description` from frontmatter (always available)
-2. **Instructions** (<5000 tokens recommended): When description matches current task, loads `SKILL.md` body
-3. **Resources** (as needed): Additional files (scripts, examples) load only when referenced
-
-Keep file references one level deep from `SKILL.md`. Avoid deeply nested reference chains.
+Keep file references one level deep from `SKILL.md`.
 
 ## When to Use
 
-**Key Signal**: Repeatable, on-demand workflows with bundled assets (scripts, templates, reference docs).
-
-## Domain Examples
-
-| Domain | Examples |
-|--------|----------|
-| Engineering | Microservice deployment, incident response runbook, security review |
-| Product | User research synthesis, roadmap prioritization, launch validation |
-| Data | Customer segmentation, data quality validation, cohort analysis |
-| Design | Design critique framework, user flow docs, design-to-dev handoff |
-| Sales | Enterprise qualification, demo prep checklist, proposal framework |
-
-## Asset Organization
-
-| Folder | Purpose |
-|--------|----------|
-| `scripts/` | Code that runs each time (profiling, deployment, data fetch) |
-| `references/` | Docs that clarify complex bits (architecture, API schemas) |
-| `assets/` | Templates and boilerplate (Terraform, SQL templates, dashboard JSON) |
-
-## Creation Process
-
-### 1. Gather Requirements
-
-- What workflow or domain knowledge should this skill provide?
-- What resources are needed (scripts, templates, reference docs)?
-- Should this be project-specific or personal?
-
-### 2. Determine Location
-
-| Scope | Path |
-|-------|------|
-| Project | `.github/skills/<skill-name>/SKILL.md` |
-| Personal | `~/.copilot/skills/<skill-name>/SKILL.md` |
-
-### 3. Create the Skill Folder
-
-```
-<skill-name>/
-├── SKILL.md           # Required: instructions and metadata
-├── scripts/           # Optional: executable code
-├── references/        # Optional: documentation to load as needed
-└── assets/            # Optional: templates, boilerplate
-```
-
-### 4. Write SKILL.md
-
-```markdown
----
-name: <skill-name>
-description: '<keyword-rich description of what and when>'
----
-# <Skill Title>
-
-## When to Use
-<Triggers and use cases>
-
-## Procedure
-<Step-by-step workflow>
-
-## Resources
-- [script.py](./scripts/script.py)
-- [reference.md](./references/reference.md)
-```
-
-### 5. Add Resources
-
-Create supporting files as needed, referencing them from SKILL.md with relative paths.
+Repeatable, on-demand workflows with bundled assets (scripts, templates, reference docs).
 
 ## Core Principles
 
-1. **Keyword-rich descriptions**: The `description` frontmatter is how skills are discovered—include all relevant trigger words and use cases
-2. **Progressive loading**: Keep SKILL.md under 500 lines; move detailed content to reference files
-3. **Relative path references**: Always use `./` relative paths to reference skill resources
-4. **Minimal context footprint**: Only load resources when needed—context window is shared
-5. **Self-contained workflows**: Include all procedural knowledge needed to complete the task
+1. **Keyword-rich descriptions**: Include trigger words for discovery
+2. **Progressive loading**: Keep SKILL.md under 500 lines; use reference files
+3. **Relative paths**: Always use `./` for skill resources
+4. **Self-contained**: Include all procedural knowledge to complete the task
 
 ## Anti-patterns
 
-- **Vague descriptions**: Generic descriptions that don't help discovery (e.g., "A helpful skill")
-- **Monolithic SKILL.md**: Putting everything in one file instead of using reference files
-- **Absolute paths**: Using system paths instead of relative references
-- **Missing procedures**: Descriptions of what but not how—skills need step-by-step guidance
-- **Untested scripts**: Including scripts without verifying they work in the target environment
-- **Duplicate content**: Copying reference content into SKILL.md instead of linking
-- **Name mismatch**: Folder name doesn't match the `name` field in frontmatter
+- **Vague descriptions**: "A helpful skill" doesn't enable discovery
+- **Monolithic SKILL.md**: Everything in one file instead of references
+- **Name mismatch**: Folder name doesn't match `name` field
+- **Missing procedures**: Descriptions without step-by-step guidance

--- a/assets/prompts/skills/agent-customization/primitives/workspace-instructions.md
+++ b/assets/prompts/skills/agent-customization/primitives/workspace-instructions.md
@@ -4,145 +4,61 @@ Guidelines that automatically apply to all chat requests across your entire work
 
 ## File Types (Choose One)
 
-Workspaces should have **only one** of these files—not both:
+| File | Location | Purpose |
+|------|----------|---------|
+| `copilot-instructions.md` | `.github/` | Project-wide standards (recommended, cross-editor) |
+| `AGENTS.md` | Root or subfolders | Open standard, monorepo hierarchy support |
 
-| File | Purpose |
-|------|---------|
-| `.github/copilot-instructions.md` | Project-wide coding standards and preferences (Recommended) |
-| `AGENTS.md` | Same, but using an open standard |
+Use **only one**—not both.
 
-## copilot-instructions.md
+## AGENTS.md Hierarchy
 
-Single file at workspace root that applies to every chat request automatically.
-
-**Location**: `.github/copilot-instructions.md`
-
-### Cross-Editor Support
-
-This file is also detected by GitHub Copilot in Visual Studio and GitHub.com, enabling shared instructions across editors.
-
-## AGENTS.md
-
-Open standard for guiding AI coding agents ([agents.md](https://agents.md/)). Standard markdown—no required fields.
-
-**Location**: Workspace root, or subfolders for monorepos. Agents automatically read the nearest file in the directory tree, so the closest one takes precedence:
+For monorepos, the closest file in the directory tree takes precedence:
 
 ```
-/AGENTS.md              # Root-level defaults
+/AGENTS.md              # Root defaults
 /frontend/AGENTS.md     # Frontend-specific (overrides root)
 /backend/AGENTS.md      # Backend-specific (overrides root)
 ```
 
 ## Template
 
-Both file types use the same markdown format. Only include sections the workspace benefits from—skip any that don't apply:
+Only include sections the workspace benefits from:
 
 ```markdown
 # Project Guidelines
 
 ## Code Style
-{Language and formatting preferences - reference key files that exemplify patterns}
+{Language and formatting preferences—reference key files that exemplify patterns}
 
 ## Architecture
-{Major components, service boundaries, data flows, the "why" behind structural decisions}
+{Major components, service boundaries, the "why" behind structural decisions}
 
 ## Build and Test
-{Commands to install, build, test - agents will attempt to run these automatically}
+{Commands to install, build, test—agents will attempt to run these}
 
-## Project Conventions
-{Patterns that differ from common practices - include specific examples from the codebase}
-
-## Integration Points
-{External dependencies and cross-component communication}
-
-## Security
-{Sensitive areas and auth patterns}
+## Conventions
+{Patterns that differ from common practices—include specific examples}
 ```
+
+For large repos, link to detailed docs instead of embedding: `See docs/TESTING.md for test conventions.`
 
 ## When to Use
 
-- **General coding standards** that apply everywhere
-- **Team preferences** shared through version control
-- **Project-wide requirements** like testing standards or documentation rules
-
-**Key Signal**: Context that's always available. Standards, guidelines, and expectations that apply broadly across work.
-
-## Domain Examples
-
-| Domain | Examples |
-|--------|----------|
-| Engineering | TypeScript strict mode, test coverage, accessibility (WCAG 2.1 AA) |
-| Product | User stories in briefs, accessibility/i18n in specs |
-| Data | SQL query comments, metric definitions linked |
-| Support | Empathetic tone, escalation includes impact/context |
-| Design | Use shared component library, include error states |
-
-## Creation Process
-
-### 1. Assess Existing Instructions
-
-Check if a workspace instructions file already exists:
-- `.github/copilot-instructions.md`
-- `AGENTS.md` at workspace root
-
-If one exists, update it rather than creating a second file. Workspaces should only have one.
-
-### 2. Choose File Type (If None Exists)
-
-| File | Best For |
-|------|----------|
-| `copilot-instructions.md` (Recommended) | VS Code/GitHub Copilot-specific, cross-editor support |
-| `AGENTS.md` | Open standard, supports subfolder organization |
-
-### 3. Create or Update
-
-**For copilot-instructions.md**:
-```
-.github/copilot-instructions.md
-```
-
-**For AGENTS.md** (supports hierarchy):
-```
-/AGENTS.md              # Root-level defaults
-/frontend/AGENTS.md     # Frontend-specific
-/backend/AGENTS.md      # Backend-specific
-```
-
-### 4. Structure Content
-
-Research existing guidelines and conventions in the workspace using a subagent as needed. Focus on essential knowledge that helps an AI agent be immediately productive:
-
-- **Architecture**: Major components, service boundaries, data flows, the "why" behind structural decisions
-- **Developer workflows**: Build, test, debug commands not obvious from file inspection
-- **Project conventions**: Patterns that differ from common practices
-- **Integration points**: External dependencies and cross-component communication
-
-Use the Template above.
+- General coding standards that apply everywhere
+- Team preferences shared through version control
+- Project-wide requirements (testing, documentation)
 
 ## Core Principles
 
-1. **Minimal by default**: Include only what's relevant to *every* task. Every extra line dilutes focus.
-2. **Concise and actionable**: Every line should guide behavior—remove filler prose
-3. **Project-specific focus**: Include conventions not obvious from reading the code or enforced by linters
-4. **Link, don't embed**: Reference docs instead of copying content. Use `See docs/TYPESCRIPT.md for conventions`
-5. **Capabilities over paths**: Describe what systems do, not where files live. File paths go stale; domain concepts stay stable
-6. **Keep current**: Update when practices change—stale instructions actively poison agent context
-
-## Progressive Disclosure
-
-For large repos, reference separate docs instead of embedding everything. Agents navigate doc hierarchies efficiently—language-specific rules load only when relevant.
-
-```markdown
-## Conventions
-For TypeScript patterns, see docs/TYPESCRIPT.md
-For testing guidelines, see docs/TESTING.md
-```
+1. **Minimal by default**: Only what's relevant to *every* task
+2. **Concise and actionable**: Every line should guide behavior
+3. **Link, don't embed**: Reference docs instead of copying
+4. **Keep current**: Update when practices change
 
 ## Anti-patterns
 
-- **Using both file types**: Having both `copilot-instructions.md` and `AGENTS.md` in the same workspace
-- **Kitchen sink**: Trying to include every possible guideline instead of focusing on what matters most
-- **Duplicating project docs**: Copying README or CONTRIBUTING content instead of linking to them
-- **Obvious instructions**: Stating conventions already enforced by linters or obvious from code
-- **Verbose prose**: Long explanations instead of clear, scannable guidelines
-- **Contradictory rules**: Different developers adding conflicting opinions without reconciliation
+- **Using both file types**: Having both `copilot-instructions.md` and `AGENTS.md`
+- **Kitchen sink**: Everything instead of what matters most
+- **Duplicating docs**: Copying README instead of linking
+- **Obvious instructions**: Conventions already enforced by linters


### PR DESCRIPTION
Based on team feedback, this PR refactors the agent customization skill documentation:

- **Shortened all primitive docs** - Reduced overall content by ~400 lines to keep prompts concise
- **Removed prompt variables** - Simplified by removing `${VAR}` variable syntax examples that were adding confusion
- **Clarified agent fields** - Improved explanations for agent configuration properties like `name`, `description`, `instructions`, etc.

### Affected files
- `SKILL.md` - Minor tweaks
- `primitives/agents.md` - Streamlined agent configuration docs
- `primitives/instructions.md` - Condensed instruction examples
- `primitives/prompts.md` - Simplified prompt documentation
- `primitives/skills.md` - Reduced skill configuration content
- `primitives/workspace-instructions.md` - Shortened workspace instruction docs