### PR TITLE
Fix delegate prompt condition in chat session participant

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
@@ -874,7 +874,7 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 				chatRequestId: request.id,
 				hasChatSessionItem: String(!!chatSessionContext?.chatSessionItem),
 				isUntitled: String(chatSessionContext?.isUntitled),
-				hasDelegatePrompt: String(request.prompt.startsWith('/delegate'))
+				hasDelegatePrompt: String(request.command === 'delegate')
 			});
 
 			const initialOptions = chatSessionContext?.initialSessionOptions;


### PR DESCRIPTION
Update the condition for determining the delegate prompt in the chat session participant to check for the command instead of the prompt string.