### PR TITLE
Handle smart image routing in auto

### DIFF
--- a/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -278,7 +278,7 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 				},
 				isUserSelectable: endpoint.showInModelPicker,
 				capabilities: {
-					imageInput: endpoint.supportsVision,
+					imageInput: endpoint instanceof AutoChatEndpoint ? true : endpoint.supportsVision,
 					toolCalling: endpoint.supportsToolCalls,
 				}
 			};

--- a/src/extension/prompts/node/panel/image.tsx
+++ b/src/extension/prompts/node/panel/image.tsx
@@ -44,13 +44,14 @@ export class HistoricalImage extends PromptElement<HistoricalImageProps, unknown
 	constructor(
 		props: HistoricalImageProps,
 		@IPromptEndpoint private readonly promptEndpoint: IPromptEndpoint,
+		@IAuthenticationService private readonly authService: IAuthenticationService,
 	) {
 		super(props);
 	}
 
 	override async render(_state: unknown, sizing: PromptSizing) {
 		// If the model doesn't support vision, omit historical images
-		if (!this.promptEndpoint.supportsVision) {
+		if (!this.promptEndpoint.supportsVision || !this.authService.copilotToken?.isEditorPreviewFeaturesEnabled()) {
 			return undefined;
 		}
 
@@ -77,7 +78,7 @@ export class Image extends PromptElement<ImageProps, unknown> {
 		const fillerUri: Uri = this.props.reference ?? Uri.parse('Attached Image');
 
 		try {
-			if (!this.promptEndpoint.supportsVision) {
+			if (!this.promptEndpoint.supportsVision || !this.authService.copilotToken?.isEditorPreviewFeaturesEnabled()) {
 				if (this.props.omitReferences) {
 					return;
 				}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/281926


This fix is not ideal because of the following:
- We don't know what vision model we should give them so they're going to get the first one in the list which is GPT 4.1
- We don't know if the history has images meaning only on the request with the image will they be routed. So the following scenario will be kind of awkward

1. What is this image
2. Image model responds
3. Can you tell me more about that?
4. Non image model goes "what image?"


We may be able to fix this somewhat with adding descriptions as fallbacks for non image models but fully fixing this and making Auto history aware was really challenging and not something I was able to do 