### PR TITLE
Symlink CLAUDE.md instead of pointing to it

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,7 +1,1 @@
-# Claude Instructions
-
-## General Repository Instructions
-
-For all repository instructions, coding standards, and development guidelines, **ALWAYS** read:
-
-**[.github/copilot-instructions.md](../.github/copilot-instructions.md)**
+../.github/copilot-instructions.md


### PR DESCRIPTION
Seems to work on macOS and from what I read, will be ok for our Windows devs:

> Windows compatibility: On Windows, symlinks require Developer Mode enabled or admin privileges. Without these, git clone will create a regular file containing the symlink path as text. 
