### PR TITLE
Update Anthropic SDK packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"hasInstallScript": true,
 			"license": "SEE LICENSE IN LICENSE.txt",
 			"dependencies": {
-				"@anthropic-ai/claude-agent-sdk": "0.2.31",
-				"@anthropic-ai/sdk": "^0.72.1",
+				"@anthropic-ai/claude-agent-sdk": "^0.2.34",
+				"@anthropic-ai/sdk": "^0.73.0",
 				"@github/blackbird-external-ingest-utils": "^0.2.0",
 				"@github/copilot": "^0.0.403",
 				"@google/genai": "^1.22.0",
@@ -166,9 +166,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk": {
-			"version": "0.2.31",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.31.tgz",
-			"integrity": "sha512-ZepnDG6r91je1LvrHST2C67m3olgmiYfrhnj4Elyj8AGqOHGYig1zDIPVhGF0u62y0rVVri2mGFDYQI0oW/LBw==",
+			"version": "0.2.34",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.34.tgz",
+			"integrity": "sha512-QLHd3Nt7bGU7/YH71fXFaztM9fNxGGruzTMrTYJkbm5gYJl5ZyU2zGyoE5VpWC0e1QU0yYdNdBVgqSYDcJGufg==",
 			"license": "SEE LICENSE IN README.md",
 			"engines": {
 				"node": ">=18.0.0"
@@ -188,9 +188,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
-			"version": "0.72.1",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.72.1.tgz",
-			"integrity": "sha512-MiUnue7qN7DvLIoYHgkedN2z05mRf2CutBzjXXY2krzOhG2r/rIfISS2uVkNLikgToB5hYIzw+xp2jdOtRkqYQ==",
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+			"integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
 			"license": "MIT",
 			"dependencies": {
 				"json-schema-to-ts": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -5737,8 +5737,8 @@
 		"zod": "3.25.76"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.31",
-		"@anthropic-ai/sdk": "^0.72.1",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.34",
+		"@anthropic-ai/sdk": "^0.73.0",
 		"@github/blackbird-external-ingest-utils": "^0.2.0",
 		"@github/copilot": "^0.0.403",
 		"@google/genai": "^1.22.0",

--- a/src/extension/agents/node/adapters/anthropicAdapter.ts
+++ b/src/extension/agents/node/adapters/anthropicAdapter.ts
@@ -281,7 +281,8 @@ class AnthropicAdapter implements IProtocolAdapter {
 					output_tokens: 1,
 					service_tier: null,
 					server_tool_use: null,
-					cache_creation: null
+					cache_creation: null,
+					inference_geo: null
 				}
 			}
 		};


### PR DESCRIPTION
### `@anthropic-ai/sdk` (0.72.1 → 0.73.0)

#### Bug Fixes
- Fixed memory leak in abort signal listener
- Fixed abort listener being removed too early

#### Chores
- Do not parse responses with empty content-length
- Restructure abort controller binding

### `@anthropic-ai/claude-agent-sdk` (0.2.31 → 0.2.34)

#### Features
- **Hook Events:** Added `TeammateIdle` and `TaskCompleted` hook events with `TeammateIdleHookInput` and `TaskCompletedHookInput` types
- **Sessions:** Added `sessionId` option to specify custom UUIDs for conversations

#### Breaking Changes
- None

#### Code Changes
- Added `inference_geo: null` to message type literal in `anthropicAdapter.ts`