### PR TITLE
Add configurable semantic search endpoint for local blackbird testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1500,6 +1500,7 @@
 			"integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@floating-ui/core": "^1.7.2",
 				"@floating-ui/utils": "^0.2.10"
@@ -4185,6 +4186,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
 			"integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==",
+			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -5822,6 +5824,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
 			"integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -5833,6 +5836,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz",
 			"integrity": "sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@types/react": "*"
 			}
@@ -6007,6 +6011,7 @@
 			"integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.36.0",
 				"@typescript-eslint/types": "8.36.0",
@@ -7232,6 +7237,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -9176,6 +9182,7 @@
 			"resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
 			"integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"semver": "^7.5.3"
 			}
@@ -9421,7 +9428,8 @@
 			"resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
 			"integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/embla-carousel-autoplay": {
 			"version": "8.6.0",
@@ -9466,16 +9474,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/encoding": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"iconv-lite": "^0.6.2"
 			}
 		},
 		"node_modules/end-of-stream": {
@@ -9789,6 +9787,7 @@
 			"integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -9977,6 +9976,7 @@
 			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -12422,6 +12422,7 @@
 			"integrity": "sha512-ypEvQvInNpUe+u+w8BIcPkQvEqXquyyibWE/1NB5T2BTzIpS5cGEV1LZskDzPSTvNAaT4+5FutvzlvnkxOSKlw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@keyv/serialize": "^1.0.3"
 			}
@@ -13665,6 +13666,7 @@
 			"integrity": "sha512-aChaVU/DO5aRPmk1GX8L+whocagUUpBQqoPtJk+cm7UOXUk87J4PeWCh6nNmTTIfEhiR9DI/+FnA8dln/hTK7g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/mobx"
@@ -13702,6 +13704,7 @@
 			"integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"browser-stdout": "^1.3.1",
 				"chokidar": "^4.0.1",
@@ -15561,6 +15564,7 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
 			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -15574,6 +15578,7 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -15967,6 +15972,7 @@
 			"integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -16150,6 +16156,7 @@
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
 			"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -18194,7 +18201,8 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD"
+			"license": "0BSD",
+			"peer": true
 		},
 		"node_modules/tsscmp": {
 			"version": "1.0.6",
@@ -18212,6 +18220,7 @@
 			"integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.25.0",
 				"get-tsconfig": "^4.7.5"
@@ -18404,6 +18413,7 @@
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -18528,6 +18538,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.2.4"
 			},
@@ -18673,6 +18684,7 @@
 			"integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",
@@ -18827,6 +18839,7 @@
 			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/chai": "^5.2.2",
 				"@vitest/expect": "3.2.4",
@@ -19316,6 +19329,7 @@
 			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"bin": {
 				"yaml": "bin.mjs"
 			},
@@ -19443,6 +19457,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1500,7 +1500,6 @@
 			"integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@floating-ui/core": "^1.7.2",
 				"@floating-ui/utils": "^0.2.10"
@@ -4186,7 +4185,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
 			"integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -5824,7 +5822,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
 			"integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -5836,7 +5833,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz",
 			"integrity": "sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@types/react": "*"
 			}
@@ -6011,7 +6007,6 @@
 			"integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.36.0",
 				"@typescript-eslint/types": "8.36.0",
@@ -7237,7 +7232,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -9182,7 +9176,6 @@
 			"resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
 			"integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"semver": "^7.5.3"
 			}
@@ -9428,8 +9421,7 @@
 			"resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
 			"integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/embla-carousel-autoplay": {
 			"version": "8.6.0",
@@ -9474,6 +9466,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/encoding": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"iconv-lite": "^0.6.2"
 			}
 		},
 		"node_modules/end-of-stream": {
@@ -9787,7 +9789,6 @@
 			"integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -9976,7 +9977,6 @@
 			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -12422,7 +12422,6 @@
 			"integrity": "sha512-ypEvQvInNpUe+u+w8BIcPkQvEqXquyyibWE/1NB5T2BTzIpS5cGEV1LZskDzPSTvNAaT4+5FutvzlvnkxOSKlw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@keyv/serialize": "^1.0.3"
 			}
@@ -13666,7 +13665,6 @@
 			"integrity": "sha512-aChaVU/DO5aRPmk1GX8L+whocagUUpBQqoPtJk+cm7UOXUk87J4PeWCh6nNmTTIfEhiR9DI/+FnA8dln/hTK7g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/mobx"
@@ -13704,7 +13702,6 @@
 			"integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"browser-stdout": "^1.3.1",
 				"chokidar": "^4.0.1",
@@ -15564,7 +15561,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
 			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -15578,7 +15574,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -15972,7 +15967,6 @@
 			"integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -16156,7 +16150,6 @@
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
 			"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -18201,8 +18194,7 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"peer": true
+			"license": "0BSD"
 		},
 		"node_modules/tsscmp": {
 			"version": "1.0.6",
@@ -18220,7 +18212,6 @@
 			"integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.25.0",
 				"get-tsconfig": "^4.7.5"
@@ -18413,7 +18404,6 @@
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -18538,7 +18528,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.2.4"
 			},
@@ -18684,7 +18673,6 @@
 			"integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",
@@ -18839,7 +18827,6 @@
 			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/chai": "^5.2.2",
 				"@vitest/expect": "3.2.4",
@@ -19329,7 +19316,6 @@
 			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"yaml": "bin.mjs"
 			},
@@ -19457,7 +19443,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -4014,6 +4014,15 @@
 							"experimental"
 						]
 					},
+					"github.copilot.chat.semanticSearchEndpoint": {
+						"type": "string",
+						"default": "",
+						"markdownDescription": "%github.copilot.config.semanticSearchEndpoint%",
+						"tags": [
+							"advanced",
+							"experimental"
+						]
+					},
 					"github.copilot.chat.inlineEdits.diagnosticsContextProvider.enabled": {
 						"type": "boolean",
 						"default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -370,6 +370,7 @@
 	"github.copilot.config.editRecording.enabled": "Enable edit recording for analysis.",
 	"github.copilot.config.inlineChat.selectionRatioThreshold": "Threshold at which to switch editing strategies for inline chat. When a selection porition of code matches a parse tree node, only that is presented to the language model. This speeds up response times but might have lower quality results. Requires having a parse tree for the document and the `inlineChat.enableV2` setting. Values must be between 0 and 1, where 0 means off and 1 means the selection perfectly matches a parse tree node.",
 	"github.copilot.config.debug.requestLogger.maxEntries": "Maximum number of entries to keep in the request logger for debugging purposes.",
+	"github.copilot.config.semanticSearchEndpoint": "Custom endpoint URL for semantic code search (for development/testing with local blackbird).",
 	"github.copilot.config.inlineEdits.diagnosticsContextProvider.enabled": "Enable diagnostics context provider for next edit suggestions.",
 	"github.copilot.config.inlineEdits.chatSessionContextProvider.enabled": "Enable chat session context provider for next edit suggestions.",
 	"github.copilot.config.codesearch.agent.enabled": "Enable code search capabilities in agent mode.",

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -657,6 +657,11 @@ export namespace ConfigKey {
 		export const AgentHistorySummarizationMode = defineAndMigrateSetting<string | undefined>('chat.advanced.agentHistorySummarizationMode', 'chat.agentHistorySummarizationMode', undefined);
 		export const UseResponsesApiTruncation = defineAndMigrateSetting<boolean | undefined>('chat.advanced.useResponsesApiTruncation', 'chat.useResponsesApiTruncation', false);
 		export const OmitBaseAgentInstructions = defineAndMigrateSetting<boolean>('chat.advanced.omitBaseAgentInstructions', 'chat.omitBaseAgentInstructions', false);
+		export const ClaudeCodeDebugEnabled = defineAndMigrateSetting<boolean>('chat.advanced.claudeCode.debug', 'chat.claudeCode.debug', false);
+		export const GitHistoryRelatedFilesUsingEmbeddings = defineAndMigrateSetting('chat.advanced.suggestRelatedFilesFromGitHistory.useEmbeddings', 'chat.suggestRelatedFilesFromGitHistory.useEmbeddings', false);
+		export const CLIAutoCommitEnabled = defineSetting<boolean>('chat.cli.autoCommit.enabled', ConfigType.Simple, false);
+		/** Custom endpoint URL for semantic code search (for development/testing with local blackbird) */
+		export const SemanticSearchEndpoint = defineAndMigrateSetting<string>('chat.advanced.semanticSearchEndpoint', 'chat.semanticSearchEndpoint', '');
 		export const CLICustomAgentsEnabled = defineAndMigrateSetting<boolean | undefined>('chat.advanced.cli.customAgents.enabled', 'chat.cli.customAgents.enabled', true);
 		export const CLIMCPServerEnabled = defineAndMigrateSetting<boolean | undefined>('chat.advanced.cli.mcp.enabled', 'chat.cli.mcp.enabled', false);
 		export const RequestLoggerMaxEntries = defineAndMigrateSetting<number>('chat.advanced.debug.requestLogger.maxEntries', 'chat.debug.requestLogger.maxEntries', 100);

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -657,9 +657,6 @@ export namespace ConfigKey {
 		export const AgentHistorySummarizationMode = defineAndMigrateSetting<string | undefined>('chat.advanced.agentHistorySummarizationMode', 'chat.agentHistorySummarizationMode', undefined);
 		export const UseResponsesApiTruncation = defineAndMigrateSetting<boolean | undefined>('chat.advanced.useResponsesApiTruncation', 'chat.useResponsesApiTruncation', false);
 		export const OmitBaseAgentInstructions = defineAndMigrateSetting<boolean>('chat.advanced.omitBaseAgentInstructions', 'chat.omitBaseAgentInstructions', false);
-		export const ClaudeCodeDebugEnabled = defineAndMigrateSetting<boolean>('chat.advanced.claudeCode.debug', 'chat.claudeCode.debug', false);
-		export const GitHistoryRelatedFilesUsingEmbeddings = defineAndMigrateSetting('chat.advanced.suggestRelatedFilesFromGitHistory.useEmbeddings', 'chat.suggestRelatedFilesFromGitHistory.useEmbeddings', false);
-		export const CLIAutoCommitEnabled = defineSetting<boolean>('chat.cli.autoCommit.enabled', ConfigType.Simple, false);
 		/** Custom endpoint URL for semantic code search (for development/testing with local blackbird) */
 		export const SemanticSearchEndpoint = defineAndMigrateSetting<string>('chat.advanced.semanticSearchEndpoint', 'chat.semanticSearchEndpoint', '');
 		export const CLICustomAgentsEnabled = defineAndMigrateSetting<boolean | undefined>('chat.advanced.cli.customAgents.enabled', 'chat.cli.customAgents.enabled', true);

--- a/src/platform/remoteCodeSearch/common/githubCodeSearchService.ts
+++ b/src/platform/remoteCodeSearch/common/githubCodeSearchService.ts
@@ -30,6 +30,12 @@ import { postRequest } from '../../networking/common/networking';
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { CodeSearchOptions, CodeSearchResult, RemoteCodeSearchError, RemoteCodeSearchIndexState, RemoteCodeSearchIndexStatus } from './remoteCodeSearch';
 
+/**
+ * Normalizes an endpoint URL by stripping trailing slashes.
+ */
+export function normalizeEndpointUrl(endpoint: string): string {
+	return endpoint.replace(/\/+$/, '');
+}
 
 interface ResponseShape {
 	readonly results: readonly SemanticSearchResult[];
@@ -116,55 +122,7 @@ export class GithubCodeSearchService implements IGithubCodeSearchService {
 		@IIgnoreService private readonly _ignoreService: IIgnoreService,
 		@ILogService private readonly _logService: ILogService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
-	) {
-		// Test custom endpoint on startup if configured
-		const customEndpoint = this._configurationService.getConfig(ConfigKey.Advanced.SemanticSearchEndpoint);
-		if (customEndpoint) {
-			this.testCustomEndpoint(customEndpoint).catch(() => { /* noop */ });
-		}
-	}
-
-	/**
-	 * Tests the custom semantic search endpoint on startup to validate connectivity.
-	 */
-	private async testCustomEndpoint(endpoint: string): Promise<void> {
-		this._logService.info(`GithubCodeSearchService: Testing custom semantic search endpoint: ${endpoint}`);
-
-		// Strip trailing slash to avoid double slashes in URL
-		const normalizedEndpoint = endpoint.replace(/\/+$/, '');
-		const searchUrl = `${normalizedEndpoint}/embeddings/code/search`;
-
-		// Use SWEBENCH_REPO env var if available, otherwise use a test repo
-		const repoNwo = env['SWEBENCH_REPO'] || 'test/test';
-		const testPayload = {
-			prompt: 'test query',
-			scoping_query: `repo:${repoNwo}`,
-			include_embeddings: false,
-			limit: 1,
-		};
-
-		this._logService.info(`GithubCodeSearchService: Custom endpoint test. Payload: ${JSON.stringify(testPayload)}`);
-
-		try {
-			const response = await this._fetcherService.fetch(searchUrl, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify(testPayload),
-			});
-
-			if (response.ok) {
-				const body = await response.json();
-				this._logService.info(`GithubCodeSearchService: Custom endpoint test SUCCESS. Response: ${JSON.stringify(body)}`);
-			} else {
-				const text = await response.text();
-				this._logService.warn(`GithubCodeSearchService: Custom endpoint test FAILED. Status: ${response.status}, Response: ${text}`);
-			}
-		} catch (e) {
-			this._logService.error(`GithubCodeSearchService: Custom endpoint test ERROR: ${e}`);
-		}
-	}
+	) { }
 
 	async getRemoteIndexState(auth: { readonly silent: boolean }, githubRepoId: GithubRepoId, token: CancellationToken): Promise<Result<RemoteCodeSearchIndexState, RemoteCodeSearchError>> {
 		const repoNwo = toGithubNwo(githubRepoId);
@@ -449,8 +407,7 @@ export class GithubCodeSearchService implements IGithubCodeSearchService {
 	): Promise<CodeSearchResult> {
 		this._logService.trace(`GithubCodeSearchService::searchCustomEndpoint. Using custom endpoint: ${endpoint}`);
 
-		// Strip trailing slash to avoid double slashes in URL
-		const normalizedEndpoint = endpoint.replace(/\/+$/, '');
+		const normalizedEndpoint = normalizeEndpointUrl(endpoint);
 		// Use the same API path as blackbird tool: /embeddings/code/search
 		const searchUrl = `${normalizedEndpoint}/embeddings/code/search`;
 		const requestBody = {
@@ -475,6 +432,22 @@ export class GithubCodeSearchService implements IGithubCodeSearchService {
 		);
 
 		if (!response.ok) {
+			/* __GDPR__
+				"githubCodeSearch.searchCustomEndpoint.error" : {
+					"owner": "mjbvz",
+					"comment": "Information about failed custom endpoint searches",
+					"workspaceSearchSource": { "classification": "SystemMetaData", "purpose": "FeatureInsight",  "comment": "Caller of the search" },
+					"workspaceSearchCorrelationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight",  "comment": "Correlation id for the search" },
+					"statusCode": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "The response status code" }
+				}
+			*/
+			this._telemetryService.sendMSFTTelemetryEvent('githubCodeSearch.searchCustomEndpoint.error', {
+				workspaceSearchSource: telemetryInfo.callTracker.toString(),
+				workspaceSearchCorrelationId: telemetryInfo.correlationId,
+			}, {
+				statusCode: response.status,
+			});
+
 			this._logService.error(`GithubCodeSearchService::searchCustomEndpoint. Custom endpoint search failed: ${response.status}`);
 			throw new Error(`Custom endpoint search failed with status: ${response.status}`);
 		}
@@ -485,7 +458,27 @@ export class GithubCodeSearchService implements IGithubCodeSearchService {
 			throw new Error('Custom endpoint returned invalid response');
 		}
 
-		return parseGithubCodeSearchResponse(body, repo, options, this._ignoreService);
+		const result = await parseGithubCodeSearchResponse(body, repo, options, this._ignoreService);
+
+		/* __GDPR__
+			"githubCodeSearch.searchCustomEndpoint.success" : {
+				"owner": "mjbvz",
+				"comment": "Information about successful custom endpoint searches",
+				"workspaceSearchSource": { "classification": "SystemMetaData", "purpose": "FeatureInsight",  "comment": "Caller of the search" },
+				"workspaceSearchCorrelationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight",  "comment": "Correlation id for the search" },
+				"resultCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Total number of returned chunks from the search" },
+				"resultOutOfSync": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Tracks if the commit we think code search has indexed matches the commit code search returns results from" }
+			}
+		*/
+		this._telemetryService.sendMSFTTelemetryEvent('githubCodeSearch.searchCustomEndpoint.success', {
+			workspaceSearchSource: telemetryInfo.callTracker.toString(),
+			workspaceSearchCorrelationId: telemetryInfo.correlationId,
+		}, {
+			resultCount: body.results.length,
+			resultOutOfSync: result.outOfSync ? 1 : 0,
+		});
+
+		return result;
 	}
 }
 

--- a/src/platform/remoteCodeSearch/common/test/githubCodeSearchService.spec.ts
+++ b/src/platform/remoteCodeSearch/common/test/githubCodeSearchService.spec.ts
@@ -1,0 +1,226 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { URI } from '../../../../util/vs/base/common/uri';
+import { EmbeddingType } from '../../../embeddings/common/embeddingsComputer';
+import { GithubRepoId } from '../../../git/common/gitService';
+import { NullIgnoreService } from '../../../ignore/common/ignoreService';
+import { normalizeEndpointUrl, parseGithubCodeSearchResponse } from '../githubCodeSearchService';
+
+describe('normalizeEndpointUrl', () => {
+	it('should strip trailing slash', () => {
+		expect(normalizeEndpointUrl('http://localhost:8080/')).toBe('http://localhost:8080');
+	});
+
+	it('should strip multiple trailing slashes', () => {
+		expect(normalizeEndpointUrl('http://localhost:8080///')).toBe('http://localhost:8080');
+	});
+
+	it('should not modify URL without trailing slash', () => {
+		expect(normalizeEndpointUrl('http://localhost:8080')).toBe('http://localhost:8080');
+	});
+
+	it('should handle URL with path', () => {
+		expect(normalizeEndpointUrl('http://localhost:8080/api/v1/')).toBe('http://localhost:8080/api/v1');
+	});
+
+	it('should handle empty string', () => {
+		expect(normalizeEndpointUrl('')).toBe('');
+	});
+});
+
+describe('parseGithubCodeSearchResponse', () => {
+	const mockIgnoreService = NullIgnoreService.Instance;
+
+	it('should parse valid response', async () => {
+		const response = {
+			results: [
+				{
+					chunk: {
+						hash: 'abc123',
+						text: 'function test() { return true; }',
+						range: { start: 0, end: 100 },
+						line_range: { start: 1, end: 5 },
+					},
+					distance: 0.5,
+					location: {
+						path: 'src/test.ts',
+						commit_sha: 'commit123',
+						repo: {
+							nwo: 'owner/repo',
+							url: 'https://github.com/owner/repo',
+						},
+					},
+				},
+			],
+			embedding_model: EmbeddingType.metis_1024_I16_Binary.id,
+		};
+
+		const repo = {
+			githubRepoId: new GithubRepoId('owner', 'repo'),
+			localRepoRoot: URI.file('/workspace'),
+			indexedCommit: 'commit123',
+		};
+
+		const result = await parseGithubCodeSearchResponse(response, repo, { globPatterns: undefined }, mockIgnoreService);
+
+		expect(result.chunks.length).toBe(1);
+		expect(result.outOfSync).toBe(false);
+		const firstChunk = result.chunks[0];
+		expect(firstChunk).toBeDefined();
+		expect(firstChunk!.chunk.text).toBe('function test() { return true; }');
+		expect(firstChunk!.distance).toBeDefined();
+		expect(firstChunk!.distance!.value).toBe(0.5);
+	});
+
+	it('should detect out of sync when commit differs', async () => {
+		const response = {
+			results: [
+				{
+					chunk: {
+						hash: 'abc123',
+						text: 'test code',
+						range: { start: 0, end: 50 },
+						line_range: { start: 1, end: 3 },
+					},
+					distance: 0.3,
+					location: {
+						path: 'src/file.ts',
+						commit_sha: 'different_commit',
+						repo: {
+							nwo: 'owner/repo',
+							url: 'https://github.com/owner/repo',
+						},
+					},
+				},
+			],
+			embedding_model: EmbeddingType.metis_1024_I16_Binary.id,
+		};
+
+		const repo = {
+			githubRepoId: new GithubRepoId('owner', 'repo'),
+			localRepoRoot: URI.file('/workspace'),
+			indexedCommit: 'original_commit',
+		};
+
+		const result = await parseGithubCodeSearchResponse(response, repo, { globPatterns: undefined }, mockIgnoreService);
+
+		expect(result.outOfSync).toBe(true);
+	});
+
+	it('should filter results by glob patterns', async () => {
+		const response = {
+			results: [
+				{
+					chunk: {
+						hash: 'abc123',
+						text: 'test code',
+						range: { start: 0, end: 50 },
+						line_range: { start: 1, end: 3 },
+					},
+					distance: 0.3,
+					location: {
+						path: 'src/file.ts',
+						commit_sha: 'commit123',
+						repo: {
+							nwo: 'owner/repo',
+							url: 'https://github.com/owner/repo',
+						},
+					},
+				},
+				{
+					chunk: {
+						hash: 'def456',
+						text: 'test code 2',
+						range: { start: 0, end: 50 },
+						line_range: { start: 1, end: 3 },
+					},
+					distance: 0.4,
+					location: {
+						path: 'test/file.spec.ts',
+						commit_sha: 'commit123',
+						repo: {
+							nwo: 'owner/repo',
+							url: 'https://github.com/owner/repo',
+						},
+					},
+				},
+			],
+			embedding_model: EmbeddingType.metis_1024_I16_Binary.id,
+		};
+
+		const repo = {
+			githubRepoId: new GithubRepoId('owner', 'repo'),
+			localRepoRoot: URI.file('/workspace'),
+			indexedCommit: 'commit123',
+		};
+
+		const result = await parseGithubCodeSearchResponse(
+			response,
+			repo,
+			{ globPatterns: { include: ['**/src/**'], exclude: [] } },
+			mockIgnoreService
+		);
+
+		expect(result.chunks.length).toBe(1);
+		const firstChunk = result.chunks[0];
+		expect(firstChunk).toBeDefined();
+		expect(firstChunk!.chunk.file.path).toContain('src/file.ts');
+	});
+
+	it('should filter results from different repos when skipVerifyRepo is false', async () => {
+		const response = {
+			results: [
+				{
+					chunk: {
+						hash: 'abc123',
+						text: 'test code',
+						range: { start: 0, end: 50 },
+						line_range: { start: 1, end: 3 },
+					},
+					distance: 0.3,
+					location: {
+						path: 'src/file.ts',
+						commit_sha: 'commit123',
+						repo: {
+							nwo: 'other/repo',
+							url: 'https://github.com/other/repo',
+						},
+					},
+				},
+			],
+			embedding_model: EmbeddingType.metis_1024_I16_Binary.id,
+		};
+
+		const repo = {
+			githubRepoId: new GithubRepoId('owner', 'repo'),
+			localRepoRoot: URI.file('/workspace'),
+			indexedCommit: 'commit123',
+		};
+
+		const result = await parseGithubCodeSearchResponse(response, repo, { globPatterns: undefined }, mockIgnoreService);
+
+		expect(result.chunks.length).toBe(0);
+	});
+
+	it('should handle empty results', async () => {
+		const response = {
+			results: [],
+			embedding_model: EmbeddingType.metis_1024_I16_Binary.id,
+		};
+
+		const repo = {
+			githubRepoId: new GithubRepoId('owner', 'repo'),
+			localRepoRoot: undefined,
+			indexedCommit: undefined,
+		};
+
+		const result = await parseGithubCodeSearchResponse(response, repo, { globPatterns: undefined }, mockIgnoreService);
+
+		expect(result.chunks.length).toBe(0);
+		expect(result.outOfSync).toBe(false);
+	});
+});


### PR DESCRIPTION
Description:

Adds a new setting github.copilot.chat.semanticSearchEndpoint that allows configuring a custom endpoint for semantic code search. This enables local development and testing with a self-hosted blackbird instance instead of the production GitHub code search service.

Changes:

New configuration setting with migration support (chat.advanced.semanticSearchEndpoint → chat.semanticSearchEndpoint)
GithubCodeSearchService routes requests to custom endpoint when configured
Custom endpoint bypasses remote index state checks (returns Ready status)
normalizeEndpointUrl() helper for consistent URL handling
Unit tests for URL normalization and response parsing
Testing:

✅ Unit tests pass (10 tests in githubCodeSearchService.spec.ts)
✅ Build tasks pass (tsc-extension, tsc-extension-web, tsc-simulation-workbench, esbuild)