### PR TITLE
Use subAgentInvocationId to determine agent name for trajectories

### DIFF
--- a/src/platform/trajectory/node/trajectoryLoggerAdapter.ts
+++ b/src/platform/trajectory/node/trajectoryLoggerAdapter.ts
@@ -12,7 +12,8 @@ import { ILoggedToolCall, IRequestLogger, LoggedInfo, LoggedInfoKind, LoggedRequ
 import { IAgentStepContext, type IObservationResult, type IStepMetrics, type IToolCall, ITrajectoryLogger } from '../common/trajectoryLogger';
 import { IToolDefinition, TRAJECTORY_FILE_EXTENSION } from '../common/trajectoryTypes';
 
-const AGENT_NAME = 'GitHub Copilot Chat';
+const MAIN_AGENT_NAME = 'GitHub Copilot Chat';
+const SUBAGENT_NAME = 'subagent';
 
 /**
  * Function type for rendering PromptTsx parts to strings.
@@ -81,8 +82,8 @@ export class TrajectoryLoggerAdapter extends Disposable {
 
 			// Get or create session for this token
 			let sessionId = this.sessionMap.get(entry.token);
-			// Use subAgentName as agent name for subagent trajectories
-			const agentName = entry.token.subAgentName ?? AGENT_NAME;
+			// Use 'subagent' for subagent trajectories, main agent name otherwise
+			const agentName = entry.token.subAgentInvocationId !== undefined ? SUBAGENT_NAME : MAIN_AGENT_NAME;
 
 			if (!sessionId) {
 				// Use the following priority for session ID:


### PR DESCRIPTION
Changed the trajectory agent name logic to use `subAgentInvocationId` presence instead of `subAgentName` fallback.

## Changes

- Now uses `'subagent'` when `subAgentInvocationId` is defined
- Uses `'GitHub Copilot Chat'` for the main agent

This provides a cleaner determination of agent type based on the invocation ID rather than relying on the name property.