### PR TITLE
Update family property to use model ID in byokKnownModelToAPIInfo function

### DIFF
--- a/src/extension/byok/common/byokProvider.ts
+++ b/src/extension/byok/common/byokProvider.ts
@@ -160,7 +160,7 @@ export function byokKnownModelToAPIInfo(providerName: string, id: string, capabi
 		maxOutputTokens: capabilities.maxOutputTokens,
 		maxInputTokens: capabilities.maxInputTokens,
 		detail: providerName,
-		family: providerName,
+		family: id,
 		tooltip: `${capabilities.name} is contributed via the ${providerName} provider.`,
 		capabilities: {
 			toolCalling: capabilities.toolCalling,


### PR DESCRIPTION
Change the family property to utilize the model ID instead of the provider name in the byokKnownModelToAPIInfo function.