### PR TITLE
Remove leftover 'usages' reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -1313,7 +1313,6 @@
 					"listDirectory",
 					"searchResults",
 					"textSearch",
-					"usages",
 					"searchSubagent"
 				]
 			},


### PR DESCRIPTION
fyi @jrieken this made a warning show up