### PR TITLE
Default large tool results to disk

### DIFF
--- a/package.json
+++ b/package.json
@@ -4249,7 +4249,7 @@
 					},
 					"github.copilot.chat.agent.largeToolResultsToDisk.enabled": {
 						"type": "boolean",
-						"default": false,
+						"default": true,
 						"markdownDescription": "%github.copilot.config.agent.largeToolResultsToDisk.enabled%",
 						"tags": [
 							"advanced",

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -706,7 +706,7 @@ export namespace ConfigKey {
 		 * When enabled, large tool results (above the threshold in bytes) are written to disk
 		 * instead of being included directly in the prompt. This helps manage context window usage.
 		 */
-		export const LargeToolResultsToDiskEnabled = defineSetting<boolean>('chat.agent.largeToolResultsToDisk.enabled', ConfigType.ExperimentBased, false);
+		export const LargeToolResultsToDiskEnabled = defineSetting<boolean>('chat.agent.largeToolResultsToDisk.enabled', ConfigType.ExperimentBased, true);
 		/**
 		 * The size threshold in bytes above which tool results are written to disk.
 		 * Only applies when LargeToolResultsToDiskEnabled is true.


### PR DESCRIPTION
Sets the default for writing large tool results to disk to true.\n\n- Updates the user-facing setting default in package.json\n- Updates the internal default in configurationService ConfigKey.Advanced