### PR TITLE
dont allow image urls in messages api

### DIFF
--- a/src/extension/prompts/node/panel/image.tsx
+++ b/src/extension/prompts/node/panel/image.tsx
@@ -93,7 +93,7 @@ export class Image extends PromptElement<ImageProps, unknown> {
 			let imageSource = Buffer.from(variable).toString('base64');
 			let imageMimeType: string | undefined = undefined;
 
-			const isChatRequest = typeof this.promptEndpoint.urlOrRequestMetadata !== 'string' && (this.promptEndpoint.urlOrRequestMetadata.type === RequestType.ChatCompletions || this.promptEndpoint.urlOrRequestMetadata.type === RequestType.ChatResponses);
+			const isChatRequest = typeof this.promptEndpoint.urlOrRequestMetadata !== 'string' && (this.promptEndpoint.urlOrRequestMetadata.type === RequestType.ChatCompletions || this.promptEndpoint.urlOrRequestMetadata.type === RequestType.ChatResponses || this.promptEndpoint.urlOrRequestMetadata.type === RequestType.ChatMessages);
 			const enabled = this.configurationService.getExperimentBasedConfig(ConfigKey.EnableChatImageUpload, this.experimentationService);
 			if (isChatRequest && enabled && modelCanUseImageURL(this.promptEndpoint)) {
 				try {

--- a/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -179,7 +179,7 @@ export function modelCanUseMcpResultImageURL(model: LanguageModelChat | IChatEnd
  * The model can accept image urls as the `image_url` parameter in requests.
  */
 export function modelCanUseImageURL(model: LanguageModelChat | IChatEndpoint): boolean {
-	return true;
+	return !('apiType' in model && model.apiType === 'messages' && isAnthropicFamily(model));
 }
 
 /**


### PR DESCRIPTION
there is an issue where messages API does not suppoort image url attachments for some reason. 

pending disucssion with capi/anthropic. DO NOT MERGE YETTTTT

<img width="400" height="400" alt="554-Darumaka" src="https://github.com/user-attachments/assets/cfb694f1-55a9-41bb-a541-cf3c51bfe657" />
