### PR TITLE
mcp: simplify endpoint selection in tool calling loop

### DIFF
--- a/src/extension/mcp/vscode-node/mcpToolCallingLoop.tsx
+++ b/src/extension/mcp/vscode-node/mcpToolCallingLoop.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { CancellationToken, ChatRequest, LanguageModelToolInformation, Progress } from 'vscode';
+import type { CancellationToken, LanguageModelToolInformation, Progress } from 'vscode';
 import { IAuthenticationChatUpgradeService } from '../../../platform/authentication/common/authenticationUpgrade';
 import { ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';
 import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
@@ -42,16 +42,12 @@ export class McpToolCallingLoop extends ToolCallingLoop<IMcpToolCallingLoopOptio
 		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, configurationService, experimentationService);
 	}
 
-	private async getEndpoint(request: ChatRequest) {
-		let endpoint = await this.endpointProvider.getChatEndpoint(this.options.request);
-		if (!endpoint.supportsToolCalls) {
-			endpoint = await this.endpointProvider.getChatEndpoint('gpt-4.1');
-		}
-		return endpoint;
+	private async getEndpoint() {
+		return await this.endpointProvider.getChatEndpoint('copilot-fast');
 	}
 
 	protected async buildPrompt(buildPromptContext: IBuildPromptContext, progress: Progress<ChatResponseReferencePart | ChatResponseProgressPart>, token: CancellationToken): Promise<IBuildPromptResult> {
-		const endpoint = await this.getEndpoint(this.options.request);
+		const endpoint = await this.getEndpoint();
 		const renderer = PromptRenderer.create(
 			this.instantiationService,
 			endpoint,
@@ -85,7 +81,7 @@ export class McpToolCallingLoop extends ToolCallingLoop<IMcpToolCallingLoopOptio
 	}
 
 	protected async fetch(opts: ToolCallingLoopFetchOptions, token: CancellationToken): Promise<ChatResponse> {
-		const endpoint = await this.getEndpoint(this.options.request);
+		const endpoint = await this.getEndpoint();
 		return endpoint.makeChatRequest2({
 			...opts,
 			debugName: McpToolCallingLoop.ID,


### PR DESCRIPTION
Simplifies the McpToolCallingLoop by removing unnecessary parameter
and conditional logic from getEndpoint(). The method now consistently
uses the 'copilot-fast' endpoint without checking supportsToolCalls.
Also removes the unused ChatRequest import.

- Removes ChatRequest import that was no longer used
- Simplifies getEndpoint() to directly return 'copilot-fast' endpoint
  without conditional checks for supportsToolCalls
- Removes request parameter from getEndpoint() calls in buildPrompt()
  and fetch() methods

Fixes https://github.com/microsoft/vscode/issues/290343

(Commit message generated by Copilot)