### PR TITLE
Always show browse repository dropdown in cloud

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -653,19 +653,17 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 
 			try {
 				const items = await this.getRepositoriesOptionItems(repoIds);
-				if (items.length > 0) {
-					optionGroups.push({
-						id: REPOSITORIES_OPTION_GROUP_ID,
-						name: vscode.l10n.t('Repository'),
-						description: vscode.l10n.t('Select repository'),
-						icon: new vscode.ThemeIcon('repo'),
-						items,
-						commands: [{
-							command: OPEN_REPOSITORY_COMMAND_ID,
-							title: vscode.l10n.t('Browse repositories...'),
-						}]
-					});
-				}
+				optionGroups.push({
+					id: REPOSITORIES_OPTION_GROUP_ID,
+					name: vscode.l10n.t('Repository'),
+					description: vscode.l10n.t('Select repository'),
+					icon: new vscode.ThemeIcon('repo'),
+					items,
+					commands: [{
+						command: OPEN_REPOSITORY_COMMAND_ID,
+						title: vscode.l10n.t('Browse repositories...'),
+					}]
+				});
 
 			} catch (error) {
 				this.logService.error(`Error fetching repositories: ${error}`);


### PR DESCRIPTION
Ensure the browse repository dropdown is always displayed, enhancing user accessibility to repository options.
For https://github.com/microsoft/vscode/issues/290511#issuecomment-3837117827