### PR TITLE
fix: align promptCategorization.requestId with panel.request for telemetry joins

### DIFF
--- a/src/extension/conversation/vscode-node/test/interactiveSessionProvider.telemetry.test.ts
+++ b/src/extension/conversation/vscode-node/test/interactiveSessionProvider.telemetry.test.ts
@@ -35,7 +35,8 @@ suite('Conversation telemetry tests - Integration tests', function () {
 				stream,
 				token,
 				{ agentName: '', agentId: '' },
-				() => false);
+				() => false,
+				undefined);
 			await session.getResult(); // and throw away the result
 		});
 		assert.ok(allEvents(messages));

--- a/src/extension/inlineChat/vscode-node/inlineChatCommands.ts
+++ b/src/extension/inlineChat/vscode-node/inlineChatCommands.ts
@@ -382,7 +382,7 @@ function fetchSuggestion(accessor: ServicesAccessor, thread: vscode.CommentThrea
 			agentId: getChatParticipantIdFromName(editorAgentName),
 			agentName: editorAgentName,
 			intentId: request.command,
-		}, () => false);
+		}, () => false, undefined);
 		const result = await requestHandler.getResult();
 		if (result.errorDetails) {
 			throw new Error(result.errorDetails.message);

--- a/src/extension/intents/node/test/agentSummarizeCommand.spec.ts
+++ b/src/extension/intents/node/test/agentSummarizeCommand.spec.ts
@@ -79,6 +79,7 @@ describe('AgentIntent /summarize command', () => {
 			undefined,
 			true,
 			request,
+			undefined,
 		);
 
 		const result = await intent.handleRequest(

--- a/src/extension/prompt/node/chatParticipantRequestHandler.ts
+++ b/src/extension/prompt/node/chatParticipantRequestHandler.ts
@@ -73,6 +73,7 @@ export class ChatParticipantRequestHandler {
 		private readonly token: CancellationToken,
 		private readonly chatAgentArgs: IChatAgentArgs,
 		private readonly yieldRequested: () => boolean,
+		telemetryMessageId: string | undefined,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IEndpointProvider private readonly _endpointProvider: IEndpointProvider,
 		@ICommandService private readonly _commandService: ICommandService,
@@ -117,7 +118,8 @@ export class ChatParticipantRequestHandler {
 			actualSessionId,
 			this.documentContext,
 			turns.length === 0,
-			this.request
+			this.request,
+			telemetryMessageId
 		);
 
 		const latestTurn = Turn.fromRequest(

--- a/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
+++ b/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
@@ -161,7 +161,7 @@ suite('defaultIntentRequestHandler', () => {
 			CancellationToken.None,
 			undefined,
 			ChatLocation.Panel,
-			instaService.createInstance(ChatTelemetryBuilder, Date.now(), sessionId, undefined, turns.length > 1, request),
+			instaService.createInstance(ChatTelemetryBuilder, Date.now(), sessionId, undefined, turns.length > 1, request, undefined),
 			{ maxToolCallIterations },
 			undefined,
 		);

--- a/src/extension/test/vscode-node/sanity.sanity-test.ts
+++ b/src/extension/test/vscode-node/sanity.sanity-test.ts
@@ -77,7 +77,7 @@ suite('Copilot Chat Sanity Test', function () {
 			try {
 				conversationFeature.activated = true;
 				let stream = new SpyChatResponseStream();
-				let interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], new TestChatRequest('Write me a for loop in javascript'), stream, fakeToken, { agentName: '', agentId: '', intentId: '' }, () => false);
+				let interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], new TestChatRequest('Write me a for loop in javascript'), stream, fakeToken, { agentName: '', agentId: '', intentId: '' }, () => false, undefined);
 
 				await interactiveSession.getResult();
 
@@ -85,7 +85,7 @@ suite('Copilot Chat Sanity Test', function () {
 				const oldText = stream.currentProgress;
 
 				stream = new SpyChatResponseStream();
-				interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], new TestChatRequest('Can you make it in typescript instead'), stream, fakeToken, { agentName: '', agentId: '', intentId: '' }, () => false);
+				interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], new TestChatRequest('Can you make it in typescript instead'), stream, fakeToken, { agentName: '', agentId: '', intentId: '' }, () => false, undefined);
 				const result2 = await interactiveSession.getResult();
 
 				assert.ok(stream.currentProgress, 'Expected progress after second request');
@@ -117,7 +117,7 @@ suite('Copilot Chat Sanity Test', function () {
 				let stream = new SpyChatResponseStream();
 				const testRequest = new TestChatRequest(`You must use the get_errors tool to check the window for errors. It may fail, that's ok, just testing, don't retry.`);
 				testRequest.tools.set(ContributedToolName.GetErrors, true);
-				let interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], testRequest, stream, fakeToken, { agentName: '', agentId: '', intentId: Intent.Agent }, () => false);
+				let interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], testRequest, stream, fakeToken, { agentName: '', agentId: '', intentId: Intent.Agent }, () => false, undefined);
 
 				const onWillInvokeTool = Event.toPromise(toolsService.onWillInvokeTool);
 				const getResultPromise = interactiveSession.getResult();
@@ -128,7 +128,7 @@ suite('Copilot Chat Sanity Test', function () {
 				const oldText = stream.currentProgress;
 
 				stream = new SpyChatResponseStream();
-				interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], new TestChatRequest('And what is 1+1'), stream, fakeToken, { agentName: '', agentId: '', intentId: Intent.Agent }, () => false);
+				interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], new TestChatRequest('And what is 1+1'), stream, fakeToken, { agentName: '', agentId: '', intentId: Intent.Agent }, () => false, undefined);
 				const result2 = await interactiveSession.getResult();
 
 				assert.ok(stream.currentProgress, 'Expected progress after second request');
@@ -152,7 +152,7 @@ suite('Copilot Chat Sanity Test', function () {
 			try {
 				conversationFeature.activated = true;
 				const progressReport = new SpyChatResponseStream();
-				const interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], new TestChatRequest('What is a fibonacci sequence?'), progressReport, fakeToken, { agentName: '', agentId: '', intentId: 'explain' }, () => false);
+				const interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], new TestChatRequest('What is a fibonacci sequence?'), progressReport, fakeToken, { agentName: '', agentId: '', intentId: 'explain' }, () => false, undefined);
 
 				// Ask a `/explain` question
 				await interactiveSession.getResult();

--- a/test/e2e/scenarioTest.ts
+++ b/test/e2e/scenarioTest.ts
@@ -93,6 +93,7 @@ export function generateScenarioTestRunner(scenario: Scenario, evaluator: Scenar
 								parsedQuery.participantName,
 					},
 					() => false,
+					undefined,
 				);
 				const result = await interactiveSession.getResult();
 				assert.ok(!result.errorDetails, result.errorDetails?.message);

--- a/test/simulation/inlineChatSimulator.ts
+++ b/test/simulation/inlineChatSimulator.ts
@@ -490,7 +490,7 @@ export async function simulateEditingScenario(
 				intentId: request.command
 			};
 
-			const requestHandler = instaService.createInstance(ChatParticipantRequestHandler, history, request, stream, CancellationToken.None, agentArgs, () => false);
+			const requestHandler = instaService.createInstance(ChatParticipantRequestHandler, history, request, stream, CancellationToken.None, agentArgs, () => false, undefined);
 			const result = await requestHandler.getResult();
 			history.push(new ChatRequestTurn(request.prompt, request.command, [...request.references], '', []));
 			history.push(new ChatResponseTurn([new ChatResponseMarkdownPart(markdownChunks.join(''))], result, ''));


### PR DESCRIPTION
## Problem

`promptCategorization` and `panel.request` telemetry events could not be joined because they used different `requestId` values:

- `promptCategorization.requestId` → VS Code's `ChatRequest.id` (`request_<uuid>`)
- `panel.request.requestId` → extension-generated UUID from `createTelemetryWithId()`

## Solution

Generate a single `telemetryMessageId = generateUuid()` on the **first turn** in `getChatParticipantHandler` and thread it through to both consumers:

1. `categorizePrompt(request, context, telemetryMessageId)` — `promptCategorization` now emits this as `requestId`
2. `ChatParticipantRequestHandler` → `ChatTelemetryBuilder` — seeds `baseUserTelemetry` with the same ID, which flows through to `panel.request.requestId`

The old VS Code request ID is preserved as `vscodeRequestId` on `promptCategorization` for VS Code-side joins.

On turn 2+, `telemetryMessageId` is `undefined` (no categorization event is emitted), so `ChatTelemetryBuilder` falls back to its original `createTelemetryWithId()` behavior — unchanged from before.

## Changes

| File | Change |
|------|--------|
| `chatParticipants.ts` | Generate shared UUID on first turn; guard `categorizePrompt` call |
| `promptCategorizer.ts` | Accept `telemetryMessageId: string`; emit as `requestId`; add `vscodeRequestId` field + GDPR annotation |
| `chatParticipantTelemetry.ts` | `ChatTelemetryBuilder` accepts optional `telemetryMessageId`; seeds `baseUserTelemetry` with it when provided |
| `chatParticipantRequestHandler.ts` | Threads `telemetryMessageId` through to `ChatTelemetryBuilder` |
| 7 test/call-site files | Add `undefined` for the new constructor parameter |