### PR TITLE
fix: cherry-pick fix for cache_control handling in rawMessagesToMessagesAPI

### DIFF
--- a/src/platform/endpoint/node/messagesApi.ts
+++ b/src/platform/endpoint/node/messagesApi.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContentBlockParam, ImageBlockParam, MessageParam, RedactedThinkingBlockParam, TextBlockParam, ThinkingBlockParam } from '@anthropic-ai/sdk/resources';
+import { ContentBlockParam, ImageBlockParam, MessageParam, RedactedThinkingBlockParam, TextBlockParam, ThinkingBlockParam, ToolResultBlockParam } from '@anthropic-ai/sdk/resources';
 import { Raw } from '@vscode/prompt-tsx';
 import { Response } from '../../../platform/networking/common/fetcherService';
 import { AsyncIterableObject } from '../../../util/vs/base/common/async';
@@ -179,7 +179,7 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	};
 }
 
-function rawMessagesToMessagesAPI(messages: readonly Raw.ChatMessage[]): { messages: MessageParam[]; system?: TextBlockParam[] } {
+export function rawMessagesToMessagesAPI(messages: readonly Raw.ChatMessage[]): { messages: MessageParam[]; system?: TextBlockParam[] } {
 	const unmergedMessages: MessageParam[] = [];
 	const systemBlocks: TextBlockParam[] = [];
 
@@ -229,16 +229,28 @@ function rawMessagesToMessagesAPI(messages: readonly Raw.ChatMessage[]): { messa
 			case Raw.ChatRole.Tool: {
 				if (message.toolCallId) {
 					const toolContent = rawContentToAnthropicContent(message.content);
+					// Extract cache_control from content blocks - it belongs on the tool_result block, not inner content
+					let hasCacheControl = false;
+					for (const block of toolContent) {
+						if (contentBlockSupportsCacheControl(block) && block.cache_control) {
+							hasCacheControl = true;
+							delete block.cache_control;
+						}
+					}
 					const validContent = toolContent.filter((c): c is TextBlockParam | ImageBlockParam =>
-						c.type === 'text' || c.type === 'image'
+						(c.type === 'text' || c.type === 'image') && !(c.type === 'text' && c.text.trim() === '')
 					);
+					const toolResultBlock: ToolResultBlockParam = {
+						type: 'tool_result',
+						tool_use_id: message.toolCallId,
+						content: validContent.length > 0 ? validContent : undefined,
+					};
+					if (hasCacheControl) {
+						toolResultBlock.cache_control = { type: 'ephemeral' };
+					}
 					unmergedMessages.push({
 						role: 'user',
-						content: [{
-							type: 'tool_result',
-							tool_use_id: message.toolCallId,
-							content: validContent.length > 0 ? validContent : undefined,
-						}],
+						content: [toolResultBlock],
 					});
 				}
 				break;

--- a/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Raw } from '@vscode/prompt-tsx';
+import { expect, suite, test } from 'vitest';
+import { rawMessagesToMessagesAPI } from '../../node/messagesApi';
+
+suite('rawMessagesToMessagesAPI', function () {
+
+	test('places cache_control on tool_result block, not inside content', function () {
+		const messages: Raw.ChatMessage[] = [
+			{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Read my file' }],
+			},
+			{
+				role: Raw.ChatRole.Assistant,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'I will read the file.' }],
+				toolCalls: [{
+					id: 'toolu_test123',
+					type: 'function',
+					function: { name: 'read_file', arguments: '{"path":"/tmp/test.txt"}' },
+				}],
+			},
+			{
+				role: Raw.ChatRole.Tool,
+				toolCallId: 'toolu_test123',
+				content: [
+					{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello world' },
+					{ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint, cacheType: 'ephemeral' },
+				],
+			},
+		];
+
+		const result = rawMessagesToMessagesAPI(messages);
+
+		// The user text and tool_result get merged into one user message
+		// Find the user message that contains the tool_result
+		const userMessages = result.messages.filter(m => m.role === 'user');
+		expect(userMessages.length).toBeGreaterThan(0);
+
+		let toolResult: any;
+		for (const msg of userMessages) {
+			const content = msg.content;
+			if (Array.isArray(content)) {
+				toolResult = (content as any[]).find((c: any) => c.type === 'tool_result');
+				if (toolResult) {
+					break;
+				}
+			}
+		}
+		expect(toolResult).toBeDefined();
+
+		// cache_control should be on the tool_result block itself
+		expect(toolResult.cache_control).toEqual({ type: 'ephemeral' });
+
+		// cache_control should NOT be on inner content blocks
+		for (const inner of toolResult.content ?? []) {
+			expect(inner.cache_control).toBeUndefined();
+		}
+	});
+
+	test('tool_result without cache_control has no cache_control property', function () {
+		const messages: Raw.ChatMessage[] = [
+			{
+				role: Raw.ChatRole.Tool,
+				toolCallId: 'toolu_no_cache',
+				content: [
+					{ type: Raw.ChatCompletionContentPartKind.Text, text: 'result text' },
+				],
+			},
+		];
+
+		const result = rawMessagesToMessagesAPI(messages);
+
+		const userMessage = result.messages[0];
+		const content = userMessage.content as any[];
+		const toolResult = content.find((c: any) => c.type === 'tool_result');
+		expect(toolResult).toBeDefined();
+		expect(toolResult.cache_control).toBeUndefined();
+	});
+
+	test('cache_control-only tool content does not produce empty inner content', function () {
+		const messages: Raw.ChatMessage[] = [
+			{
+				role: Raw.ChatRole.Tool,
+				toolCallId: 'toolu_cache_only',
+				content: [
+					{ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint, cacheType: 'ephemeral' },
+				],
+			},
+		];
+
+		const result = rawMessagesToMessagesAPI(messages);
+
+		const userMessage = result.messages[0];
+		const content = userMessage.content as any[];
+		const toolResult = content.find((c: any) => c.type === 'tool_result');
+		expect(toolResult).toBeDefined();
+		expect(toolResult.cache_control).toEqual({ type: 'ephemeral' });
+		// The dummy whitespace-only text block should be filtered out
+		expect(toolResult.content).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Cherry-pick of #3861 to release/0.37.

This is an issue affects a subset of users on messagesAPI hitting aws provider. 
Fix checked into main. 

Todo: Check telemetry in insiders to ensure fix mitigates issue.

Fixes: https://github.com/microsoft/vscode/issues/293887