### PR TITLE
Removing hash as this is incorrect with gpt-5.2-codex (#3327)

### DIFF
--- a/src/extension/prompts/node/agent/openai/gpt51CodexPrompt.tsx
+++ b/src/extension/prompts/node/agent/openai/gpt51CodexPrompt.tsx
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { PromptElement, PromptSizing } from '@vscode/prompt-tsx';
+import { isGpt5_2_CodexFamily } from '../../../../../platform/endpoint/common/chatModelCapabilities';
 import { IChatEndpoint } from '../../../../../platform/networking/common/networking';
 import { ToolName } from '../../../../tools/common/toolNames';
 import { GPT5CopilotIdentityRule } from '../../base/copilotIdentity';
@@ -14,7 +15,6 @@ import { MathIntegrationRules } from '../../panel/editorIntegrationRules';
 import { DefaultAgentPromptProps, detectToolCapabilities } from '../defaultAgentInstructions';
 import { FileLinkificationInstructions } from '../fileLinkificationInstructions';
 import { CopilotIdentityRulesConstructor, IAgentPrompt, PromptRegistry, SafetyRulesConstructor, SystemPrompt } from '../promptRegistry';
-import { isHiddenModelC } from '../../../../../platform/endpoint/common/chatModelCapabilities';
 
 /**
  * This is inspired by the Codex CLI prompt, with some custom tweaks for VS Code.
@@ -124,7 +124,7 @@ class Gpt51CodexResolver implements IAgentPrompt {
 	static readonly familyPrefixes = [];
 
 	static async matchesModel(endpoint: IChatEndpoint): Promise<boolean> {
-		return (endpoint.family.startsWith('gpt-5.1') && endpoint.family.includes('-codex')) || isHiddenModelC(endpoint.family);
+		return (endpoint.family.startsWith('gpt-5.1') && endpoint.family.includes('-codex')) || isGpt5_2_CodexFamily(endpoint);
 	}
 
 	resolveSystemPrompt(endpoint: IChatEndpoint): SystemPrompt | undefined {

--- a/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -12,11 +12,6 @@ const HIDDEN_MODEL_A_HASHES = [
 	'6b0f165d0590bf8d508540a796b4fda77bf6a0a4ed4e8524d5451b1913100a95'
 ];
 
-const HIDDEN_MODEL_C_HASHES = [
-	'2daf0e6c79009f9234ed9baa5bb930898e2847810617e118518d88e4d3140a2e',
-	'854910cb8a637565e3933f64549ac7e83dd55f6721e98f8324eb2065a84e09f8'
-];
-
 const VSC_MODEL_HASHES_A: string[] = [];
 
 const VSC_MODEL_HASHES_B = [
@@ -63,11 +58,6 @@ export function isHiddenModelA(model: LanguageModelChat | IChatEndpoint) {
 	return HIDDEN_MODEL_A_HASHES.includes(h);
 }
 
-export function isHiddenModelC(modelFamily: string) {
-	const h = getCachedSha256Hash(modelFamily);
-	return HIDDEN_MODEL_C_HASHES.includes(h);
-}
-
 export function isHiddenModelB(modelFamily: string) {
 	const h = getCachedSha256Hash(modelFamily);
 	return HIDDEN_MODEL_B_HASHES.includes(h);
@@ -107,6 +97,11 @@ export function isVSCModelC(model: LanguageModelChat | IChatEndpoint) {
 	return VSC_MODEL_HASHES_SUBSET_C.includes(ID_hash) || VSC_MODEL_HASHES_SUBSET_C.includes(family_hash);
 }
 
+export function isGpt5_2_CodexFamily(model: LanguageModelChat | IChatEndpoint | string): boolean {
+	const family = typeof model === 'string' ? model : model.family;
+	return family === 'gpt-5.2-codex';
+}
+
 /**
  * Returns whether the instructions should be given in a user message instead
  * of a system message when talking to the model.
@@ -131,14 +126,14 @@ export function modelSupportsApplyPatch(model: LanguageModelChat | IChatEndpoint
 	if (isVSCModelC(model)) {
 		return false;
 	}
-	return (model.family.startsWith('gpt') && !model.family.includes('gpt-4o')) || model.family === 'o4-mini' || isHiddenModelC(model.family) || isVSCModelA(model) || isVSCModelB(model) || isHiddenModelB(model.family);
+	return (model.family.startsWith('gpt') && !model.family.includes('gpt-4o')) || model.family === 'o4-mini' || isGpt5_2_CodexFamily(model.family) || isVSCModelA(model) || isVSCModelB(model) || isHiddenModelB(model.family);
 }
 
 /**
  * Model prefers JSON notebook representation.
  */
 export function modelPrefersJsonNotebookRepresentation(model: LanguageModelChat | IChatEndpoint): boolean {
-	return (model.family.startsWith('gpt') && !model.family.includes('gpt-4o')) || model.family === 'o4-mini' || isHiddenModelC(model.family) || isHiddenModelB(model.family);
+	return (model.family.startsWith('gpt') && !model.family.includes('gpt-4o')) || model.family === 'o4-mini' || isGpt5_2_CodexFamily(model.family) || isHiddenModelB(model.family);
 }
 
 /**
@@ -227,7 +222,7 @@ export function isGpt5PlusFamily(model: LanguageModelChat | IChatEndpoint | stri
 	}
 
 	const family = typeof model === 'string' ? model : model.family;
-	return !!family.startsWith('gpt-5') || isHiddenModelC(family) || isHiddenModelB(family);
+	return !!family.startsWith('gpt-5') || isHiddenModelB(family);
 }
 
 /**
@@ -239,7 +234,7 @@ export function isGptCodexFamily(model: LanguageModelChat | IChatEndpoint | stri
 	}
 
 	const family = typeof model === 'string' ? model : model.family;
-	return (!!family.startsWith('gpt-') && family.includes('-codex')) || isHiddenModelC(family);
+	return (!!family.startsWith('gpt-') && family.includes('-codex'));
 }
 
 /**
@@ -260,7 +255,7 @@ export function isGptFamily(model: LanguageModelChat | IChatEndpoint | string | 
 	}
 
 	const family = typeof model === 'string' ? model : model.family;
-	return !!family.startsWith('gpt-') || isHiddenModelC(family);
+	return !!family.startsWith('gpt-');
 }
 
 /**
@@ -272,7 +267,7 @@ export function isGpt51Family(model: LanguageModelChat | IChatEndpoint | string 
 	}
 
 	const family = typeof model === 'string' ? model : model.family;
-	return !!family.match(/^gpt-5\.\d+/i) || isHiddenModelC(family);
+	return !!family.match(/^gpt-5\.\d+/i) || isGpt5_2_CodexFamily(family);
 }
 
 /**


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/291958

Removing the hash that is used for tented model name. Current hashes are not resolving to intended gpt-5.1-codex prompt for 5.2-codex model.