### PR TITLE
Don't call refresh handler directly

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
@@ -133,7 +133,7 @@ export class CopilotCLIChatSessionItemProvider extends Disposable implements vsc
 
 	public notifySessionsChange(): void {
 		if (this.useController) {
-			void this.controller!.refreshHandler();
+			void this.refreshControllerItems();
 		} else {
 			this._onDidChangeChatSessionItems.fire();
 		}


### PR DESCRIPTION
In general extension should not call the controller refresh handler like this directly(it's fine to call the actual implementation that does the refresh). I'm going to update the api so that there is no confusing `refreshHandler` property to avoid this confusion. However before making that change, I need to remove this caller

cc @DonJayamanne 