### PR TITLE
Align cloud picker with other pickers

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -680,8 +680,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 						id: DEFAULT_CUSTOM_AGENT_ID,
 						default: true,
 						name: vscode.l10n.t('Agent'),
-						description: vscode.l10n.t('Default'),
-						icon: new vscode.ThemeIcon('file-text')
+						icon: new vscode.ThemeIcon('agent')
 					},
 					...(customAgents.status === 'fulfilled' ? customAgents.value.map(agent => ({
 						id: agent.name,
@@ -710,6 +709,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 				const modelItems: vscode.ChatSessionProviderOptionItem[] = models.value.map(model => ({
 					id: model.id,
 					name: model.name,
+					description: `${model.billing.multiplier}x`,
 				}));
 				if (!models.value.find(m => m.id === DEFAULT_MODEL_ID)) {
 					modelItems.unshift({ id: DEFAULT_MODEL_ID, name: vscode.l10n.t('Auto'), description: vscode.l10n.t('Automatically select the best model') });


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the cloud picker alignment to match the layout of other pickers and update the icon for the default agent. Additionally, include a description for model items indicating their billing multiplier.

https://github.com/microsoft/vscode/issues/291526