### PR TITLE
feat(agents): deprecate extension setting in favor of core model picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -3728,6 +3728,7 @@
 						"default": "",
 						"scope": "resource",
 						"markdownDescription": "%github.copilot.config.planAgent.model%",
+						"markdownDeprecationMessage": "%github.copilot.config.planAgent.model.deprecated%",
 						"tags": [
 							"experimental"
 						]

--- a/package.nls.json
+++ b/package.nls.json
@@ -327,6 +327,7 @@
 	"github.copilot.config.organizationInstructions.enabled": "When enabled, Copilot will load custom instructions defined by your GitHub Organization.",
 	"github.copilot.config.planAgent.additionalTools": "Additional tools to enable for the Plan agent, on top of built-in tools. Use fully-qualified tool names (e.g., `github/issue_read`, `mcp_server/tool_name`).",
 	"github.copilot.config.planAgent.model": "Override the language model used by the Plan agent. Leave empty to use the default model.",
+	"github.copilot.config.planAgent.model.deprecated": "This setting is deprecated. Use `chat.planAgent.defaultModel` in VS Code settings instead.",
 	"github.copilot.config.implementAgent.model": "Override the language model used when starting implementation from the Plan agent's handoff. Use the format `Model Name (vendor)` (e.g., `GPT-5 (copilot)`). Leave empty to use the default model.",
 	"copilot.toolSet.editing.description": "Edit files in your workspace",
 	"copilot.toolSet.read.description": "Read files in your workspace",

--- a/src/extension/agents/vscode-node/planAgentProvider.ts
+++ b/src/extension/agents/vscode-node/planAgentProvider.ts
@@ -295,7 +295,11 @@ ${askQuestionsEnabled ? '- NO questions at the end — ask during workflow via #
 
 	private buildCustomizedConfig(): PlanAgentConfig {
 		const additionalTools = this.configurationService.getConfig(ConfigKey.PlanAgentAdditionalTools);
-		const modelOverride = this.configurationService.getConfig(ConfigKey.PlanAgentModel);
+
+		// Prefer VS Code core setting, fallback to extension setting for migration
+		const coreModelSetting = this.configurationService.getNonExtensionConfig<string>('chat.planAgent.defaultModel') ?? '';
+		const extensionModelSetting = this.configurationService.getConfig(ConfigKey.PlanAgentModel);
+		const modelOverride = coreModelSetting || extensionModelSetting;
 
 		// Check askQuestions config first (needed for both tools and body)
 		const askQuestionsEnabled = this.configurationService.getConfig(ConfigKey.AskQuestionsEnabled);


### PR DESCRIPTION
Companion to https://github.com/microsoft/vscode/pull/292437

## Changes
- **Deprecate extension setting**: `github.copilot.chat.planAgent.model` now shows a deprecation message pointing to the core `chat.planAgent.defaultModel` setting
- **Read core setting with fallback**: `planAgentProvider.ts` uses `getNonExtensionConfig` to read the core VS Code setting, falling back to the extension setting for migration

This enables the plan agent model to be configurable via the new dynamic model picker in VS Code settings UI.