### PR TITLE
Fix incorrect JSX terminology in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ We have developed a TSX-based framework for composing prompts. This section desc
 - If your prompt does asynchronous work e.g. VS Code extension API calls or additional requests to the Copilot API for chunk reranking, you can precompute this state in an optional async `prepare` method. `prepare` is called before `render` and the prepared state will be passed back to your prompt component's sync `render` method.
 
 Please note:
-* Newlines are not preserved in string literals when rendered, and must be explicitly declared with the builtin `<br />` attribute.
+* Newlines are not preserved in string literals when rendered, and must be explicitly declared with the builtin `<br />` element.
 * For now, if two prompt messages _with the same priority_ are up for eviction due to exceeding the token budget, it is not possible for a subtree of the prompt message declared before to evict a subtree of the prompt message declared later.
 
 ## Code structure


### PR DESCRIPTION
## Summary
Fixes incorrect JSX/TSX terminology in the "Developing Prompts" section of CONTRIBUTING.md.

## Problem
Line 183 currently states:
> Newlines are not preserved in string literals when rendered, and must be explicitly declared with the builtin `<br />` **attribute**.

This is technically incorrect. In JSX/TSX, `<br />` is a **self-closing element** (or tag), not an attribute.

## Solution
Changed "attribute" to "element" for technical accuracy.

**Attributes** are properties of elements (e.g., `className="foo"`, `onClick={handler}`)  
**Elements** are the JSX tags themselves (e.g., `<br />`, `<div>`, `<UserMessage>`)

## Changes
- **File:** `CONTRIBUTING.md`
- **Line:** 183
- **Change:** `attribute` → `element`

## Additional Context
The `.github/instructions/prompt-tsx.instructions.md` file already uses correct terminology when describing `<br />` as a line break element, making this change consistent with existing documentation.

## Type of Change
- [x] Documentation fix

---

*This is a minor documentation correction to improve technical accuracy.*