### PR TITLE
fix: BYOK models not appearing in chat model picker

### DIFF
--- a/src/extension/byok/common/byokProvider.ts
+++ b/src/extension/byok/common/byokProvider.ts
@@ -167,6 +167,7 @@ export function byokKnownModelToAPIInfo(providerName: string, id: string, capabi
 		family: id,
 		tooltip: `${capabilities.name} is contributed via the ${providerName} provider.`,
 		multiplierNumeric: 0,
+		isUserSelectable: true,
 		capabilities: {
 			toolCalling: capabilities.toolCalling,
 			imageInput: capabilities.vision


### PR DESCRIPTION
### Summary
Ollama models are not visible in the chat model pickers with Agent mode. This is because 
`byokKnownModelToAPIInfo()` does not set `isUserSelectable: true`
on the returned model metadata. VS Code's model picker filters on this field,
so all BYOK models get filtered out.

The similar function `chatModelInfoToProviderMetadata()` already sets
`isUserSelectable: true` — this is a one-line consistency fix to
`byokKnownModelToAPIInfo().`

### Steps to reproduce

1. Configure an Ollama provider (or any BYOK provider)
2. Open Copilot Chat and click the model picker dropdown
3. No BYOK models appear

### Fix
Add `isUserSelectable: true` to the model metadata returned by
`byokKnownModelToAPIInfo()` in `src/extension/byok/common/byokProvider.ts`.