### PR TITLE
subagent: persist sessions to support resume

### DIFF
--- a/src/extension/agents/node/adapters/anthropicAdapter.ts
+++ b/src/extension/agents/node/adapters/anthropicAdapter.ts
@@ -282,7 +282,9 @@ class AnthropicAdapter implements IProtocolAdapter {
 					service_tier: null,
 					server_tool_use: null,
 					cache_creation: null,
-					inference_geo: null
+					// NOTE: Some Anthropic SDK versions used to include extra usage fields
+					// (e.g. `inference_geo`). We intentionally only emit fields that exist
+					// in the current SDK's `Usage` type.
 				}
 			}
 		};

--- a/src/extension/extension/vscode-node/services.ts
+++ b/src/extension/extension/vscode-node/services.ts
@@ -116,6 +116,7 @@ import { IChatDiskSessionResources } from '../../prompts/common/chatDiskSessionR
 import { ChatDiskSessionResources } from '../../prompts/node/chatDiskSessionResourcesImpl';
 import { CodeMapperService, ICodeMapperService } from '../../prompts/node/codeMapper/codeMapperService';
 import { FixCookbookService, IFixCookbookService } from '../../prompts/node/inline/fixCookbookService';
+import { ISubagentSessionStore, SubagentSessionStore } from '../../subagentSessionStore/node/subagentSessionStore';
 import { WorkspaceMutationManager } from '../../testing/node/setupTestsFileManager';
 import { AgentMemoryService, IAgentMemoryService } from '../../tools/common/agentMemoryService';
 import { IToolsService } from '../../tools/common/toolsService';
@@ -140,6 +141,7 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 
 	builder.define(IAutomodeService, new SyncDescriptor(AutomodeService));
 	builder.define(IConversationStore, new ConversationStore());
+	builder.define(ISubagentSessionStore, new SubagentSessionStore());
 	builder.define(IDiffService, new DiffServiceImpl());
 	builder.define(ITokenizerProvider, new SyncDescriptor(TokenizerProvider, [true]));
 	builder.define(IToolsService, new SyncDescriptor(ToolsService));

--- a/src/extension/intents/node/testIntent/testIntent.tsx
+++ b/src/extension/intents/node/testIntent/testIntent.tsx
@@ -31,6 +31,7 @@ import { DefaultIntentRequestHandler } from '../../../prompt/node/defaultIntentR
 import { IDocumentContext } from '../../../prompt/node/documentContext';
 import { IIntent, IIntentInvocation, IIntentInvocationContext, IIntentSlashCommandInfo } from '../../../prompt/node/intents';
 import { isTestFile } from '../../../prompt/node/testFiles';
+import { ISubagentSessionStore } from '../../../subagentSessionStore/node/subagentSessionStore';
 import { ContributedToolName } from '../../../tools/common/toolNames';
 import { TestFromSourceInvocation } from './testFromSrcInvocation';
 import { TestFromTestInvocation } from './testFromTestInvocation';
@@ -239,8 +240,9 @@ class RequestHandler extends DefaultIntentRequestHandler {
 		@IEditSurvivalTrackerService editSurvivalTrackerService: IEditSurvivalTrackerService,
 		@IAuthenticationService authenticationService: IAuthenticationService,
 		@IChatHookService chatHookService: IChatHookService,
+		@ISubagentSessionStore subagentSessionStore: ISubagentSessionStore,
 	) {
-		super(intent, conversation, request, stream, token, documentContext, location, chatTelemetry, undefined, undefined, instantiationService, conversationOptions, telemetryService, logService, surveyService, requestLogger, editSurvivalTrackerService, authenticationService, chatHookService);
+		super(intent, conversation, request, stream, token, documentContext, location, chatTelemetry, undefined, undefined, instantiationService, conversationOptions, telemetryService, logService, surveyService, requestLogger, editSurvivalTrackerService, authenticationService, chatHookService, subagentSessionStore);
 	}
 
 	/**

--- a/src/extension/intents/node/toolCallingLoop.ts
+++ b/src/extension/intents/node/toolCallingLoop.ts
@@ -162,6 +162,18 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 		return this.options.conversation.getLatestTurn();
 	}
 
+	/**
+	 * Pre-populates the tool call state from a prior subagent session.
+	 * This is used when resuming a subagent with its full prior context:
+	 * the prior rounds and results are loaded so the prompt builder includes
+	 * them as conversation history.
+	 */
+	public hydrateFromPriorSession(priorRounds: IToolCallRound[], priorResults: Record<string, LanguageModelToolResult2>): void {
+		this.toolCallRounds = [...priorRounds];
+		this.toolCallResults = { ...this.toolCallResults, ...priorResults };
+		this._logService.info(`[ToolCallingLoop] Hydrated ${priorRounds.length} prior rounds and ${Object.keys(priorResults).length} results from prior subagent session`);
+	}
+
 	constructor(
 		protected readonly options: TOptions,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,

--- a/src/extension/replay/vscode-node/chatReplayNotebookSerializer.ts
+++ b/src/extension/replay/vscode-node/chatReplayNotebookSerializer.ts
@@ -214,15 +214,15 @@ export class ChatReplayNotebookSerializer implements NotebookSerializer {
 				lines.push(`**Model:** ${metadata.model}`);
 			}
 			if (metadata.duration !== undefined) {
-				lines.push(`**Duration:** ${metadata.duration.toLocaleString()}ms`);
+				lines.push(`**Duration:** ${metadata.duration.toLocaleString('en-US')}ms`);
 			}
 			if (metadata.usage) {
 				const usage = metadata.usage;
 				if (usage.prompt_tokens !== undefined) {
-					lines.push(`**Prompt Tokens:** ${usage.prompt_tokens.toLocaleString()}`);
+					lines.push(`**Prompt Tokens:** ${usage.prompt_tokens.toLocaleString('en-US')}`);
 				}
 				if (usage.completion_tokens !== undefined) {
-					lines.push(`**Completion Tokens:** ${usage.completion_tokens.toLocaleString()}`);
+					lines.push(`**Completion Tokens:** ${usage.completion_tokens.toLocaleString('en-US')}`);
 				}
 			}
 		}
@@ -238,7 +238,7 @@ export class ChatReplayNotebookSerializer implements NotebookSerializer {
 
 		if (log.tokens !== undefined && log.maxTokens !== undefined) {
 			const percentage = ((log.tokens / log.maxTokens) * 100).toFixed(1);
-			lines.push(`**Tokens:** ${log.tokens.toLocaleString()} / ${log.maxTokens.toLocaleString()} (${percentage}%)`);
+			lines.push(`**Tokens:** ${log.tokens.toLocaleString('en-US')} / ${log.maxTokens.toLocaleString('en-US')} (${percentage}%)`);
 		}
 
 		return lines.join('\n');
@@ -256,15 +256,15 @@ export class ChatReplayNotebookSerializer implements NotebookSerializer {
 				lines.push(`**Model:** ${metadata.model}`);
 			}
 			if (metadata.duration !== undefined) {
-				lines.push(`**Duration:** ${metadata.duration.toLocaleString()}ms`);
+				lines.push(`**Duration:** ${metadata.duration.toLocaleString('en-US')}ms`);
 			}
 			if (metadata.usage) {
 				const usage = metadata.usage;
 				if (usage.prompt_tokens !== undefined) {
-					lines.push(`**Prompt Tokens:** ${usage.prompt_tokens.toLocaleString()}`);
+					lines.push(`**Prompt Tokens:** ${usage.prompt_tokens.toLocaleString('en-US')}`);
 				}
 				if (usage.completion_tokens !== undefined) {
-					lines.push(`**Completion Tokens:** ${usage.completion_tokens.toLocaleString()}`);
+					lines.push(`**Completion Tokens:** ${usage.completion_tokens.toLocaleString('en-US')}`);
 				}
 			}
 			if (metadata.startTime) {

--- a/src/extension/replay/vscode-node/test/chatReplayNotebook.spec.ts
+++ b/src/extension/replay/vscode-node/test/chatReplayNotebook.spec.ts
@@ -489,7 +489,7 @@ describe('ChatReplayNotebookSerializer', () => {
 			// Element cell should show token usage
 			const elementCell = notebookData.cells[2];
 			expect(elementCell.value).toContain('#### Element: PromptElement');
-			expect(elementCell.value).toContain('**Tokens:** 5,000 / 100,000');
+			expect(elementCell.value).toContain('**Tokens:** 5,000 / 100,000 (5.0%)');
 		});
 
 		it('formats request entries with metadata (non-ChatMLSuccess)', async () => {

--- a/src/extension/subagentSessionStore/node/subagentSessionStore.ts
+++ b/src/extension/subagentSessionStore/node/subagentSessionStore.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createServiceIdentifier } from '../../../util/common/services';
+import { LRUCache } from '../../../util/vs/base/common/map';
+import { LanguageModelToolResult2 } from '../../../vscodeTypes';
+import { IToolCallRound } from '../../prompt/common/intents';
+
+/**
+ * Represents a saved subagent session that can be resumed.
+ * Contains the full conversation transcript (tool call rounds + results)
+ * needed to restore context on resume.
+ */
+export interface ISubagentSession {
+	/** The stable subAgentInvocationId for this session. */
+	readonly subAgentInvocationId: string;
+	/** Optional agent name for this session. */
+	readonly subAgentName?: string;
+	/** The original prompt that started this session. */
+	readonly originalPrompt: string;
+	/** The tool call rounds from the subagent's conversation. */
+	readonly toolCallRounds: IToolCallRound[];
+	/** The tool call results keyed by tool call ID. */
+	readonly toolCallResults: Record<string, LanguageModelToolResult2>;
+	/** The final response text from the last run. */
+	readonly lastResponse: string;
+	/** Timestamp of when the session was saved. */
+	readonly savedAt: number;
+}
+
+export const ISubagentSessionStore = createServiceIdentifier<ISubagentSessionStore>('ISubagentSessionStore');
+
+export interface ISubagentSessionStore {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Save a subagent session for potential resume later.
+	 */
+	saveSession(session: ISubagentSession): void;
+
+	/**
+	 * Retrieve a saved subagent session by its invocation ID.
+	 * Returns undefined if no session exists for this ID.
+	 */
+	getSession(subAgentInvocationId: string): ISubagentSession | undefined;
+
+	/**
+	 * Check if a session exists for the given invocation ID.
+	 */
+	hasSession(subAgentInvocationId: string): boolean;
+
+	/**
+	 * Remove a session by its invocation ID.
+	 */
+	removeSession(subAgentInvocationId: string): void;
+}
+
+/**
+ * Maximum number of subagent sessions to keep in the LRU cache.
+ * Older sessions are evicted when this limit is reached.
+ */
+const MAX_SESSIONS = 100;
+
+export class SubagentSessionStore implements ISubagentSessionStore {
+	readonly _serviceBrand: undefined;
+
+	private readonly sessions: LRUCache<string, ISubagentSession>;
+
+	constructor() {
+		this.sessions = new LRUCache<string, ISubagentSession>(MAX_SESSIONS);
+	}
+
+	saveSession(session: ISubagentSession): void {
+		this.sessions.set(session.subAgentInvocationId, session);
+	}
+
+	getSession(subAgentInvocationId: string): ISubagentSession | undefined {
+		return this.sessions.get(subAgentInvocationId);
+	}
+
+	hasSession(subAgentInvocationId: string): boolean {
+		return this.sessions.has(subAgentInvocationId);
+	}
+
+	removeSession(subAgentInvocationId: string): void {
+		this.sessions.delete(subAgentInvocationId);
+	}
+}

--- a/src/extension/test/node/services.ts
+++ b/src/extension/test/node/services.ts
@@ -64,6 +64,7 @@ import { IChatDiskSessionResources } from '../../prompts/common/chatDiskSessionR
 import { ChatDiskSessionResources } from '../../prompts/node/chatDiskSessionResourcesImpl';
 import { CodeMapperService, ICodeMapperService } from '../../prompts/node/codeMapper/codeMapperService';
 import { FixCookbookService, IFixCookbookService } from '../../prompts/node/inline/fixCookbookService';
+import { ISubagentSessionStore, SubagentSessionStore } from '../../subagentSessionStore/node/subagentSessionStore';
 import { AgentMemoryService, IAgentMemoryService } from '../../tools/common/agentMemoryService';
 import { EditToolLearningService, IEditToolLearningService } from '../../tools/common/editToolLearningService';
 import { IToolsService } from '../../tools/common/toolsService';
@@ -132,6 +133,7 @@ export function createExtensionUnitTestingServices(disposables: Pick<DisposableS
 	testingServiceCollection.define(IEmbeddingsComputer, new SyncDescriptor(RemoteEmbeddingsComputer));
 	testingServiceCollection.define(ITodoListContextProvider, new SyncDescriptor(TodoListContextProvider));
 	testingServiceCollection.define(ILanguageModelServer, new SyncDescriptor(MockLanguageModelServer));
+	testingServiceCollection.define(ISubagentSessionStore, new SyncDescriptor(SubagentSessionStore));
 	testingServiceCollection.define(IEditToolLearningService, new SyncDescriptor(EditToolLearningService));
 	testingServiceCollection.define(IAgentMemoryService, new SyncDescriptor(AgentMemoryService));
 	testingServiceCollection.define(IGitService, new SyncDescriptor(NullGitExtensionService));

--- a/src/extension/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/extension/vscode.proposed.chatParticipantPrivate.d.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// version: 11
+// version: 12
 
 declare module 'vscode' {
 
@@ -103,6 +103,13 @@ declare module 'vscode' {
 		 * The request ID of the parent request that invoked this subagent.
 		 */
 		readonly parentRequestId?: string;
+
+		/**
+		 * When set, indicates that this is a resumed subagent invocation.
+		 * The extension should rehydrate the prior conversation context for this subagent
+		 * using the stored transcript keyed by this ID.
+		 */
+		readonly resumeSubAgentInvocationId?: string;
 	}
 
 	export enum ChatRequestEditedFileEventKind {

--- a/test/base/simulationContext.ts
+++ b/test/base/simulationContext.ts
@@ -10,6 +10,7 @@ import { IIntentService, IntentService } from '../../src/extension/intents/node/
 import { ITestGenInfoStorage, TestGenInfoStorage } from '../../src/extension/intents/node/testIntent/testInfoStorage';
 import { ILinkifyService, LinkifyService } from '../../src/extension/linkify/common/linkifyService';
 import { ChatMLFetcherImpl } from '../../src/extension/prompt/node/chatMLFetcher';
+import { ISubagentSessionStore, SubagentSessionStore } from '../../src/extension/subagentSessionStore/node/subagentSessionStore';
 import { createExtensionUnitTestingServices, ISimulationModelConfig } from '../../src/extension/test/node/services';
 import { AIEvaluationService, IAIEvaluationService } from '../../src/extension/testing/node/aiEvaluationService';
 import { IChatMLFetcher } from '../../src/platform/chat/common/chatMLFetcher';
@@ -289,6 +290,7 @@ export async function createSimulationAccessor(
 	testingServiceCollection.define(ITestProvider, new SyncDescriptor(NullTestProvider));
 	testingServiceCollection.define(ITestGenInfoStorage, new SyncDescriptor(TestGenInfoStorage));
 	testingServiceCollection.define(IConversationStore, new SyncDescriptor(ConversationStore));
+	testingServiceCollection.define(ISubagentSessionStore, new SyncDescriptor(SubagentSessionStore));
 	testingServiceCollection.define(IReviewService, new SyncDescriptor(SimulationReviewService));
 	testingServiceCollection.define(IGitExtensionService, new SyncDescriptor(NullGitExtensionService));
 	testingServiceCollection.define(IReleaseNotesService, new SyncDescriptor(ReleaseNotesService));


### PR DESCRIPTION
Implements persistence + hydration for “resume subagent” so a follow-up request can continue from a previous subagent run.

Companion PR (VS Code): https://github.com/microsoft/vscode/pull/293511

### What changed
- Add an `ISubagentSessionStore` (LRU-backed) to store subagent transcripts keyed by `subAgentInvocationId`.
- `ToolCallingLoop`: add `hydrateFromPriorSession(...)` to pre-seed prior tool-call rounds/results when resuming.
- `DefaultIntentRequestHandler`: 
  - when `request.resumeSubAgentInvocationId` is provided, load and hydrate the loop before continuing
  - when `request.subAgentInvocationId` is set, persist the completed session for potential resume.
- Align proposed API to **`chatParticipantPrivate@12`** (`resumeSubAgentInvocationId?: string`).
- Misc: fix Anthropic adapter typing by removing unsupported `inference_geo`, and make replay notebook token formatting locale-stable.

### How to test
1. Run a subagent once and capture the emitted `subAgentInvocationId` (from the VS Code `runSubagent` tool result).
2. Run again with `resumeSubAgentInvocationId` set to that value.
3. Verify the second run can refer back to the first run’s context (e.g., ask it to continue or summarize its prior progress).

### Test coverage
- `npm run test:unit`
