### PR TITLE
Don't break when parsing partial JSON is invalid

### DIFF
--- a/src/extension/prompt/node/pseudoStartStopConversationCallback.ts
+++ b/src/extension/prompt/node/pseudoStartStopConversationCallback.ts
@@ -237,6 +237,7 @@ function tryParsePartialToolInput(raw: string | undefined): unknown {
 	}
 
 	try {
+		// Certain patterns, especially partially-generated unicode escape sequences, cause this to throw.
 		return parsePartialJson(raw);
 	} catch {
 		return undefined;


### PR DESCRIPTION
I don't think this is supposed to throw but I guess it does sometimes 

Fix microsoft/vscode#297160