### PR TITLE
Fix experiment assignment race condition for copilotTrackingId filter

### DIFF
--- a/src/extension/completions-core/vscode-node/lib/src/experiments/defaultExpFilters.ts
+++ b/src/extension/completions-core/vscode-node/lib/src/experiments/defaultExpFilters.ts
@@ -22,10 +22,11 @@ export function setupCompletionsExperimentationService(accessor: ServicesAccesso
 	const authService = accessor.get(IAuthenticationService);
 	const instantiationService = accessor.get(IInstantiationService);
 
-	const disposable = authService.onDidAccessTokenChange(() => {
-		authService.getCopilotToken()
-			.then(t => instantiationService.invokeFunction(updateCompletionsFilters, t))
-			.catch(err => { });
+	// Use onDidAuthenticationChange instead of deprecated onDidAccessTokenChange.
+	// onDidAuthenticationChange fires AFTER CopilotToken is minted and stored,
+	// ensuring copilotTrackingId is available for experiment assignment.
+	const disposable = authService.onDidAuthenticationChange(() => {
+		instantiationService.invokeFunction(updateCompletionsFilters, authService.copilotToken);
 	});
 
 	updateCompletionsFilters(accessor, authService.copilotToken);


### PR DESCRIPTION
The code was listening to `onDidAccessTokenChange` which fires **before** the CopilotToken is minted. The handler called `getCopilotToken()` which could:
1. Throw if no token was cached yet (error silently swallowed)
2. Return a stale cached token without the new `tid` value

Meanwhile, telemetry was updating via `onDidStoreUpdate` which fires **after** token is stored, causing a mismatch between telemetry (has `copilotTrackingId`) and ExP assignment (missing the filter).

## Fix
Switch from deprecated `onDidAccessTokenChange` to `onDidAuthenticationChange`, which fires after the CopilotToken is minted and stored. This ensures `authService.copilotToken` already contains the fresh token with `copilotTrackingId` when filters are updated.
