### PR TITLE
Copilot CLI: Fix Initializing Connections

### DIFF
--- a/src/extension/agents/copilotcli/vscode-node/inProcHttpServer.ts
+++ b/src/extension/agents/copilotcli/vscode-node/inProcHttpServer.ts
@@ -171,7 +171,15 @@ export class InProcHttpServer {
 	}
 
 	private async _handlePost(mcpOptions: McpProviderOptions, req: express.Request, res: express.Response): Promise<void> {
-		const sessionId = (req.headers['mcp-session-id'] ?? req.headers['x-copilot-session-id']) as string | undefined;
+		const sessionId = req.headers['mcp-session-id'] ?? req.headers['x-copilot-session-id'];
+		if (Array.isArray(sessionId) || !sessionId || typeof sessionId !== 'string') {
+			res.status(400).json({
+				jsonrpc: '2.0',
+				error: { code: -32000, message: 'Bad Request: Session ID must be a single, defined, string value' },
+				id: null,
+			});
+			return;
+		}
 		this._logger.trace(`POST /mcp request, sessionId: ${sessionId ?? '(none)'}`);
 
 		const isInitializeRequest = await isInitializeRequestLazy.value;


### PR DESCRIPTION
Fix session ID mismatch in MCP transport registration. The transport was registered under the client's `x-copilot-session-id`, but the MCP SDK generated a different `mcp-session-id` via `sessionIdGenerator`. Follow-up requests using the SDK-assigned ID couldn't find the transport, causing `"Bad Request: No valid session ID provided"` errors. Fixed by using the client's session ID as the MCP session ID.

Also, added code to not allow multiple clients to connect for the same CLI session ID.
