### PR TITLE
Preserve copilotTracking ID (tid) in telemetry when token is reset

### DIFF
--- a/src/platform/telemetry/common/msftTelemetrySender.ts
+++ b/src/platform/telemetry/common/msftTelemetrySender.ts
@@ -114,7 +114,11 @@ export class BaseMsftTelemetrySender implements IMSFTTelemetrySender {
 	private processToken(token: CopilotToken | undefined) {
 		this._username = token?.username;
 		this._vscodeTeamMember = !!token?.isVscodeTeamMember;
-		this._tid = token?.getTokenValue('tid');
+		// Only update tid if we have a new valid value - preserve last known tid for error telemetry where token may be undefined
+		const newTid = token?.getTokenValue('tid');
+		if (newTid) {
+			this._tid = newTid;
+		}
 		this._sku = token?.sku;
 		this._isInternal = !!token?.isInternal;
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/6678

Fixes missing copilotTracking ID (tid) values in error telemetry events (e.g., [response.error] for quotaExceeded, badRequest).

When the Copilot token is reset due to HTTP 401/402/403 responses, the telemetry sender was clearing the tid value immediately. Since error telemetry is sent after the token reset, these events were missing the tracking ID.

The fix preserves the last known tid value instead of clearing it when the token becomes undefined, ensuring error events can still be correlated with the user session that made the request.