### PR TITLE
nes: xtab: migrate to native AsyncIterable's

### DIFF
--- a/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
+++ b/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
@@ -5,7 +5,6 @@
 
 import { NoNextEditReason, StreamedEdit } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { fromUnknown } from '../../../util/common/errors';
-import { AsyncIterableObject } from '../../../util/vs/base/common/async';
 import { LineReplacement } from '../../../util/vs/editor/common/core/edits/lineEdit';
 import { LineRange } from '../../../util/vs/editor/common/core/ranges/lineRange';
 import { OffsetRange } from '../../../util/vs/editor/common/core/ranges/offsetRange';
@@ -57,7 +56,7 @@ class Patch {
 export class XtabCustomDiffPatchResponseHandler {
 
 	public static async *handleResponse(
-		linesStream: AsyncIterableObject<string>,
+		linesStream: AsyncIterable<string>,
 		documentBeforeEdits: StringText,
 		window: OffsetRange | undefined,
 		originalWindow?: OffsetRange,
@@ -84,7 +83,7 @@ export class XtabCustomDiffPatchResponseHandler {
 		return new LineReplacement(new LineRange(patch.lineNumZeroBased + 1, patch.lineNumZeroBased + 1 + patch.removedLines.length), patch.addedLines);
 	}
 
-	public static async *extractEdits(linesStream: AsyncIterableObject<string>): AsyncGenerator<Patch> {
+	public static async *extractEdits(linesStream: AsyncIterable<string>): AsyncGenerator<Patch> {
 		let currentPatch: Patch | null = null;
 		for await (const line of linesStream) {
 			// if no current patch, try to parse a new one

--- a/src/extension/xtab/test/common/responseProcessor.spec.ts
+++ b/src/extension/xtab/test/common/responseProcessor.spec.ts
@@ -5,14 +5,14 @@
 
 import { describe, expect, it, suite, test } from 'vitest';
 import { ResponseProcessor } from '../../../../platform/inlineEdits/common/responseProcessor';
-import { AsyncIterableObject } from '../../../../util/vs/base/common/async';
 import { LineEdit, LineReplacement } from '../../../../util/vs/editor/common/core/edits/lineEdit';
 import { LineRange } from '../../../../util/vs/editor/common/core/ranges/lineRange';
+import { AsyncIterUtils } from '../../../../util/common/asyncIterableUtils';
 
 suite('stream diffing', () => {
 
 	async function run(editWindow: string[], updatedEditWindowLines: string[]) {
-		const updatedEditWindowLinesStream = AsyncIterableObject.fromArray(updatedEditWindowLines);
+		const updatedEditWindowLinesStream = AsyncIterUtils.fromArray(updatedEditWindowLines);
 
 		const editsGen = ResponseProcessor.diff(editWindow, updatedEditWindowLinesStream, 0, ResponseProcessor.DEFAULT_DIFF_PARAMS);
 
@@ -399,7 +399,7 @@ describe('emitFastCursorLineChange with empty lines', () => {
 		cursorOffset: number,
 		emitFastCursorLineChange: ResponseProcessor.EmitFastCursorLineChange = ResponseProcessor.EmitFastCursorLineChange.Always,
 	) {
-		const updatedEditWindowLinesStream = AsyncIterableObject.fromArray(updatedEditWindowLines);
+		const updatedEditWindowLinesStream = AsyncIterUtils.fromArray(updatedEditWindowLines);
 
 		const params: ResponseProcessor.DiffParams = {
 			...ResponseProcessor.DEFAULT_DIFF_PARAMS,

--- a/src/extension/xtab/test/node/xtabCustomDiffPatchResponseHandler.spec.ts
+++ b/src/extension/xtab/test/node/xtabCustomDiffPatchResponseHandler.spec.ts
@@ -4,17 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, it } from 'vitest';
-import { AsyncIterableObject } from '../../../../util/vs/base/common/async';
+import { AsyncIterUtils } from '../../../../util/common/asyncIterableUtils';
 import { XtabCustomDiffPatchResponseHandler } from '../../node/xtabCustomDiffPatchResponseHandler';
 
 describe('XtabCustomDiffPatchResponseHandler', () => {
 
 	async function collectPatches(patchText: string): Promise<string> {
-		const linesStream = AsyncIterableObject.fromArray(patchText.split('\n'));
-		const patches: string[] = [];
-		for await (const patch of XtabCustomDiffPatchResponseHandler.extractEdits(linesStream)) {
-			patches.push(patch.toString());
-		}
+		const linesStream = AsyncIterUtils.fromArray(patchText.split('\n'));
+		const patches = await AsyncIterUtils.toArray(XtabCustomDiffPatchResponseHandler.extractEdits(linesStream));
 		return patches.map(p => p.toString()).join('\n');
 	}
 

--- a/src/extension/xtab/test/node/xtabUtils.spec.ts
+++ b/src/extension/xtab/test/node/xtabUtils.spec.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, it } from 'vitest';
-import { AsyncIterableObject } from '../../../../util/vs/base/common/async';
+import { AsyncIterUtils } from '../../../../util/common/asyncIterableUtils';
 import { toLines } from '../../node/xtabUtils';
 
 describe('toLines', () => {
 
 	async function chunksToLines(chunks: string[]) {
-		const iter = AsyncIterableObject.fromArray(chunks.map(text => ({ delta: { text } })));
+		const iter = AsyncIterUtils.fromArray(chunks.map(text => ({ delta: { text } })));
 		const arr: string[] = [];
 		for await (const line of toLines(iter)) {
 			arr.push(line);

--- a/src/platform/inlineEdits/common/responseProcessor.ts
+++ b/src/platform/inlineEdits/common/responseProcessor.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { AsyncIterableObject } from '../../../util/vs/base/common/async';
 import { illegalArgument } from '../../../util/vs/base/common/errors';
 import { LineReplacement } from '../../../util/vs/editor/common/core/edits/lineEdit';
 import { LineRange } from '../../../util/vs/editor/common/core/ranges/lineRange';
@@ -66,7 +65,7 @@ export namespace ResponseProcessor {
 	 * @param modifiedLines
 	 * @param cursorOriginalLinesOffset offset of cursor within original lines
 	 */
-	export async function* diff(originalLines: string[], modifiedLines: AsyncIterableObject<string>, cursorOriginalLinesOffset: number, params: DiffParams): AsyncIterable<LineReplacement> {
+	export async function* diff(originalLines: string[], modifiedLines: AsyncIterable<string>, cursorOriginalLinesOffset: number, params: DiffParams): AsyncIterable<LineReplacement> {
 
 		const lineToIdxs = new ArrayMap<string, number>();
 		for (const [i, line] of originalLines.entries()) {


### PR DESCRIPTION
AsyncIterableObject keeps all yielded elements and consumes memory