### PR TITLE
Only enable copilotCLI.addFileReference command when the setting is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -2836,6 +2836,7 @@
 			{
 				"command": "github.copilot.chat.copilotCLI.addFileReference",
 				"title": "%github.copilot.command.chat.copilotCLI.addFileReference%",
+				"enablement": "config.github.copilot.chat.cli.integration.enabled",
 				"category": "Copilot CLI"
 			},
 			{
@@ -4563,7 +4564,7 @@
 				{
 					"command": "github.copilot.chat.copilotCLI.addFileReference",
 					"group": "copilot",
-					"when": "!inOutput && resourceScheme != 'vscode-webview' && resourceScheme != 'webview-panel'"
+					"when": "config.github.copilot.chat.cli.integration.enabled && !inOutput && resourceScheme != 'vscode-webview' && resourceScheme != 'webview-panel'"
 				}
 			],
 			"editor/context/chat": [
@@ -5382,7 +5383,7 @@
 				"command": "github.copilot.chat.copilotCLI.addFileReference",
 				"key": "ctrl+shift+.",
 				"mac": "cmd+shift+.",
-				"when": "editorTextFocus"
+				"when": "config.github.copilot.chat.cli.integration.enabled && editorTextFocus"
 			},
 			{
 				"command": "github.copilot.chat.rerunWithCopilotDebug",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/294006

I didn't change the keybinding, we can discuss that as a team later @rebornix @DonJayamanne. But for now this will fix the main issue