### PR TITLE
Revert "Always show browse repository dropdown in cloud (#3388)"

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -725,17 +725,19 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 
 			try {
 				const items = await this.getRepositoriesOptionItems(repoIds);
-				optionGroups.push({
-					id: REPOSITORIES_OPTION_GROUP_ID,
-					name: vscode.l10n.t('Repository'),
-					description: vscode.l10n.t('Select repository'),
-					icon: new vscode.ThemeIcon('repo'),
-					items,
-					commands: [{
-						command: OPEN_REPOSITORY_COMMAND_ID,
-						title: vscode.l10n.t('Browse repositories...'),
-					}]
-				});
+				if (items.length > 0) {
+					optionGroups.push({
+						id: REPOSITORIES_OPTION_GROUP_ID,
+						name: vscode.l10n.t('Repository'),
+						description: vscode.l10n.t('Select repository'),
+						icon: new vscode.ThemeIcon('repo'),
+						items,
+						commands: [{
+							command: OPEN_REPOSITORY_COMMAND_ID,
+							title: vscode.l10n.t('Browse repositories...'),
+						}]
+					});
+				}
 
 			} catch (error) {
 				this.logService.error(`Error fetching repositories: ${error}`);


### PR DESCRIPTION
Reverts microsoft/vscode-copilot-chat#3428
ref https://github.com/microsoft/vscode/issues/290511

This breaks cloud agent for the common case (single repo workspaces). The send button is blocked until a repo is picked, but there are no suggested repos

<img width="1238" height="428" alt="image" src="https://github.com/user-attachments/assets/a0150b32-4399-4f13-a9e8-f8d72cfd7288" />
