### PR TITLE
Fix broken file links in chat when model emits bare line anchors or Windows absolute paths

### DIFF
--- a/src/extension/linkify/common/linkifier.ts
+++ b/src/extension/linkify/common/linkifier.ts
@@ -264,7 +264,7 @@ export class Linkifier implements ILinkifier {
 							return matched;
 						}
 
-						return /^\w+:/.test(path) ? matched : text;
+						return /^\w{2,}:/.test(path) ? matched : text;
 					});
 				}
 				return part;

--- a/src/extension/linkify/common/modelFilePathLinkifier.ts
+++ b/src/extension/linkify/common/modelFilePathLinkifier.ts
@@ -224,11 +224,11 @@ export class ModelFilePathLinkifier implements IContributedLinkifier {
 	}
 
 	private parseAnchor(anchor: string | undefined): { readonly range: Range; readonly startLine: string; readonly endLine: string | undefined } | undefined {
-		// Parse supported anchor formats: L123, L123-456, L123-L456
+		// Parse supported anchor formats: L123, L123-456, L123-L456, 123, 123-456
 		if (!anchor) {
 			return undefined;
 		}
-		const match = /^L(\d+)(?:-L?(\d+))?$/.exec(anchor);
+		const match = /^L?(\d+)(?:-L?(\d+))?$/.exec(anchor);
 		if (!match) {
 			return undefined;
 		}

--- a/src/extension/linkify/test/node/linkifier.spec.ts
+++ b/src/extension/linkify/test/node/linkifier.spec.ts
@@ -311,6 +311,19 @@ suite('Stateful Linkifier', () => {
 		]);
 	});
 
+	test(`Should de-linkify Windows absolute paths with drive letters`, async () => {
+		const linkifier = createTestLinkifierService().createLinkifier(emptyContext);
+
+		const parts: string[] = [
+			'[text](c:\\src\\file.ts)',
+		];
+
+		const result = await runLinkifier(linkifier, parts);
+		assertPartsEqual(result, [
+			'text'
+		]);
+	});
+
 	test(`Should not unlinkify text inside of code blocks`, async () => {
 		const linkifier = createTestLinkifierService().createLinkifier(emptyContext);
 

--- a/src/extension/linkify/test/node/modelFilePathLinkifier.spec.ts
+++ b/src/extension/linkify/test/node/modelFilePathLinkifier.spec.ts
@@ -148,6 +148,33 @@ suite('Model File Path Linkifier', () => {
 		expect(anchor.title).toBe('src/file.ts#L10');
 		assertPartsEqual([anchor], [expected]);
 	});
+
+	test('Should linkify bare line number anchors without L prefix', async () => {
+		const service = createTestLinkifierService('src/file.ts');
+		const result = await linkify(service, '[src/file.ts](src/file.ts#10)');
+		const anchor = result.parts[0] as LinkifyLocationAnchor;
+		const expected = new LinkifyLocationAnchor(new Location(workspaceFile('src/file.ts'), new Range(new Position(9, 0), new Position(9, 0))));
+		expect(anchor.title).toBe('src/file.ts#L10');
+		assertPartsEqual([anchor], [expected]);
+	});
+
+	test('Should linkify bare line range anchors without L prefix', async () => {
+		const service = createTestLinkifierService('src/file.ts');
+		const result = await linkify(service, '[src/file.ts](src/file.ts#10-20)');
+		const anchor = result.parts[0] as LinkifyLocationAnchor;
+		const expected = new LinkifyLocationAnchor(new Location(workspaceFile('src/file.ts'), new Range(new Position(9, 0), new Position(19, 0))));
+		expect(anchor.title).toBe('src/file.ts#L10-L20');
+		assertPartsEqual([anchor], [expected]);
+	});
+
+	test('Should linkify descriptive text with bare line range anchor', async () => {
+		const service = createTestLinkifierService('src/file.ts');
+		const result = await linkify(service, '[existing pattern in chatListRenderer](src/file.ts#1287-1290)');
+		const anchor = result.parts[0] as LinkifyLocationAnchor;
+		const expected = new LinkifyLocationAnchor(new Location(workspaceFile('src/file.ts'), new Range(new Position(1286, 0), new Position(1289, 0))));
+		expect(anchor.title).toBe('src/file.ts#L1287-L1290');
+		assertPartsEqual([anchor], [expected]);
+	});
 });
 
 suite('Model File Path Linkifier Remote Workspace', () => {


### PR DESCRIPTION
Fixes microsoft/vscode#271573

When models emit markdown links with bare line number anchors (e.g., #1287-1290 instead of #L1287-L1290) or absolute Windows paths (e.g., c:\src\file.ts), the linkifier failed to convert them to clickable file reference widgets, resulting in "Unable to open file" errors.

Two fixes:

- ModelFilePathLinkifier.parseAnchor: Made the L prefix optional in the anchor regex so bare line numbers like `#1287` and `#1287-1290` are parsed correctly and converted into proper LinkifyLocationAnchor widgets.

- Linkifier un-linkify pass: Changed the URI scheme regex from \w+: to \w{2,}: so single-letter Windows drive prefixes (.) are no longer mistaken for URI schemes. This ensures raw markdown links with Windows paths are stripped instead of passed through to the renderer.