### PR TITLE
Fix Gemini BYOK telemetry: token usage capture and TTFTE improvements

### DIFF
--- a/src/extension/byok/vscode-node/geminiNativeProvider.ts
+++ b/src/extension/byok/vscode-node/geminiNativeProvider.ts
@@ -312,7 +312,12 @@ export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvide
 				// This ensures we capture prompt token info even if stream is cancelled mid-way
 				if (chunk.usageMetadata) {
 					const promptTokens = chunk.usageMetadata.promptTokenCount;
-					const completionTokens = chunk.usageMetadata.candidatesTokenCount;
+					// For thinking models (e.g., gemini-3-pro-high), candidatesTokenCount only includes
+					// regular output tokens. thoughtsTokenCount contains the thinking/reasoning tokens.
+					// We include both in the completion token count.
+					const candidateTokens = chunk.usageMetadata.candidatesTokenCount ?? 0;
+					const thoughtTokens = chunk.usageMetadata.thoughtsTokenCount ?? 0;
+					const completionTokens = candidateTokens + thoughtTokens > 0 ? candidateTokens + thoughtTokens : undefined;
 					const cachedTokens = chunk.usageMetadata.cachedContentTokenCount;
 
 					if (!usage) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/6706

1. Token usage including promptCacheTokenCount was only reported when the stream completed successfully. When users cancelled requests mid-stream, all usage data was lost.
2. TTFTE only tracked text content, missing thinking parts and tool calls. For models with extended thinking TTFTE was incorrectly delayed until visible text appeared.
