### PR TITLE
tools: support vscode-chat-response-resource scheme in external file check

### DIFF
--- a/src/extension/tools/node/toolUtils.ts
+++ b/src/extension/tools/node/toolUtils.ts
@@ -190,7 +190,7 @@ export async function isFileExternalAndNeedsConfirmation(accessor: ServicesAcces
 	if (workspaceService.getWorkspaceFolder(normalizedUri)) {
 		return false;
 	}
-	if (uri.scheme === Schemas.untitled) {
+	if (uri.scheme === Schemas.untitled || uri.scheme === 'vscode-chat-response-resource') {
 		return false;
 	}
 	if (await customInstructionsService.isExternalInstructionsFile(normalizedUri)) {


### PR DESCRIPTION
Adds support for the 'vscode-chat-response-resource' scheme when checking
if a file is external and needs confirmation. This scheme is used for
chat response resources and should be treated similarly to untitled files
that don't require external file confirmation.

- Extends isFileExternalAndNeedsConfirmation to recognize the
  vscode-chat-response-resource scheme
- Allows chat response resources to be accessed without confirmation
  dialogs

Fixes https://github.com/microsoft/vscode/issues/292733

(Commit message generated by Copilot)