### PR TITLE
feat: Enhance Claude chat session management with folder options

### DIFF
--- a/src/extension/agents/claude/common/claudeFolderInfo.ts
+++ b/src/extension/agents/claude/common/claudeFolderInfo.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface ClaudeFolderInfo {
+	readonly cwd: string;
+	readonly additionalDirectories: string[];
+}

--- a/src/extension/agents/claude/node/sessionParser/test/claudeCodeSessionService.spec.ts
+++ b/src/extension/agents/claude/node/sessionParser/test/claudeCodeSessionService.spec.ts
@@ -15,9 +15,9 @@ import { TestWorkspaceService } from '../../../../../../platform/test/node/testW
 import { IWorkspaceService } from '../../../../../../platform/workspace/common/workspaceService';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../util/common/test/testUtils';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../util/vs/base/common/cancellation';
-import { cwd } from '../../../../../../util/vs/base/common/process';
 import { URI } from '../../../../../../util/vs/base/common/uri';
 import { IInstantiationService } from '../../../../../../util/vs/platform/instantiation/common/instantiation';
+import { FolderRepositoryMRUEntry, IFolderRepositoryManager } from '../../../../../chatSessions/common/folderRepositoryManager';
 import { createExtensionUnitTestingServices } from '../../../../../test/node/services';
 import { ClaudeCodeSessionService } from '../claudeCodeSessionService';
 
@@ -25,6 +25,24 @@ function computeFolderSlug(folderUri: URI): string {
 	return folderUri.path
 		.replace(/^\/([a-z]):/i, (_, driveLetter) => driveLetter.toUpperCase() + '-')
 		.replace(/[\/ .]/g, '-');
+}
+
+class MockFolderRepositoryManager implements IFolderRepositoryManager {
+	declare _serviceBrand: undefined;
+	private _mruEntries: FolderRepositoryMRUEntry[] = [];
+
+	setMRUEntries(entries: FolderRepositoryMRUEntry[]): void {
+		this._mruEntries = entries;
+	}
+
+	setUntitledSessionFolder(): void { }
+	getUntitledSessionFolder(): undefined { return undefined; }
+	deleteUntitledSessionFolder(): void { }
+	async getFolderRepository(): Promise<any> { return { folder: undefined, repository: undefined, worktree: undefined, worktreeProperties: undefined, trusted: undefined }; }
+	async initializeFolderRepository(): Promise<any> { return { folder: undefined, repository: undefined, worktree: undefined, worktreeProperties: undefined, trusted: undefined }; }
+	getFolderMRU(): FolderRepositoryMRUEntry[] { return this._mruEntries; }
+	async deleteMRUEntry(): Promise<void> { }
+	getLastUsedFolderIdInUntitledWorkspace(): undefined { return undefined; }
 }
 
 describe('ClaudeCodeSessionService', () => {
@@ -47,6 +65,7 @@ describe('ClaudeCodeSessionService', () => {
 		// Create mock workspace service with the test workspace folder
 		const workspaceService = store.add(new TestWorkspaceService([folderUri]));
 		testingServiceCollection.set(IWorkspaceService, workspaceService);
+		testingServiceCollection.define(IFolderRepositoryManager, new MockFolderRepositoryManager());
 
 		const accessor = testingServiceCollection.createTestingAccessor();
 		mockFs = accessor.get(IFileSystemService) as MockFileSystemService;
@@ -446,31 +465,38 @@ describe('ClaudeCodeSessionService', () => {
 	// ========================================================================
 
 	describe('no-workspace scenario', () => {
+		const mruFolder = URI.file('/recent/project');
+		const mruSlug = computeFolderSlug(mruFolder);
 		let noWorkspaceDirUri: URI;
 		let noWorkspaceService: ClaudeCodeSessionService;
 		let noWorkspaceMockFs: MockFileSystemService;
-		// No-workspace uses process.cwd() to compute the slug (matching SDK behavior)
-		const cwdSlug = computeFolderSlug(URI.file(cwd()));
+		let noWorkspaceFolderManager: MockFolderRepositoryManager;
 
 		beforeEach(() => {
 			noWorkspaceMockFs = new MockFileSystemService();
+			noWorkspaceFolderManager = new MockFolderRepositoryManager();
 			const noWorkspaceTestingServiceCollection = store.add(createExtensionUnitTestingServices(store));
 			noWorkspaceTestingServiceCollection.set(IFileSystemService, noWorkspaceMockFs);
 
 			// Create mock workspace service with no workspace folders (empty)
 			const emptyWorkspaceService = store.add(new TestWorkspaceService([]));
 			noWorkspaceTestingServiceCollection.set(IWorkspaceService, emptyWorkspaceService);
+			noWorkspaceTestingServiceCollection.define(IFolderRepositoryManager, noWorkspaceFolderManager);
+
+			// Set up MRU entries so the service can discover sessions
+			noWorkspaceFolderManager.setMRUEntries([
+				{ folder: mruFolder, repository: undefined, lastAccessed: Date.now(), isUntitledSessionSelection: false },
+			]);
 
 			const accessor = noWorkspaceTestingServiceCollection.createTestingAccessor();
 			noWorkspaceMockFs = accessor.get(IFileSystemService) as MockFileSystemService;
 			const instaService = accessor.get(IInstantiationService);
 			const nativeEnvService = accessor.get(INativeEnvService);
-			// When there's no workspace, sessions are stored based on process.cwd()
-			noWorkspaceDirUri = URI.joinPath(nativeEnvService.userHome, '.claude', 'projects', cwdSlug);
+			noWorkspaceDirUri = URI.joinPath(nativeEnvService.userHome, '.claude', 'projects', mruSlug);
 			noWorkspaceService = instaService.createInstance(ClaudeCodeSessionService);
 		});
 
-		it('loads sessions from process.cwd() directory when there are no workspace folders', async () => {
+		it('loads sessions from MRU folder directories when there are no workspace folders', async () => {
 			const fileName = 'no-workspace-session.jsonl';
 			const fileContents = JSON.stringify({
 				parentUuid: null,
@@ -491,21 +517,73 @@ describe('ClaudeCodeSessionService', () => {
 			expect(sessions[0].label).toBe('session without workspace');
 		});
 
-		it('returns empty array when process.cwd() directory does not exist', async () => {
-			// Don't mock any directory - simulate non-existent directory
+		it('returns empty array when no MRU entries exist', async () => {
+			noWorkspaceFolderManager.setMRUEntries([]);
+			const noMruServiceCollection = store.add(createExtensionUnitTestingServices(store));
+			noMruServiceCollection.set(IFileSystemService, new MockFileSystemService());
+			noMruServiceCollection.set(IWorkspaceService, store.add(new TestWorkspaceService([])));
+			noMruServiceCollection.define(IFolderRepositoryManager, noWorkspaceFolderManager);
 
-			const sessions = await noWorkspaceService.getAllSessions(CancellationToken.None);
+			const accessor = noMruServiceCollection.createTestingAccessor();
+			const noMruService = accessor.get(IInstantiationService).createInstance(ClaudeCodeSessionService);
 
+			const sessions = await noMruService.getAllSessions(CancellationToken.None);
 			expect(sessions).toHaveLength(0);
+		});
+
+		it('discovers sessions across all MRU folder slugs', async () => {
+			const mruFolder2 = URI.file('/another/project');
+			const mruSlug2 = computeFolderSlug(mruFolder2);
+
+			noWorkspaceFolderManager.setMRUEntries([
+				{ folder: mruFolder, repository: undefined, lastAccessed: Date.now(), isUntitledSessionSelection: false },
+				{ folder: mruFolder2, repository: undefined, lastAccessed: Date.now() - 1000, isUntitledSessionSelection: false },
+			]);
+
+			const noWorkspaceTestingServiceCollection2 = store.add(createExtensionUnitTestingServices(store));
+			const mockFs2 = new MockFileSystemService();
+			noWorkspaceTestingServiceCollection2.set(IFileSystemService, mockFs2);
+			noWorkspaceTestingServiceCollection2.set(IWorkspaceService, store.add(new TestWorkspaceService([])));
+			noWorkspaceTestingServiceCollection2.define(IFolderRepositoryManager, noWorkspaceFolderManager);
+
+			const accessor2 = noWorkspaceTestingServiceCollection2.createTestingAccessor();
+			const mockFs2Actual = accessor2.get(IFileSystemService) as MockFileSystemService;
+			const nativeEnv2 = accessor2.get(INativeEnvService);
+			const dir1 = URI.joinPath(nativeEnv2.userHome, '.claude', 'projects', mruSlug);
+			const dir2 = URI.joinPath(nativeEnv2.userHome, '.claude', 'projects', mruSlug2);
+
+			const fileName1 = 'session-mru1.jsonl';
+			const fileName2 = 'session-mru2.jsonl';
+			mockFs2Actual.mockDirectory(dir1, [[fileName1, FileType.File]]);
+			mockFs2Actual.mockFile(URI.joinPath(dir1, fileName1), JSON.stringify({
+				parentUuid: null, sessionId: 'session-mru1', type: 'user',
+				message: { role: 'user', content: 'from mru 1' }, uuid: 'u1', timestamp: new Date().toISOString()
+			}), 1000);
+			mockFs2Actual.mockDirectory(dir2, [[fileName2, FileType.File]]);
+			mockFs2Actual.mockFile(URI.joinPath(dir2, fileName2), JSON.stringify({
+				parentUuid: null, sessionId: 'session-mru2', type: 'user',
+				message: { role: 'user', content: 'from mru 2' }, uuid: 'u2', timestamp: new Date().toISOString()
+			}), 1000);
+
+			const service2 = accessor2.get(IInstantiationService).createInstance(ClaudeCodeSessionService);
+			const sessions = await service2.getAllSessions(CancellationToken.None);
+
+			expect(sessions).toHaveLength(2);
+			const ids = sessions.map(s => s.id);
+			expect(ids).toContain('session-mru1');
+			expect(ids).toContain('session-mru2');
 		});
 	});
 
 	describe('multi-root workspace scenario', () => {
-		let multiRootDirUri: URI;
+		const folder1 = URI.file('/project1');
+		const folder2 = URI.file('/project2');
+		const folder1Slug = computeFolderSlug(folder1);
+		const folder2Slug = computeFolderSlug(folder2);
+		let folder1DirUri: URI;
+		let folder2DirUri: URI;
 		let multiRootService: ClaudeCodeSessionService;
 		let multiRootMockFs: MockFileSystemService;
-		// Multi-root workspaces use process.cwd() to compute the slug (matching SDK behavior)
-		const cwdSlug = computeFolderSlug(URI.file(cwd()));
 
 		beforeEach(() => {
 			multiRootMockFs = new MockFileSystemService();
@@ -513,21 +591,21 @@ describe('ClaudeCodeSessionService', () => {
 			multiRootTestingServiceCollection.set(IFileSystemService, multiRootMockFs);
 
 			// Create mock workspace service with multiple workspace folders
-			const folder1 = URI.file('/project1');
-			const folder2 = URI.file('/project2');
 			const multiRootWorkspaceService = store.add(new TestWorkspaceService([folder1, folder2]));
 			multiRootTestingServiceCollection.set(IWorkspaceService, multiRootWorkspaceService);
+			multiRootTestingServiceCollection.define(IFolderRepositoryManager, new MockFolderRepositoryManager());
 
 			const accessor = multiRootTestingServiceCollection.createTestingAccessor();
 			multiRootMockFs = accessor.get(IFileSystemService) as MockFileSystemService;
 			const instaService = accessor.get(IInstantiationService);
 			const nativeEnvService = accessor.get(INativeEnvService);
-			// Multi-root workspaces use process.cwd() slug to match where SDK stores sessions
-			multiRootDirUri = URI.joinPath(nativeEnvService.userHome, '.claude', 'projects', cwdSlug);
+			// Multi-root workspaces scan all workspace folder slugs
+			folder1DirUri = URI.joinPath(nativeEnvService.userHome, '.claude', 'projects', folder1Slug);
+			folder2DirUri = URI.joinPath(nativeEnvService.userHome, '.claude', 'projects', folder2Slug);
 			multiRootService = instaService.createInstance(ClaudeCodeSessionService);
 		});
 
-		it('loads sessions from process.cwd() directory for multi-root workspaces', async () => {
+		it('loads sessions from all workspace folder directories for multi-root workspaces', async () => {
 			const fileName = 'multi-root-session.jsonl';
 			const fileContents = JSON.stringify({
 				parentUuid: null,
@@ -538,8 +616,8 @@ describe('ClaudeCodeSessionService', () => {
 				timestamp: new Date().toISOString()
 			});
 
-			multiRootMockFs.mockDirectory(multiRootDirUri, [[fileName, FileType.File]]);
-			multiRootMockFs.mockFile(URI.joinPath(multiRootDirUri, fileName), fileContents, 1000);
+			multiRootMockFs.mockDirectory(folder1DirUri, [[fileName, FileType.File]]);
+			multiRootMockFs.mockFile(URI.joinPath(folder1DirUri, fileName), fileContents, 1000);
 
 			const sessions = await multiRootService.getAllSessions(CancellationToken.None);
 
@@ -548,34 +626,48 @@ describe('ClaudeCodeSessionService', () => {
 			expect(sessions[0].label).toBe('session in multi-root workspace');
 		});
 
-		it('returns empty array when process.cwd() directory does not exist for multi-root', async () => {
-			// Don't mock any directory - simulate non-existent directory
+		it('returns empty array when no workspace folder directories exist for multi-root', async () => {
+			// Don't mock any directory - simulate non-existent directories
 
 			const sessions = await multiRootService.getAllSessions(CancellationToken.None);
 
 			expect(sessions).toHaveLength(0);
 		});
 
-		it('uses process.cwd() directory not individual folder slugs for multi-root', async () => {
-			// Mock the process.cwd() directory with a session
-			const fileName = 'shared-session.jsonl';
-			const fileContents = JSON.stringify({
+		it('discovers sessions across all workspace folder slugs for multi-root', async () => {
+			// Mock sessions in both folder directories
+			const fileName1 = 'session-from-folder1.jsonl';
+			const fileContents1 = JSON.stringify({
 				parentUuid: null,
-				sessionId: 'shared-session',
+				sessionId: 'session-from-folder1',
 				type: 'user',
-				message: { role: 'user', content: 'shared session' },
-				uuid: 'uuid-shared',
+				message: { role: 'user', content: 'from folder 1' },
+				uuid: 'uuid-folder1',
 				timestamp: new Date().toISOString()
 			});
 
-			multiRootMockFs.mockDirectory(multiRootDirUri, [[fileName, FileType.File]]);
-			multiRootMockFs.mockFile(URI.joinPath(multiRootDirUri, fileName), fileContents, 1000);
+			const fileName2 = 'session-from-folder2.jsonl';
+			const fileContents2 = JSON.stringify({
+				parentUuid: null,
+				sessionId: 'session-from-folder2',
+				type: 'user',
+				message: { role: 'user', content: 'from folder 2' },
+				uuid: 'uuid-folder2',
+				timestamp: new Date().toISOString()
+			});
 
-			// The session should only come from the process.cwd() directory, not individual folder slugs
+			multiRootMockFs.mockDirectory(folder1DirUri, [[fileName1, FileType.File]]);
+			multiRootMockFs.mockFile(URI.joinPath(folder1DirUri, fileName1), fileContents1, 1000);
+
+			multiRootMockFs.mockDirectory(folder2DirUri, [[fileName2, FileType.File]]);
+			multiRootMockFs.mockFile(URI.joinPath(folder2DirUri, fileName2), fileContents2, 1000);
+
 			const sessions = await multiRootService.getAllSessions(CancellationToken.None);
 
-			expect(sessions).toHaveLength(1);
-			expect(sessions[0].id).toBe('shared-session');
+			expect(sessions).toHaveLength(2);
+			const ids = sessions.map(s => s.id);
+			expect(ids).toContain('session-from-folder1');
+			expect(ids).toContain('session-from-folder2');
 		});
 	});
 
@@ -594,6 +686,7 @@ describe('ClaudeCodeSessionService', () => {
 
 			const spaceWorkspaceService = store.add(new TestWorkspaceService([spaceFolderUri]));
 			spaceTestingServiceCollection.set(IWorkspaceService, spaceWorkspaceService);
+			spaceTestingServiceCollection.define(IFolderRepositoryManager, new MockFolderRepositoryManager());
 
 			const accessor = spaceTestingServiceCollection.createTestingAccessor();
 			spaceMockFs = accessor.get(IFileSystemService) as MockFileSystemService;

--- a/src/extension/agents/claude/node/test/claudeCodeAgent.spec.ts
+++ b/src/extension/agents/claude/node/test/claudeCodeAgent.spec.ts
@@ -11,6 +11,7 @@ import { DisposableStore } from '../../../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
 import { createExtensionUnitTestingServices } from '../../../../test/node/services';
 import { MockChatResponseStream, TestChatRequest } from '../../../../test/node/testHelpers';
+import type { ClaudeFolderInfo } from '../../common/claudeFolderInfo';
 import { ClaudeAgentManager, ClaudeCodeSession } from '../claudeCodeAgent';
 import { IClaudeCodeSdkService } from '../claudeCodeSdkService';
 import { ClaudeLanguageModelServer } from '../claudeLanguageModelServer';
@@ -28,6 +29,8 @@ function toPromptBlocks(text: string): Anthropic.TextBlockParam[] {
 }
 
 const TEST_MODEL_ID = 'claude-3-sonnet';
+const TEST_PERMISSION_MODE = 'acceptEdits' as const;
+const TEST_FOLDER_INFO: ClaudeFolderInfo = { cwd: '/test/project', additionalDirectories: [] };
 
 describe('ClaudeAgentManager', () => {
 	const store = new DisposableStore();
@@ -56,7 +59,7 @@ describe('ClaudeAgentManager', () => {
 		const stream1 = new MockChatResponseStream();
 
 		const req1 = new TestChatRequest('Hi');
-		const res1 = await manager.handleRequest(undefined, req1, { history: [] } as any, stream1, CancellationToken.None, TEST_MODEL_ID);
+		const res1 = await manager.handleRequest(undefined, req1, { history: [] } as any, stream1, CancellationToken.None, TEST_MODEL_ID, TEST_PERMISSION_MODE, TEST_FOLDER_INFO);
 
 		expect(stream1.output.join('\n')).toContain('Hello from mock!');
 		expect(res1.claudeSessionId).toBe('sess-1');
@@ -65,7 +68,7 @@ describe('ClaudeAgentManager', () => {
 		const stream2 = new MockChatResponseStream();
 
 		const req2 = new TestChatRequest('Again');
-		const res2 = await manager.handleRequest(res1.claudeSessionId, req2, { history: [] } as any, stream2, CancellationToken.None, TEST_MODEL_ID);
+		const res2 = await manager.handleRequest(res1.claudeSessionId, req2, { history: [] } as any, stream2, CancellationToken.None, TEST_MODEL_ID, TEST_PERMISSION_MODE, TEST_FOLDER_INFO);
 
 		expect(stream2.output.join('\n')).toContain('Hello from mock!');
 		expect(res2.claudeSessionId).toBe('sess-1');
@@ -96,10 +99,10 @@ describe('ClaudeCodeSession', () => {
 	it('processes a single request correctly', async () => {
 		const serverConfig = { port: 8080, nonce: 'test-nonce' };
 		const mockServer = createMockLangModelServer();
-		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', TEST_MODEL_ID, undefined));
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', TEST_MODEL_ID, TEST_PERMISSION_MODE, TEST_FOLDER_INFO));
 		const stream = new MockChatResponseStream();
 
-		await session.invoke(toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream, CancellationToken.None, TEST_MODEL_ID);
+		await session.invoke(toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream, CancellationToken.None, TEST_MODEL_ID, TEST_PERMISSION_MODE);
 
 		expect(stream.output.join('\n')).toContain('Hello from mock!');
 	});
@@ -107,14 +110,14 @@ describe('ClaudeCodeSession', () => {
 	it('queues multiple requests and processes them sequentially', async () => {
 		const serverConfig = { port: 8080, nonce: 'test-nonce' };
 		const mockServer = createMockLangModelServer();
-		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', TEST_MODEL_ID, undefined));
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', TEST_MODEL_ID, TEST_PERMISSION_MODE, TEST_FOLDER_INFO));
 
 		const stream1 = new MockChatResponseStream();
 		const stream2 = new MockChatResponseStream();
 
 		// Start both requests simultaneously
-		const promise1 = session.invoke(toPromptBlocks('First'), {} as vscode.ChatParticipantToolToken, stream1, CancellationToken.None, TEST_MODEL_ID);
-		const promise2 = session.invoke(toPromptBlocks('Second'), {} as vscode.ChatParticipantToolToken, stream2, CancellationToken.None, TEST_MODEL_ID);
+		const promise1 = session.invoke(toPromptBlocks('First'), {} as vscode.ChatParticipantToolToken, stream1, CancellationToken.None, TEST_MODEL_ID, TEST_PERMISSION_MODE);
+		const promise2 = session.invoke(toPromptBlocks('Second'), {} as vscode.ChatParticipantToolToken, stream2, CancellationToken.None, TEST_MODEL_ID, TEST_PERMISSION_MODE);
 
 		// Wait for both to complete
 		await Promise.all([promise1, promise2]);
@@ -127,25 +130,25 @@ describe('ClaudeCodeSession', () => {
 	it('cancels pending requests when cancelled', async () => {
 		const serverConfig = { port: 8080, nonce: 'test-nonce' };
 		const mockServer = createMockLangModelServer();
-		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', TEST_MODEL_ID, undefined));
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', TEST_MODEL_ID, TEST_PERMISSION_MODE, TEST_FOLDER_INFO));
 		const stream = new MockChatResponseStream();
 		const source = new CancellationTokenSource();
 		source.cancel();
 
-		await expect(session.invoke(toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream, source.token, TEST_MODEL_ID)).rejects.toThrow();
+		await expect(session.invoke(toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream, source.token, TEST_MODEL_ID, TEST_PERMISSION_MODE)).rejects.toThrow();
 	});
 
 	it('cleans up resources when disposed', async () => {
 		const serverConfig = { port: 8080, nonce: 'test-nonce' };
 		const mockServer = createMockLangModelServer();
-		const session = instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', TEST_MODEL_ID, undefined);
+		const session = instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', TEST_MODEL_ID, TEST_PERMISSION_MODE, TEST_FOLDER_INFO);
 
 		// Dispose the session immediately
 		session.dispose();
 
 		// Any new requests should be rejected
 		const stream = new MockChatResponseStream();
-		await expect(session.invoke(toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream, CancellationToken.None, TEST_MODEL_ID))
+		await expect(session.invoke(toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream, CancellationToken.None, TEST_MODEL_ID, TEST_PERMISSION_MODE))
 			.rejects.toThrow('Session disposed');
 	});
 
@@ -153,8 +156,8 @@ describe('ClaudeCodeSession', () => {
 		const serverConfig = { port: 8080, nonce: 'test-nonce' };
 		const mockServer1 = createMockLangModelServer();
 		const mockServer2 = createMockLangModelServer();
-		const session1 = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer1, 'session-1', TEST_MODEL_ID, undefined));
-		const session2 = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer2, 'session-2', TEST_MODEL_ID, undefined));
+		const session1 = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer1, 'session-1', TEST_MODEL_ID, TEST_PERMISSION_MODE, TEST_FOLDER_INFO));
+		const session2 = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer2, 'session-2', TEST_MODEL_ID, TEST_PERMISSION_MODE, TEST_FOLDER_INFO));
 
 		expect(session1.sessionId).toBe('session-1');
 		expect(session2.sessionId).toBe('session-2');
@@ -164,8 +167,8 @@ describe('ClaudeCodeSession', () => {
 
 		// Both sessions should work independently
 		await Promise.all([
-			session1.invoke(toPromptBlocks('Hello from session 1'), {} as vscode.ChatParticipantToolToken, stream1, CancellationToken.None, TEST_MODEL_ID),
-			session2.invoke(toPromptBlocks('Hello from session 2'), {} as vscode.ChatParticipantToolToken, stream2, CancellationToken.None, TEST_MODEL_ID)
+			session1.invoke(toPromptBlocks('Hello from session 1'), {} as vscode.ChatParticipantToolToken, stream1, CancellationToken.None, TEST_MODEL_ID, TEST_PERMISSION_MODE),
+			session2.invoke(toPromptBlocks('Hello from session 2'), {} as vscode.ChatParticipantToolToken, stream2, CancellationToken.None, TEST_MODEL_ID, TEST_PERMISSION_MODE)
 		]);
 
 		expect(stream1.output.join('\n')).toContain('Hello from mock!');
@@ -175,10 +178,10 @@ describe('ClaudeCodeSession', () => {
 	it('initializes with model ID from constructor', async () => {
 		const serverConfig = { port: 8080, nonce: 'test-nonce' };
 		const mockServer = createMockLangModelServer();
-		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', 'claude-3-opus', undefined));
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', 'claude-3-opus', TEST_PERMISSION_MODE, TEST_FOLDER_INFO));
 		const stream = new MockChatResponseStream();
 
-		await session.invoke(toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream, CancellationToken.None, 'claude-3-opus');
+		await session.invoke(toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream, CancellationToken.None, 'claude-3-opus', TEST_PERMISSION_MODE);
 
 		expect(stream.output.join('\n')).toContain('Hello from mock!');
 	});
@@ -190,16 +193,16 @@ describe('ClaudeCodeSession', () => {
 		mockService.queryCallCount = 0;
 		mockService.setModelCallCount = 0;
 
-		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', 'claude-3-sonnet', undefined));
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', 'claude-3-sonnet', TEST_PERMISSION_MODE, TEST_FOLDER_INFO));
 
 		// First request with initial model
 		const stream1 = new MockChatResponseStream();
-		await session.invoke(toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream1, CancellationToken.None, 'claude-3-sonnet');
+		await session.invoke(toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream1, CancellationToken.None, 'claude-3-sonnet', TEST_PERMISSION_MODE);
 		expect(mockService.queryCallCount).toBe(1);
 
 		// Second request with different model should call setModel on existing session
 		const stream2 = new MockChatResponseStream();
-		await session.invoke(toPromptBlocks('Hello again'), {} as vscode.ChatParticipantToolToken, stream2, CancellationToken.None, 'claude-3-opus');
+		await session.invoke(toPromptBlocks('Hello again'), {} as vscode.ChatParticipantToolToken, stream2, CancellationToken.None, 'claude-3-opus', TEST_PERMISSION_MODE);
 		expect(mockService.queryCallCount).toBe(1); // Same query reused
 		expect(mockService.setModelCallCount).toBe(1); // setModel was called
 		expect(mockService.lastSetModel).toBe('claude-3-opus');
@@ -211,16 +214,16 @@ describe('ClaudeCodeSession', () => {
 		const mockService = instantiationService.invokeFunction(accessor => accessor.get(IClaudeCodeSdkService)) as MockClaudeCodeSdkService;
 		mockService.queryCallCount = 0;
 
-		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', 'claude-3-sonnet', undefined));
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', 'claude-3-sonnet', TEST_PERMISSION_MODE, TEST_FOLDER_INFO));
 
 		// First request
 		const stream1 = new MockChatResponseStream();
-		await session.invoke(toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream1, CancellationToken.None, 'claude-3-sonnet');
+		await session.invoke(toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream1, CancellationToken.None, 'claude-3-sonnet', TEST_PERMISSION_MODE);
 		expect(mockService.queryCallCount).toBe(1);
 
 		// Second request with same model should reuse session
 		const stream2 = new MockChatResponseStream();
-		await session.invoke(toPromptBlocks('Hello again'), {} as vscode.ChatParticipantToolToken, stream2, CancellationToken.None, 'claude-3-sonnet');
+		await session.invoke(toPromptBlocks('Hello again'), {} as vscode.ChatParticipantToolToken, stream2, CancellationToken.None, 'claude-3-sonnet', TEST_PERMISSION_MODE);
 		expect(mockService.queryCallCount).toBe(1); // Same query reused
 	});
 });

--- a/src/extension/chatSessions/vscode-node/chatSessions.ts
+++ b/src/extension/chatSessions/vscode-node/chatSessions.ts
@@ -18,8 +18,8 @@ import { ClaudeToolPermissionService, IClaudeToolPermissionService } from '../..
 import { ClaudeAgentManager } from '../../agents/claude/node/claudeCodeAgent';
 import { ClaudeCodeModels, IClaudeCodeModels } from '../../agents/claude/node/claudeCodeModels';
 import { ClaudeCodeSdkService, IClaudeCodeSdkService } from '../../agents/claude/node/claudeCodeSdkService';
-import { ClaudeCodeSessionService, IClaudeCodeSessionService } from '../../agents/claude/node/sessionParser/claudeCodeSessionService';
 import { ClaudeSessionStateService, IClaudeSessionStateService } from '../../agents/claude/node/claudeSessionStateService';
+import { ClaudeCodeSessionService, IClaudeCodeSessionService } from '../../agents/claude/node/sessionParser/claudeCodeSessionService';
 import { ClaudeSlashCommandService, IClaudeSlashCommandService } from '../../agents/claude/vscode-node/claudeSlashCommandService';
 import { ChatDelegationSummaryService, IChatDelegationSummaryService } from '../../agents/copilotcli/common/delegationSummaryService';
 import { CopilotCLIAgents, CopilotCLIModels, CopilotCLISDK, ICopilotCLIAgents, ICopilotCLIModels, ICopilotCLISDK } from '../../agents/copilotcli/node/copilotCli';
@@ -42,7 +42,7 @@ import { ClaudeChatSessionItemProvider } from './claudeChatSessionItemProvider';
 import { CopilotCLIChatSessionContentProvider, CopilotCLIChatSessionItemProvider, CopilotCLIChatSessionParticipant, registerCLIChatCommands } from './copilotCLIChatSessionsContribution';
 import { CopilotCLITerminalIntegration, ICopilotCLITerminalIntegration } from './copilotCLITerminalIntegration';
 import { CopilotCloudSessionsProvider } from './copilotCloudSessionsProvider';
-import { FolderRepositoryManager } from './folderRepositoryManagerImpl';
+import { ClaudeFolderRepositoryManager, CopilotCLIFolderRepositoryManager } from './folderRepositoryManagerImpl';
 import { PRContentProvider } from './prContentProvider';
 import { IPullRequestFileChangesService, PullRequestFileChangesService } from './pullRequestFileChangesService';
 
@@ -87,6 +87,9 @@ export class ChatSessionsContrib extends Disposable implements IExtensionContrib
 				[IClaudeToolPermissionService, new SyncDescriptor(ClaudeToolPermissionService)],
 				[IClaudeSessionStateService, new SyncDescriptor(ClaudeSessionStateService)],
 				[IClaudeSlashCommandService, new SyncDescriptor(ClaudeSlashCommandService)],
+				[IChatSessionWorktreeService, new SyncDescriptor(ChatSessionWorktreeService)],
+				[IChatSessionWorkspaceFolderService, new SyncDescriptor(ChatSessionWorkspaceFolderService)],
+				[IFolderRepositoryManager, new SyncDescriptor(ClaudeFolderRepositoryManager)],
 			));
 
 		const sessionItemProvider = this._register(claudeAgentInstaService.createInstance(ClaudeChatSessionItemProvider));
@@ -125,7 +128,7 @@ export class ChatSessionsContrib extends Disposable implements IExtensionContrib
 				[IChatSessionWorktreeService, new SyncDescriptor(ChatSessionWorktreeService)],
 				[IChatSessionWorkspaceFolderService, new SyncDescriptor(ChatSessionWorkspaceFolderService)],
 				[ICopilotCLIMCPHandler, new SyncDescriptor(CopilotCLIMCPHandler)],
-				[IFolderRepositoryManager, new SyncDescriptor(FolderRepositoryManager)],
+				[IFolderRepositoryManager, new SyncDescriptor(CopilotCLIFolderRepositoryManager)],
 			));
 
 		const copilotcliSessionItemProvider = this._register(copilotcliAgentInstaService.createInstance(CopilotCLIChatSessionItemProvider));

--- a/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
+++ b/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
@@ -39,7 +39,7 @@ import { IChatSessionWorkspaceFolderService } from '../../common/chatSessionWork
 import { IChatSessionWorktreeService, type ChatSessionWorktreeProperties } from '../../common/chatSessionWorktreeService';
 import { CopilotCLIChatSessionContentProvider, CopilotCLIChatSessionItemProvider, CopilotCLIChatSessionParticipant } from '../copilotCLIChatSessionsContribution';
 import { CopilotCloudSessionsProvider } from '../copilotCloudSessionsProvider';
-import { FolderRepositoryManager } from '../folderRepositoryManagerImpl';
+import { CopilotCLIFolderRepositoryManager } from '../folderRepositoryManagerImpl';
 
 // Mock terminal integration to avoid importing PowerShell asset (.ps1) which Vite cannot parse during tests
 vi.mock('../copilotCLITerminalIntegration', () => {
@@ -186,7 +186,7 @@ describe('CopilotCLIChatSessionParticipant.handleRequest', () => {
 	let instantiationService: IInstantiationService;
 	let manager: MockCliSdkSessionManager;
 	let mcpHandler: ICopilotCLIMCPHandler;
-	let folderRepositoryManager: FolderRepositoryManager;
+	let folderRepositoryManager: CopilotCLIFolderRepositoryManager;
 	let cliSessionServiceForFolderManager: FakeCopilotCLISessionService;
 	let contentProvider: CopilotCLIChatSessionContentProvider;
 	const cliSessions: TestCopilotCLISession[] = [];
@@ -260,7 +260,7 @@ describe('CopilotCLIChatSessionParticipant.handleRequest', () => {
 				// tracked by vi.fn
 			});
 		}();
-		folderRepositoryManager = new FolderRepositoryManager(
+		folderRepositoryManager = new CopilotCLIFolderRepositoryManager(
 			worktree,
 			workspaceFolderService,
 			cliSessionServiceForFolderManager as unknown as ICopilotCLISessionService,

--- a/src/extension/chatSessions/vscode-node/test/folderRepositoryManager.spec.ts
+++ b/src/extension/chatSessions/vscode-node/test/folderRepositoryManager.spec.ts
@@ -17,7 +17,7 @@ import { MockChatResponseStream } from '../../../test/node/testHelpers';
 import { IChatSessionWorkspaceFolderService } from '../../common/chatSessionWorkspaceFolderService';
 import { ChatSessionWorktreeProperties, IChatSessionWorktreeService } from '../../common/chatSessionWorktreeService';
 import { IFolderRepositoryManager } from '../../common/folderRepositoryManager';
-import { FolderRepositoryManager } from '../folderRepositoryManagerImpl';
+import { CopilotCLIFolderRepositoryManager } from '../folderRepositoryManagerImpl';
 
 /**
  * Fake implementation of IChatSessionWorktreeService for testing.
@@ -225,9 +225,9 @@ export class FakeFolderRepositoryManager extends mock<IFolderRepositoryManager>(
 	}
 }
 
-describe('FolderRepositoryManager', () => {
+describe('CopilotCLIFolderRepositoryManager', () => {
 	const disposables = new DisposableStore();
-	let manager: FolderRepositoryManager;
+	let manager: CopilotCLIFolderRepositoryManager;
 	let worktreeService: FakeChatSessionWorktreeService;
 	let workspaceFolderService: FakeChatSessionWorkspaceFolderService;
 	let sessionService: FakeCopilotCLISessionService;
@@ -248,7 +248,7 @@ describe('FolderRepositoryManager', () => {
 			override error = vi.fn();
 		}();
 
-		manager = new FolderRepositoryManager(
+		manager = new CopilotCLIFolderRepositoryManager(
 			worktreeService,
 			workspaceFolderService,
 			sessionService,
@@ -499,7 +499,7 @@ describe('FolderRepositoryManager', () => {
 			// Use empty workspace to trigger trust check
 			workspaceService = new MockWorkspaceService([]);
 			workspaceService.trustResponse = false;
-			manager = new FolderRepositoryManager(
+			manager = new CopilotCLIFolderRepositoryManager(
 				worktreeService,
 				workspaceFolderService,
 				sessionService,
@@ -678,7 +678,7 @@ describe('FolderRepositoryManager', () => {
 		it('handles empty workspace scenarios', async () => {
 			// Create manager with no workspace folders
 			workspaceService = new MockWorkspaceService([]);
-			manager = new FolderRepositoryManager(
+			manager = new CopilotCLIFolderRepositoryManager(
 				worktreeService,
 				workspaceFolderService,
 				sessionService,


### PR DESCRIPTION
- Introduced folder selection capabilities for Claude chat sessions, allowing users to choose folders in single-root, multi-root, and empty workspace scenarios.
- Implemented `getFolderInfoForSession` to resolve current working directory and additional directories based on workspace state.
- Added folder option handling in `provideChatSessionProviderOptions` to dynamically include folder options based on workspace type.
- Created `ClaudeFolderInfo` interface to encapsulate folder information for session management.
- Updated tests to cover new folder option functionalities, ensuring correct behavior across different workspace configurations.
- Refactored `FolderRepositoryManager` to support Claude-specific folder management while maintaining compatibility with Copilot CLI sessions.