### PR TITLE
Cloud: tactically disable customAgents when > 1 git repo is detected

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -674,7 +674,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 				customAgents.status === 'fulfilled' ? customAgents.value : []
 			);
 
-			if ((customAgents.status === 'fulfilled' && customAgents.value.length > 0) || localOnly.length > 0) {
+			if ((customAgents.status === 'fulfilled' && customAgents.value.length > 0) || (repoIds?.length === 1 && localOnly.length > 0)) {
 				const agentItems: vscode.ChatSessionProviderOptionItem[] = [
 					{
 						id: DEFAULT_CUSTOM_AGENT_ID,


### PR DESCRIPTION
I think we need API changes in `provideChatSessionProviderOptions` or add some `filter()` to enable updating other options based on one option