### PR TITLE
Infer agent migration and new skills folder

### DIFF
--- a/assets/prompts/skills/agent-customization/SKILL.md
+++ b/assets/prompts/skills/agent-customization/SKILL.md
@@ -20,13 +20,13 @@ description: 'Create, update, review, fix, or debug VS Code agent customization 
 
 Consult the reference docs for templates, domain examples, advanced frontmatter options, asset organization, anti-patterns, and creation checklists.
 
-| Type | File | Location | Key Field | Reference |
-|------|------|----------|-----------|---------|
-| Workspace Instructions | `copilot-instructions.md`, `AGENTS.md` | `.github/` or root | N/A (always applies) | [Link](./primitives/workspace-instructions.md) |
-| File Instructions | `*.instructions.md` | `.github/instructions/` | `applyTo` (explicit), `description` (on-demand) | [Link](./primitives/instructions.md) |
-| Prompts | `*.prompt.md` | `.github/prompts/` | `description` (user-invoked) | [Link](./primitives/prompts.md) |
-| Custom Agents | `*.agent.md` | `.github/agents/` | `description` (on-demand), `infer` (subagent) | [Link](./primitives/agents.md) |
-| Skills | `SKILL.md` | `.github/skills/<name>/` | `description` (on-demand) | [Link](./primitives/skills.md) |
+| Type | File | Location | Reference |
+|------|------|----------|-----------|
+| Workspace Instructions | `copilot-instructions.md`, `AGENTS.md` | `.github/` or root | [Link](./primitives/workspace-instructions.md) |
+| File Instructions | `*.instructions.md` | `.github/instructions/` | [Link](./primitives/instructions.md) |
+| Prompts | `*.prompt.md` | `.github/prompts/` | [Link](./primitives/prompts.md) |
+| Custom Agents | `*.agent.md` | `.github/agents/` | [Link](./primitives/agents.md) |
+| Skills | `SKILL.md` | `.github/skills/<name>/`, `.agents/skills/<name>/`, `.claude/skills/<name>/` | [Link](./primitives/skills.md) |
 
 **User-level**: `{{USER_PROMPTS_FOLDER}}/` (*.prompt.md, *.instructions.md, *.agent.md; not skills)
 Customizations roam with user's settings sync

--- a/assets/prompts/skills/agent-customization/primitives/agents.md
+++ b/assets/prompts/skills/agent-customization/primitives/agents.md
@@ -16,22 +16,27 @@ Custom personas with specific tools, instructions, and behaviors. Use for orches
 description: "<required>"    # For agent picker and subagent discovery
 name: "Agent Name"           # Optional, defaults to filename
 tools: ["search", "web"]     # Optional: aliases, MCP (<server>/*), extension tools
-model: "Claude Sonnet 4"     # Optional, uses picker default
+model: "Claude Sonnet 4"     # Optional, uses picker default; supports array for fallback
 argument-hint: "Task..."     # Optional, input guidance
 agents: ["Agent1", "Agent2"] # Optional, restrict allowed subagents by name (omit = all, [] = none)
-infer: "all"                 # Optional: "all"|true, "user"|false, "agent", "hidden"
+user-invokable: true         # Optional, show in agent picker (default: true)
+disable-model-invocation: false  # Optional, prevent subagent invocation (default: false)
 handoffs: [...]              # Optional, transitions to other agents
 ---
 ```
 
-### `infer` Values
+### Invocation Control
 
-| Value | Behavior |
-|-------|----------|
-| `"all"` or `true` | Available in agent picker AND as subagent (default) |
-| `"user"` or `false` | Only in agent picker, not as subagent |
-| `"agent"` | Only as subagent, hidden from picker |
-| `"hidden"` | Not available anywhere |
+| Attribute | Default | Effect |
+|-----------|---------|--------|
+| `user-invokable: false` | `true` | Hide from agent picker, only accessible as subagent |
+| `disable-model-invocation: true` | `false` | Prevent other agents from invoking as subagent |
+
+### Model Fallback
+
+```yaml
+model: ['Claude Sonnet 4.5 (copilot)', 'GPT-5 (copilot)']  # First available model is used
+```
 
 ## Tools
 
@@ -68,7 +73,7 @@ To discover available tools, check your current tool list or use `#tool:` syntax
 ---
 description: "{Use when... trigger phrases for subagent discovery}"
 tools: ["{minimal set of tool aliases}"]
-infer: "agent"
+user-invokable: false
 ---
 You are a specialist at {specific task}. Your job is to {clear purpose}.
 

--- a/assets/prompts/skills/agent-customization/primitives/skills.md
+++ b/assets/prompts/skills/agent-customization/primitives/skills.md
@@ -17,7 +17,10 @@ Folders of instructions, scripts, and resources that agents load on-demand for s
 | Path | Scope |
 |------|-------|
 | `.github/skills/<name>/` | Project |
+| `.agents/skills/<name>/` | Project |
+| `.claude/skills/<name>/` | Project |
 | `~/.copilot/skills/<name>/` | Personal |
+| `~/.claude/skills/<name>/` | Personal |
 
 ## SKILL.md Format
 

--- a/src/extension/agents/vscode-node/planAgentProvider.ts
+++ b/src/extension/agents/vscode-node/planAgentProvider.ts
@@ -33,7 +33,7 @@ interface PlanAgentConfig {
 	tools: string[];
 	model?: string;
 	target?: string;
-	infer?: string;
+	disableModelInvocation?: boolean;
 	agents?: string[];
 	handoffs: PlanAgentHandoff[];
 	body: string;
@@ -48,7 +48,7 @@ const BASE_PLAN_AGENT_CONFIG: PlanAgentConfig = {
 	description: 'Researches and outlines multi-step plans',
 	argumentHint: 'Outline the goal or problem to research',
 	target: 'vscode',
-	infer: 'user',
+	disableModelInvocation: true,
 	agents: [],
 	tools: [
 		'agent',
@@ -84,8 +84,8 @@ export function buildAgentMarkdown(config: PlanAgentConfig): string {
 	if (config.target) {
 		lines.push(`target: ${config.target}`);
 	}
-	if (config.infer) {
-		lines.push(`infer: ${config.infer}`);
+	if (config.disableModelInvocation) {
+		lines.push(`disable-model-invocation: true`);
 	}
 
 	// Tools array - flow style for readability


### PR DESCRIPTION
The changes went in late in the release and missed updating the customization skill (now creates invalid custom agents and skills) and plan agent (means it can be called as a sub-agent, leading to odd side effects as it can use the ask questions tool).