### PR TITLE
Include enterprise_list in chat telemetry

### DIFF
--- a/src/platform/telemetry/common/telemetry.ts
+++ b/src/platform/telemetry/common/telemetry.ts
@@ -41,6 +41,7 @@ export interface ITelemetryUserConfig {
 	readonly _serviceBrand: undefined;
 	trackingId: string | undefined;
 	organizationsList: string | undefined;
+	enterpriseList: string | undefined;
 	optedIn: boolean;
 }
 
@@ -49,6 +50,7 @@ export class TelemetryUserConfigImpl implements ITelemetryUserConfig {
 	// tracking id from auth token
 	public trackingId: string | undefined;
 	public organizationsList: string | undefined;
+	public enterpriseList: string | undefined;
 	public optedIn: boolean;
 
 	constructor(
@@ -72,6 +74,7 @@ export class TelemetryUserConfigImpl implements ITelemetryUserConfig {
 			if (trackingId !== undefined) {
 				this.trackingId = trackingId;
 				this.organizationsList = token.organizationList.toString();
+				this.enterpriseList = token.enterpriseList.toString();
 				this.optedIn = enhancedTelemetry;
 			}
 		});

--- a/src/platform/telemetry/common/telemetryData.ts
+++ b/src/platform/telemetry/common/telemetryData.ts
@@ -91,6 +91,9 @@ export class TelemetryData {
 		if (telemetryConfig.organizationsList) {
 			configProperties['organizations_list'] = telemetryConfig.organizationsList;
 		}
+		if (telemetryConfig.enterpriseList) {
+			configProperties['enterprise_list'] = telemetryConfig.enterpriseList;
+		}
 
 		// By being the second argument, configProperties will always override
 		this.properties = { ...this.properties, ...configProperties };

--- a/src/platform/telemetry/test/node/telemetry.spec.ts
+++ b/src/platform/telemetry/test/node/telemetry.spec.ts
@@ -189,6 +189,7 @@ suite('GitHub Telemetry Sender', function () {
 			_serviceBrand: undefined,
 			optedIn: true,
 			organizationsList: undefined,
+			enterpriseList: undefined,
 			trackingId: 'testId'
 		};
 		const mockLoggerFactory = (enhanced: boolean) => {

--- a/src/platform/telemetry/test/node/telemetry2.spec.ts
+++ b/src/platform/telemetry/test/node/telemetry2.spec.ts
@@ -8,8 +8,11 @@ import { suite, test } from 'vitest';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { CopilotToken, createTestExtendedTokenInfo } from '../../../authentication/common/copilotToken';
 import { ICopilotTokenStore } from '../../../authentication/common/copilotTokenStore';
+import { IConfigurationService } from '../../../configuration/common/configurationService';
+import { IEnvService } from '../../../env/common/envService';
 import { createPlatformServices } from '../../../test/node/services';
-import { TelemetryUserConfigImpl } from '../../common/telemetry';
+import { ITelemetryUserConfig, TelemetryUserConfigImpl } from '../../common/telemetry';
+import { TelemetryData } from '../../common/telemetryData';
 
 suite('Telemetry unit tests', function () {
 	test('Can create telemetry user config with values', async function () {
@@ -69,5 +72,69 @@ suite('Telemetry unit tests', function () {
 		accessor.get(ICopilotTokenStore).copilotToken = copilotToken;
 
 		assert.ok(!config.optedIn);
+	});
+
+	test('Telemetry user config updates enterprise_list on token change', async function () {
+		const accessor = createPlatformServices().createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const config = instantiationService.createInstance(TelemetryUserConfigImpl, undefined, undefined);
+		const copilotToken = new CopilotToken(createTestExtendedTokenInfo({
+			token: 'tid=0123456789abcdef0123456789abcdef;rt=1;ssc=0;dom=org1.com;ol=org1,org2',
+			organization_list: ['org1', 'org2'],
+			enterprise_list: [12345, 67890],
+			username: 'fake',
+			copilot_plan: 'enterprise',
+		}));
+
+		accessor.get(ICopilotTokenStore).copilotToken = copilotToken;
+
+		assert.strictEqual(config.trackingId, '0123456789abcdef0123456789abcdef');
+		assert.strictEqual(config.organizationsList, 'org1,org2');
+		assert.strictEqual(config.enterpriseList, '12345,67890');
+		assert.ok(config.optedIn);
+	});
+
+	test('TelemetryData includes enterprise_list in config properties', async function () {
+		const accessor = createPlatformServices().createTestingAccessor();
+		const configService = accessor.get(IConfigurationService);
+		const envService = accessor.get(IEnvService);
+
+		const telemetryUserConfig: ITelemetryUserConfig = {
+			_serviceBrand: undefined,
+			trackingId: 'test-tracking-id',
+			organizationsList: 'org1,org2',
+			enterpriseList: '12345,67890',
+			optedIn: true,
+		};
+
+		const telemetryData = TelemetryData.createAndMarkAsIssued({}, {});
+		telemetryData.extendWithConfigProperties(configService, envService, telemetryUserConfig);
+
+		// Note: keys use dots before sanitizeKeys() is called
+		assert.strictEqual(telemetryData.properties['copilot.trackingId'], 'test-tracking-id');
+		assert.strictEqual(telemetryData.properties['organizations_list'], 'org1,org2');
+		assert.strictEqual(telemetryData.properties['enterprise_list'], '12345,67890');
+	});
+
+	test('TelemetryData omits enterprise_list when undefined', async function () {
+		const accessor = createPlatformServices().createTestingAccessor();
+		const configService = accessor.get(IConfigurationService);
+		const envService = accessor.get(IEnvService);
+
+		const telemetryUserConfig: ITelemetryUserConfig = {
+			_serviceBrand: undefined,
+			trackingId: 'test-tracking-id',
+			organizationsList: 'org1,org2',
+			enterpriseList: undefined,
+			optedIn: true,
+		};
+
+		const telemetryData = TelemetryData.createAndMarkAsIssued({}, {});
+		telemetryData.extendWithConfigProperties(configService, envService, telemetryUserConfig);
+
+		// Note: keys use dots before sanitizeKeys() is called
+		assert.strictEqual(telemetryData.properties['copilot.trackingId'], 'test-tracking-id');
+		assert.strictEqual(telemetryData.properties['organizations_list'], 'org1,org2');
+		assert.strictEqual(telemetryData.properties['enterprise_list'], undefined);
 	});
 });


### PR DESCRIPTION
Chat events were missing `enterprise_list` while completions events included it, causing incomplete enterprise usage reports.

Adds `enterpriseList` to `ITelemetryUserConfig` and `TelemetryData` so chat telemetry includes this field.