### PR TITLE
nes: recent files: fix: enforce token budget for proportional and aroundEditRange clipping strategies

### DIFF
--- a/src/extension/xtab/common/recentFilesForPrompt.md
+++ b/src/extension/xtab/common/recentFilesForPrompt.md
@@ -1,0 +1,206 @@
+# Recently Viewed Files — Clipping Strategies Specification
+
+This document specifies the three clipping strategies used to select and truncate
+recently viewed file content for inclusion in the NES/xtab prompt.
+
+## Shared Concepts
+
+### Inputs
+
+| Input | Description |
+|---|---|
+| `recentlyViewedCodeSnippets` | Files ordered **most-recent-first**. Each entry carries content, optional focal ranges (character-offset ranges of edit locations), and an `editEntryCount` weight. |
+| `totalBudget` | Maximum tokens for the entire recently-viewed-files section (`opts.recentlyViewedDocuments.maxTokens`). |
+| `pageSize` | Number of lines per page for paged clipping. |
+| `computeTokens` | Token counting function. |
+
+### Paged Clipping
+
+All strategies use page-based clipping. File content is divided into pages of
+`pageSize` lines. Token costs are computed per page. Pages are included or
+excluded as whole units — no partial pages.
+
+### Output Ordering
+
+All strategies reverse the collected snippets before returning, so the final
+prompt order is **least-recent-first** (oldest file at top, most recent at
+bottom).
+
+### Budget Enforcement in `clipAroundFocalRanges`
+
+The `AroundEditRange` and `Proportional` strategies share `clipAroundFocalRanges`
+for files with focal ranges. This function enforces a strict budget: if the focal
+pages alone exceed the remaining token budget, the file is **skipped** entirely
+(returns `undefined`). This prevents any single file from overshooting the
+budget. The caller interprets `undefined` as "nothing fit" and either breaks the
+loop (greedy strategies) or carries the budget forward (proportional strategy).
+
+### Focal Range Span Capping
+
+When clipping around focal ranges, `selectFocalRangesWithinSpanCap` limits the
+span to `pageSize × 3` lines. Focal ranges are ordered most-recent-first;
+ranges are greedily included until adding the next one would exceed the span cap.
+This prevents wide-scatter edits (e.g., line 10 + line 90) from causing the
+initial focal span to cover the entire document.
+
+---
+
+## Strategy: TopToBottom
+
+### History Collection
+
+Uses `collectRecentDocuments`: collects the **last `nDocuments` unique
+documents**, keeping only the **most recent entry** per document. Focal ranges
+are **not** extracted from edit entries — all entries are treated as full
+documents.
+
+### Algorithm
+
+Greedy, most-recent-first:
+
+1. Process files in most-recent-first order.
+2. Each file is clipped **from the top** of the file, taking pages sequentially
+   until the budget is exhausted (`clipFullDocument`).
+3. If a page doesn't fit, stop clipping that file. Move to the next.
+4. When the budget reaches 0, stop processing files.
+
+### Behavior
+
+- No focal ranges are used — the clip always starts at line 0.
+- The most recently touched file gets the largest share of budget (greedy).
+- Files beyond the budget are silently dropped.
+- Visible-range entries also use top-to-bottom clipping (no centering on the
+  visible range).
+
+---
+
+## Strategy: AroundEditRange
+
+### History Collection
+
+Uses `collectRecentDocuments`: same as `TopToBottom` — **one entry per
+document**, most recent only.
+
+For edit entries, focal ranges are extracted from `edit.getNewRanges()` (the
+character-offset ranges of the replacement text in the post-edit document). For
+visible-range entries, the `visibleRanges` are used as focal ranges.
+
+### Algorithm
+
+Greedy, most-recent-first:
+
+1. Process files in most-recent-first order.
+2. For files **with** focal ranges: call `clipAroundFocalRanges`.
+   - Focal ranges are span-capped to `pageSize × 3` lines.
+   - The focal range is mapped to page indices, and those pages are always
+     included (the "focal pages").
+   - If the focal pages exceed the remaining budget, the file is **skipped**.
+   - Otherwise, the remaining budget is split evenly between expanding upward
+     and downward from the focal pages.
+   - Expansion continues page by page in each direction until the half-budget
+     is exhausted.
+3. For files **without** focal ranges: fall through to `clipFullDocument`
+   (top-to-bottom clipping).
+4. When the budget reaches 0 or a file can't fit, stop processing.
+
+### Behavior
+
+- The clip is centered on the edit/visible location rather than the top of file.
+- Budget is consumed greedily — the most recent file gets the most context.
+- Only one entry per document is used, so if a file was edited multiple times,
+  only the most recent edit location determines the clip center.
+
+---
+
+## Strategy: Proportional
+
+### History Collection
+
+Uses `collectRecentDocumentsGrouped`: collects the last `nDocuments` unique
+documents, keeping **all entries** per document (not just the latest). This
+allows `historyEntriesToCodeSnippet` to merge focal ranges from multiple edits
+in the same file, giving the model visibility into all recent edit locations
+within each document.
+
+For older edit entries, focal ranges are transformed forward through the chain
+of subsequent edits so they remain valid in the most recent content.
+
+### Algorithm
+
+Two-pass:
+
+#### Pass 1 — Compute Minimum Focal Costs & Select Files
+
+1. For each file, compute the **focal page cost** via `computeFocalPageCost`:
+   the token cost of the pages containing the file's focal ranges (after
+   span-capping). Files without focal ranges have a focal cost of 0.
+
+2. Sum all focal costs. If the sum exceeds `totalBudget`, **drop files from the
+   end** of the list (oldest first) until the sum fits.
+
+3. If no files can be included, return empty.
+
+#### Pass 2 — Distribute Expansion Budget & Clip
+
+1. Compute `expansionBudget = totalBudget − sumFocalCosts`.
+
+2. Compute per-file **weights** from `editEntryCount` (default 1).
+
+3. Each included file gets an **expansion share**:
+   `floor(expansionBudget × (weight / totalWeight))`.
+
+4. Process files most-recent-first. Each file's effective budget is:
+   `focalCost + expansionShare + unspentBudget` (carry-forward from previous).
+
+5. For files **with** focal ranges: call `clipAroundFocalRanges` with the
+   effective budget. The focal pages are guaranteed to fit (by construction
+   from pass 1).
+
+6. For files **without** focal ranges: call `clipFullDocument`.
+
+7. Any unspent budget carries forward to the next file.
+
+### Invariants
+
+- **Budget guarantee**: The sum of raw code tokens across all included files
+  never exceeds `totalBudget`. (Formatting overhead — tags, file path headers —
+  is not counted against the budget, matching all strategies.)
+
+- **Focal page guarantee**: Every included file's focal pages are present in the
+  output. A file is only included if its focal cost fits within the remaining
+  budget after accounting for all other included files.
+
+- **Recency priority**: When files must be dropped, the oldest (last in the
+  most-recent-first input) are dropped first.
+
+- **Proportional fairness**: Expansion budget beyond focal pages is distributed
+  proportionally to edit-entry count, so files with more edits get more
+  surrounding context.
+
+- **Carry-forward**: If a file uses less than its allocation (e.g., the file is
+  small), the unspent tokens flow to the next file.
+
+---
+
+## Comparison
+
+| Property | TopToBottom | AroundEditRange | Proportional |
+|---|---|---|---|
+| Budget allocation | Greedy, most-recent-first | Greedy, most-recent-first | Two-pass proportional |
+| Clip center | Top of file | Edit/visible ranges | Edit ranges |
+| File dropping | Implicit (budget exhausted) | Implicit (focal cost exceeds remaining budget) | Explicit (oldest first) |
+| Multi-edit per file | Single entry per file | Single entry per file | All entries merged |
+| Budget overrun risk | None | None | None |
+| History collection | `collectRecentDocuments` | `collectRecentDocuments` | `collectRecentDocumentsGrouped` |
+
+## Focal Page Cost Computation
+
+The focal page cost for a file is computed by `computeFocalPageCost`:
+
+1. Apply `selectFocalRangesWithinSpanCap` to cap the focal range span to
+   `pageSize × 3` lines (prioritizing the most recent focal ranges).
+2. Convert the character-offset range to line numbers via the content's
+   transformer.
+3. Map to page indices: `firstPageIdx = floor((startLine − 1) / pageSize)`,
+   `lastPageIdxIncl = floor((endLine − 1) / pageSize)`.
+4. Sum the token cost of all pages from `firstPageIdx` to `lastPageIdxIncl`.

--- a/src/extension/xtab/common/recentFilesForPrompt.ts
+++ b/src/extension/xtab/common/recentFilesForPrompt.ts
@@ -355,6 +355,48 @@ function clipFullDocument(
 }
 
 /**
+ * Compute the token cost of the focal pages for a file — the minimum tokens
+ * needed to include just the pages that contain the focal ranges.
+ *
+ * Returns `undefined` when there are no usable focal ranges.
+ */
+export function computeFocalPageCost(
+	content: StringText,
+	focalRanges: readonly OffsetRange[],
+	pageSize: number,
+	computeTokens: (s: string) => number,
+): number | undefined {
+	const contentTransform = content.getTransformer();
+	const maxFocalSpanLines = pageSize * 3;
+	const capped = selectFocalRangesWithinSpanCap(
+		focalRanges,
+		offset => contentTransform.getPosition(offset).lineNumber,
+		maxFocalSpanLines,
+	);
+
+	if (capped.length === 0) {
+		return undefined;
+	}
+
+	const startOffset = Math.min(...capped.map(r => r.start));
+	const endOffset = Math.max(...capped.map(r => r.endExclusive - 1));
+	const startLine = contentTransform.getPosition(startOffset).lineNumber;
+	const endLine = contentTransform.getPosition(endOffset).lineNumber;
+
+	const lines = content.getLines();
+	const firstPageIdx = Math.floor((startLine - 1) / pageSize);
+	const lastPageIdxIncl = Math.floor((endLine - 1) / pageSize);
+
+	let cost = 0;
+	for (let p = firstPageIdx; p <= lastPageIdxIncl; p++) {
+		const start = p * pageSize;
+		const end = Math.min(start + pageSize, lines.length);
+		cost += countTokensForLines(lines.slice(start, end), computeTokens);
+	}
+	return cost;
+}
+
+/**
  * Clip a file around its focal ranges (visible ranges or edit locations)
  * by expanding pages outward until budget is exhausted.
  *
@@ -410,13 +452,17 @@ function clipAroundFocalRanges(
 		return undefined; // nothing fit — signal caller to stop
 	}
 
+	// If the focal pages alone exceed the budget (negative budgetLeft from
+	// expandRangeToPageRange), skip this file rather than silently overshooting.
+	if (budgetLeft < 0) {
+		return undefined;
+	}
+
 	const startLineOffset = firstPageIdx * pageSize;
 	const linesToKeep = document.content.getLines().slice(startLineOffset, (lastPageIdxIncl + 1) * pageSize);
 	result.docsInPrompt.add(document.id);
 	result.snippets.push(formatCodeSnippet(document.id, linesToKeep, { truncated: linesToKeep.length < totalLineCount, includeLineNumbers, startLineOffset }));
-	// Clamp to 0 so that over-budget focal pages don't cascade
-	// negative budget into subsequent files.
-	return Math.max(budgetLeft, 0);
+	return budgetLeft;
 }
 
 /**
@@ -489,8 +535,12 @@ function buildCodeSnippetsGreedy(
 }
 
 /**
- * Proportional budget allocation: distribute tokens across files based on edit location count,
- * then clip each file centered on its focal ranges.
+ * Two-pass proportional budget allocation:
+ * 1. Compute the minimum focal page cost for each file and determine which files
+ *    can be included within the total budget. When files must be dropped, the
+ *    oldest (last in the most-recent-first input order) are dropped first.
+ * 2. Distribute the remaining budget proportionally (by edit-entry-count weight)
+ *    across included files for page expansion around their focal ranges.
  */
 function buildCodeSnippetsWithProportionalBudget(
 	recentlyViewedCodeSnippets: RecentCodeSnippet[],
@@ -511,27 +561,42 @@ function buildCodeSnippetsWithProportionalBudget(
 		return { snippets: [], docsInPrompt: new Set() };
 	}
 
-	// Compute weights per file based on edit entry count
-	const weights = recentlyViewedCodeSnippets.map(f => f.editEntryCount ?? 1);
+	// --- Pass 1: compute minimum focal costs ---
+	const focalCosts = recentlyViewedCodeSnippets.map(file =>
+		file.focalRanges !== undefined && file.focalRanges.length > 0
+			? computeFocalPageCost(file.content, file.focalRanges, pageSize, computeTokens) ?? 0
+			: 0
+	);
+
+	// Determine which files to include. Input is ordered most-recent-first,
+	// so we drop from the end (oldest) when focal minimums exceed the budget.
+	let includedCount = recentlyViewedCodeSnippets.length;
+	let sumFocalCosts = focalCosts.reduce((a, b) => a + b, 0);
+	while (includedCount > 0 && sumFocalCosts > totalBudget) {
+		includedCount--;
+		sumFocalCosts -= focalCosts[includedCount];
+	}
+
+	if (includedCount === 0) {
+		return { snippets: [], docsInPrompt: new Set() };
+	}
+
+	// --- Pass 2: distribute expansion budget proportionally ---
+	const expansionBudget = totalBudget - sumFocalCosts;
+
+	const weights = recentlyViewedCodeSnippets.slice(0, includedCount).map(f => f.editEntryCount ?? 1);
 	const totalWeight = weights.reduce((sum, w) => sum + w, 0);
 
-	// Per-file minimum: enough for at least 1 page
-	const minPerFile = Math.floor(totalBudget / (recentlyViewedCodeSnippets.length * 4));
-	// Per-file maximum: no more than 60% of total budget
-	const maxPerFile = Math.floor(totalBudget * 0.6);
-
-	// Pre-compute per-file budgets
-	const fileBudgets = weights.map(w => {
-		const raw = Math.floor(totalBudget * (w / totalWeight));
-		return Math.max(minPerFile, Math.min(maxPerFile, raw));
-	});
+	// Per-file expansion shares, proportional to edit-entry weight
+	const expansionShares = weights.map(w => Math.floor(expansionBudget * (w / totalWeight)));
 
 	let unspentBudget = 0;
 
-	for (let i = 0; i < recentlyViewedCodeSnippets.length; i++) {
+	for (let i = 0; i < includedCount; i++) {
 		const file = recentlyViewedCodeSnippets[i];
 		const lines = file.content.getLines();
-		const effectiveBudget = fileBudgets[i] + unspentBudget;
+		// Each file's budget = guaranteed focal cost + proportional expansion share + carry-forward
+		const effectiveBudget = focalCosts[i] + expansionShares[i] + unspentBudget;
 
 		if (file.focalRanges !== undefined && file.focalRanges.length > 0) {
 			const budgetLeft = clipAroundFocalRanges(

--- a/src/extension/xtab/test/common/recentFilesForPrompt.snapshots.spec.ts
+++ b/src/extension/xtab/test/common/recentFilesForPrompt.snapshots.spec.ts
@@ -1,0 +1,593 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, suite, test } from 'vitest';
+import { DocumentId } from '../../../../platform/inlineEdits/common/dataTypes/documentId';
+import { DEFAULT_OPTIONS, PromptOptions, RecentFileClippingStrategy } from '../../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
+import { OffsetRange } from '../../../../util/vs/editor/common/core/ranges/offsetRange';
+import { StringText } from '../../../../util/vs/editor/common/core/text/abstractText';
+import { buildCodeSnippetsUsingPagedClipping } from '../../common/recentFilesForPrompt';
+
+// --- Helpers ---
+
+function computeTokens(s: string) {
+	return Math.ceil(s.length / 4);
+}
+
+type FileEntry = {
+	id: DocumentId;
+	content: StringText;
+	focalRanges?: readonly OffsetRange[];
+	editEntryCount?: number;
+};
+
+function buildSnippets(
+	files: FileEntry[],
+	opts: PromptOptions,
+): { snippets: string[]; docsInPrompt: Set<DocumentId> } {
+	return buildCodeSnippetsUsingPagedClipping(files, computeTokens, opts);
+}
+
+function makeOpts(overrides: {
+	maxTokens: number;
+	pageSize: number;
+	clippingStrategy: RecentFileClippingStrategy;
+}): PromptOptions {
+	return {
+		...DEFAULT_OPTIONS,
+		recentlyViewedDocuments: {
+			...DEFAULT_OPTIONS.recentlyViewedDocuments,
+			maxTokens: overrides.maxTokens,
+			clippingStrategy: overrides.clippingStrategy,
+		},
+		pagedClipping: {
+			pageSize: overrides.pageSize,
+		},
+	};
+}
+
+/** Compute byte offset of line `lineIdx` (0-based) in a StringText. */
+function lineOffset(content: StringText, lineIdx: number): number {
+	const lines = content.getLines();
+	let offset = 0;
+	for (let i = 0; i < lineIdx; i++) {
+		offset += lines[i].length + 1;
+	}
+	return offset;
+}
+
+function lineRange(content: StringText, lineIdx: number): OffsetRange {
+	const start = lineOffset(content, lineIdx);
+	return new OffsetRange(start, start + content.getLines()[lineIdx].length);
+}
+
+// --- Realistic file content ---
+
+// A TypeScript service class (37 lines, ~273 tokens total across 4 pages of 10)
+const tsServiceFile = new StringText([
+	`import { Injectable } from '@angular/core';`,
+	`import { HttpClient } from '@angular/common/http';`,
+	`import { Observable } from 'rxjs';`,
+	``,
+	`export interface User {`,
+	`  id: number;`,
+	`  name: string;`,
+	`  email: string;`,
+	`  role: 'admin' | 'user';`,
+	`}`,
+	``,
+	`@Injectable({ providedIn: 'root' })`,
+	`export class UserService {`,
+	`  private readonly apiUrl = '/api/users';`,
+	``,
+	`  constructor(private http: HttpClient) {}`,
+	``,
+	`  getUsers(): Observable<User[]> {`,
+	`    return this.http.get<User[]>(this.apiUrl);`,
+	`  }`,
+	``,
+	`  getUserById(id: number): Observable<User> {`,
+	`    return this.http.get<User>(\`\${this.apiUrl}/\${id}\`);`,
+	`  }`,
+	``,
+	`  createUser(user: Omit<User, 'id'>): Observable<User> {`,
+	`    return this.http.post<User>(this.apiUrl, user);`,
+	`  }`,
+	``,
+	`  updateUser(id: number, user: Partial<User>): Observable<User> {`,
+	`    return this.http.put<User>(\`\${this.apiUrl}/\${id}\`, user);`,
+	`  }`,
+	``,
+	`  deleteUser(id: number): Observable<void> {`,
+	`    return this.http.delete<void>(\`\${this.apiUrl}/\${id}\`);`,
+	`  }`,
+	`}`,
+].join('\n'));
+
+// A React component (38 lines)
+const reactComponentFile = new StringText([
+	`import React, { useState, useEffect } from 'react';`,
+	`import { UserService } from './userService';`,
+	`import { User } from './types';`,
+	``,
+	`interface Props {`,
+	`  userId: number;`,
+	`  onUpdate: (user: User) => void;`,
+	`}`,
+	``,
+	`export function UserProfile({ userId, onUpdate }: Props) {`,
+	`  const [user, setUser] = useState<User | null>(null);`,
+	`  const [loading, setLoading] = useState(true);`,
+	`  const [error, setError] = useState<string | null>(null);`,
+	``,
+	`  useEffect(() => {`,
+	`    setLoading(true);`,
+	`    UserService.getById(userId)`,
+	`      .then(data => {`,
+	`        setUser(data);`,
+	`        setLoading(false);`,
+	`      })`,
+	`      .catch(err => {`,
+	`        setError(err.message);`,
+	`        setLoading(false);`,
+	`      });`,
+	`  }, [userId]);`,
+	``,
+	`  if (loading) return <div className="spinner" />;`,
+	`  if (error) return <div className="error">{error}</div>;`,
+	`  if (!user) return null;`,
+	``,
+	`  return (`,
+	`    <div className="user-profile">`,
+	`      <h2>{user.name}</h2>`,
+	`      <p>{user.email}</p>`,
+	`      <span className="role-badge">{user.role}</span>`,
+	`      <button onClick={() => onUpdate(user)}>Edit</button>`,
+	`    </div>`,
+	`  );`,
+	`}`,
+].join('\n'));
+
+// A tsconfig.json (18 lines, ~58 tokens per page)
+const configFile = new StringText([
+	`{`,
+	`  "compilerOptions": {`,
+	`    "target": "ES2020",`,
+	`    "module": "commonjs",`,
+	`    "lib": ["ES2020"],`,
+	`    "strict": true,`,
+	`    "esModuleInterop": true,`,
+	`    "skipLibCheck": true,`,
+	`    "forceConsistentCasingInFileNames": true,`,
+	`    "outDir": "./dist",`,
+	`    "rootDir": "./src",`,
+	`    "declaration": true,`,
+	`    "declarationMap": true,`,
+	`    "sourceMap": true`,
+	`  },`,
+	`  "include": ["src/**/*"],`,
+	`  "exclude": ["node_modules", "dist", "**/*.spec.ts"]`,
+	`}`,
+].join('\n'));
+
+const serviceId = DocumentId.create('file:///src/services/userService.ts');
+const componentId = DocumentId.create('file:///src/components/UserProfile.tsx');
+const configId = DocumentId.create('file:///tsconfig.json');
+
+// --- Snapshot tests ---
+
+suite('Clipping strategy snapshots', () => {
+
+	suite('TopToBottom — clips from start of file, greedy budget', () => {
+
+		test('single file: takes content from top until budget exhausted', () => {
+			const { snippets } = buildSnippets(
+				[{ id: serviceId, content: tsServiceFile }],
+				makeOpts({ maxTokens: 100, pageSize: 10, clippingStrategy: RecentFileClippingStrategy.TopToBottom }),
+			);
+
+			expect(snippets).toMatchInlineSnapshot(`
+				[
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/services/userService.ts (truncated)
+				import { Injectable } from '@angular/core';
+				import { HttpClient } from '@angular/common/http';
+				import { Observable } from 'rxjs';
+
+				export interface User {
+				  id: number;
+				  name: string;
+				  email: string;
+				  role: 'admin' | 'user';
+				}
+				<|/recently_viewed_code_snippet|>",
+				]
+			`);
+		});
+
+		test('two files: most recent gets budget first, second gets remainder', () => {
+			const { snippets } = buildSnippets(
+				[
+					{ id: componentId, content: reactComponentFile },
+					{ id: serviceId, content: tsServiceFile },
+				],
+				makeOpts({ maxTokens: 200, pageSize: 10, clippingStrategy: RecentFileClippingStrategy.TopToBottom }),
+			);
+
+			expect(snippets).toMatchInlineSnapshot(`
+				[
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/components/UserProfile.tsx (truncated)
+				import React, { useState, useEffect } from 'react';
+				import { UserService } from './userService';
+				import { User } from './types';
+
+				interface Props {
+				  userId: number;
+				  onUpdate: (user: User) => void;
+				}
+
+				export function UserProfile({ userId, onUpdate }: Props) {
+				  const [user, setUser] = useState<User | null>(null);
+				  const [loading, setLoading] = useState(true);
+				  const [error, setError] = useState<string | null>(null);
+
+				  useEffect(() => {
+				    setLoading(true);
+				    UserService.getById(userId)
+				      .then(data => {
+				        setUser(data);
+				        setLoading(false);
+				<|/recently_viewed_code_snippet|>",
+				]
+			`);
+		});
+
+		test('three files: budget exhausted after two, third dropped', () => {
+			const { snippets, docsInPrompt } = buildSnippets(
+				[
+					{ id: componentId, content: reactComponentFile },
+					{ id: serviceId, content: tsServiceFile },
+					{ id: configId, content: configFile },
+				],
+				makeOpts({ maxTokens: 160, pageSize: 10, clippingStrategy: RecentFileClippingStrategy.TopToBottom }),
+			);
+
+			expect(docsInPrompt.has(configId)).toBe(false);
+			expect(snippets).toMatchInlineSnapshot(`
+				[
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/services/userService.ts (truncated)
+				import { Injectable } from '@angular/core';
+				import { HttpClient } from '@angular/common/http';
+				import { Observable } from 'rxjs';
+
+				export interface User {
+				  id: number;
+				  name: string;
+				  email: string;
+				  role: 'admin' | 'user';
+				}
+				<|/recently_viewed_code_snippet|>",
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/components/UserProfile.tsx (truncated)
+				import React, { useState, useEffect } from 'react';
+				import { UserService } from './userService';
+				import { User } from './types';
+
+				interface Props {
+				  userId: number;
+				  onUpdate: (user: User) => void;
+				}
+
+				export function UserProfile({ userId, onUpdate }: Props) {
+				<|/recently_viewed_code_snippet|>",
+				]
+			`);
+		});
+	});
+
+	suite('AroundEditRange — clips centered on edit locations, greedy budget', () => {
+
+		test('single file: centers clip on edit near the bottom of the file', () => {
+			// Edit to the `deleteUser` method (line 34)
+			const { snippets } = buildSnippets(
+				[{ id: serviceId, content: tsServiceFile, focalRanges: [lineRange(tsServiceFile, 34)] }],
+				makeOpts({ maxTokens: 100, pageSize: 10, clippingStrategy: RecentFileClippingStrategy.AroundEditRange }),
+			);
+
+			expect(snippets).toMatchInlineSnapshot(`
+				[
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/services/userService.ts (truncated)
+				    return this.http.put<User>(\`\${this.apiUrl}/\${id}\`, user);
+				  }
+
+				  deleteUser(id: number): Observable<void> {
+				    return this.http.delete<void>(\`\${this.apiUrl}/\${id}\`);
+				  }
+				}
+				<|/recently_viewed_code_snippet|>",
+				]
+			`);
+		});
+
+		test('two files: each clipped around its own edit location', () => {
+			const { snippets } = buildSnippets(
+				[
+					// Edit on component: the return JSX (line 32)
+					{ id: componentId, content: reactComponentFile, focalRanges: [lineRange(reactComponentFile, 32)] },
+					// Edit on service: updateUser method (line 30)
+					{ id: serviceId, content: tsServiceFile, focalRanges: [lineRange(tsServiceFile, 30)] },
+				],
+				makeOpts({ maxTokens: 300, pageSize: 10, clippingStrategy: RecentFileClippingStrategy.AroundEditRange }),
+			);
+
+			expect(snippets).toMatchInlineSnapshot(`
+				[
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/services/userService.ts (truncated)
+				    return this.http.put<User>(\`\${this.apiUrl}/\${id}\`, user);
+				  }
+
+				  deleteUser(id: number): Observable<void> {
+				    return this.http.delete<void>(\`\${this.apiUrl}/\${id}\`);
+				  }
+				}
+				<|/recently_viewed_code_snippet|>",
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/components/UserProfile.tsx (truncated)
+				      })
+				      .catch(err => {
+				        setError(err.message);
+				        setLoading(false);
+				      });
+				  }, [userId]);
+
+				  if (loading) return <div className="spinner" />;
+				  if (error) return <div className="error">{error}</div>;
+				  if (!user) return null;
+
+				  return (
+				    <div className="user-profile">
+				      <h2>{user.name}</h2>
+				      <p>{user.email}</p>
+				      <span className="role-badge">{user.role}</span>
+				      <button onClick={() => onUpdate(user)}>Edit</button>
+				    </div>
+				  );
+				}
+				<|/recently_viewed_code_snippet|>",
+				]
+			`);
+		});
+
+		test('file without focal ranges falls back to top-to-bottom', () => {
+			const { snippets } = buildSnippets(
+				[{ id: configId, content: configFile }],
+				makeOpts({ maxTokens: 100, pageSize: 10, clippingStrategy: RecentFileClippingStrategy.AroundEditRange }),
+			);
+
+			expect(snippets).toMatchInlineSnapshot(`
+				[
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /tsconfig.json (truncated)
+				{
+				  "compilerOptions": {
+				    "target": "ES2020",
+				    "module": "commonjs",
+				    "lib": ["ES2020"],
+				    "strict": true,
+				    "esModuleInterop": true,
+				    "skipLibCheck": true,
+				    "forceConsistentCasingInFileNames": true,
+				    "outDir": "./dist",
+				<|/recently_viewed_code_snippet|>",
+				]
+			`);
+		});
+	});
+
+	suite('Proportional — two-pass budget, centered on edit locations', () => {
+
+		test('two files with equal edits: budget split evenly', () => {
+			const { snippets } = buildSnippets(
+				[
+					// Edit on component: the useEffect block (line 14)
+					{ id: componentId, content: reactComponentFile, focalRanges: [lineRange(reactComponentFile, 14)], editEntryCount: 1 },
+					// Edit on service: createUser method (line 26)
+					{ id: serviceId, content: tsServiceFile, focalRanges: [lineRange(tsServiceFile, 26)], editEntryCount: 1 },
+				],
+				makeOpts({ maxTokens: 250, pageSize: 10, clippingStrategy: RecentFileClippingStrategy.Proportional }),
+			);
+
+			expect(snippets).toMatchInlineSnapshot(`
+				[
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/services/userService.ts (truncated)
+
+				  getUserById(id: number): Observable<User> {
+				    return this.http.get<User>(\`\${this.apiUrl}/\${id}\`);
+				  }
+
+				  createUser(user: Omit<User, 'id'>): Observable<User> {
+				    return this.http.post<User>(this.apiUrl, user);
+				  }
+
+				  updateUser(id: number, user: Partial<User>): Observable<User> {
+				<|/recently_viewed_code_snippet|>",
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/components/UserProfile.tsx (truncated)
+				  const [user, setUser] = useState<User | null>(null);
+				  const [loading, setLoading] = useState(true);
+				  const [error, setError] = useState<string | null>(null);
+
+				  useEffect(() => {
+				    setLoading(true);
+				    UserService.getById(userId)
+				      .then(data => {
+				        setUser(data);
+				        setLoading(false);
+				<|/recently_viewed_code_snippet|>",
+				]
+			`);
+		});
+
+		test('file with more edits gets more expansion budget', () => {
+			const { snippets } = buildSnippets(
+				[
+					// Service file: 3 edits (higher weight), edit on getUsers (line 18)
+					{ id: serviceId, content: tsServiceFile, focalRanges: [lineRange(tsServiceFile, 18)], editEntryCount: 3 },
+					// Config file: 1 edit, edit on "strict" (line 5)
+					{ id: configId, content: configFile, focalRanges: [lineRange(configFile, 5)], editEntryCount: 1 },
+				],
+				makeOpts({ maxTokens: 250, pageSize: 10, clippingStrategy: RecentFileClippingStrategy.Proportional }),
+			);
+
+			expect(snippets).toMatchInlineSnapshot(`
+				[
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /tsconfig.json (truncated)
+				{
+				  "compilerOptions": {
+				    "target": "ES2020",
+				    "module": "commonjs",
+				    "lib": ["ES2020"],
+				    "strict": true,
+				    "esModuleInterop": true,
+				    "skipLibCheck": true,
+				    "forceConsistentCasingInFileNames": true,
+				    "outDir": "./dist",
+				<|/recently_viewed_code_snippet|>",
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/services/userService.ts (truncated)
+
+				@Injectable({ providedIn: 'root' })
+				export class UserService {
+				  private readonly apiUrl = '/api/users';
+
+				  constructor(private http: HttpClient) {}
+
+				  getUsers(): Observable<User[]> {
+				    return this.http.get<User[]>(this.apiUrl);
+				  }
+				<|/recently_viewed_code_snippet|>",
+				]
+			`);
+		});
+
+		test('three files: oldest dropped when budget is tight', () => {
+			const { snippets, docsInPrompt } = buildSnippets(
+				[
+					{ id: componentId, content: reactComponentFile, focalRanges: [lineRange(reactComponentFile, 10)], editEntryCount: 1 },
+					{ id: serviceId, content: tsServiceFile, focalRanges: [lineRange(tsServiceFile, 15)], editEntryCount: 1 },
+					{ id: configId, content: configFile, focalRanges: [lineRange(configFile, 5)], editEntryCount: 1 },
+				],
+				makeOpts({ maxTokens: 150, pageSize: 10, clippingStrategy: RecentFileClippingStrategy.Proportional }),
+			);
+
+			// Config (oldest) should be dropped
+			expect(docsInPrompt.has(configId)).toBe(false);
+			expect(snippets).toMatchInlineSnapshot(`
+				[
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/components/UserProfile.tsx (truncated)
+				  const [user, setUser] = useState<User | null>(null);
+				  const [loading, setLoading] = useState(true);
+				  const [error, setError] = useState<string | null>(null);
+
+				  useEffect(() => {
+				    setLoading(true);
+				    UserService.getById(userId)
+				      .then(data => {
+				        setUser(data);
+				        setLoading(false);
+				<|/recently_viewed_code_snippet|>",
+				]
+			`);
+		});
+	});
+
+	suite('Strategy comparison — same file and edit, different strategies', () => {
+
+		// Edit on createUser method (line 26, near the middle-bottom)
+		const editFocalRange = lineRange(tsServiceFile, 26);
+
+		test('TopToBottom: always clips from top, edit location not visible', () => {
+			const { snippets } = buildSnippets(
+				[{ id: serviceId, content: tsServiceFile, focalRanges: [editFocalRange] }],
+				makeOpts({ maxTokens: 100, pageSize: 10, clippingStrategy: RecentFileClippingStrategy.TopToBottom }),
+			);
+
+			expect(snippets).toMatchInlineSnapshot(`
+				[
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/services/userService.ts (truncated)
+				import { Injectable } from '@angular/core';
+				import { HttpClient } from '@angular/common/http';
+				import { Observable } from 'rxjs';
+
+				export interface User {
+				  id: number;
+				  name: string;
+				  email: string;
+				  role: 'admin' | 'user';
+				}
+				<|/recently_viewed_code_snippet|>",
+				]
+			`);
+		});
+
+		test('AroundEditRange: clips centered on the edit location', () => {
+			const { snippets } = buildSnippets(
+				[{ id: serviceId, content: tsServiceFile, focalRanges: [editFocalRange] }],
+				makeOpts({ maxTokens: 100, pageSize: 10, clippingStrategy: RecentFileClippingStrategy.AroundEditRange }),
+			);
+
+			expect(snippets).toMatchInlineSnapshot(`
+				[
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/services/userService.ts (truncated)
+
+				  getUserById(id: number): Observable<User> {
+				    return this.http.get<User>(\`\${this.apiUrl}/\${id}\`);
+				  }
+
+				  createUser(user: Omit<User, 'id'>): Observable<User> {
+				    return this.http.post<User>(this.apiUrl, user);
+				  }
+
+				  updateUser(id: number, user: Partial<User>): Observable<User> {
+				<|/recently_viewed_code_snippet|>",
+				]
+			`);
+		});
+
+		test('Proportional: same as AroundEditRange for a single file', () => {
+			const { snippets } = buildSnippets(
+				[{ id: serviceId, content: tsServiceFile, focalRanges: [editFocalRange], editEntryCount: 1 }],
+				makeOpts({ maxTokens: 100, pageSize: 10, clippingStrategy: RecentFileClippingStrategy.Proportional }),
+			);
+
+			expect(snippets).toMatchInlineSnapshot(`
+				[
+				  "<|recently_viewed_code_snippet|>
+				code_snippet_file_path: /src/services/userService.ts (truncated)
+
+				  getUserById(id: number): Observable<User> {
+				    return this.http.get<User>(\`\${this.apiUrl}/\${id}\`);
+				  }
+
+				  createUser(user: Omit<User, 'id'>): Observable<User> {
+				    return this.http.post<User>(this.apiUrl, user);
+				  }
+
+				  updateUser(id: number, user: Partial<User>): Observable<User> {
+				<|/recently_viewed_code_snippet|>",
+				]
+			`);
+		});
+	});
+});


### PR DESCRIPTION
The proportional and aroundEditRange strategies could overshoot the token
budget by ~15% because \`clipAroundFocalRanges\` unconditionally included focal
pages even when they exceeded the remaining budget, clamping the negative
remainder to 0.

**For proportional:** rewrite to two-pass allocation — first compute minimum
focal page costs and drop oldest files that don't fit, then distribute the
remaining budget proportionally by edit-entry weight for page expansion.

**For aroundEditRange:** skip files whose focal pages exceed the remaining budget
instead of silently overshooting.

### Changes
- Add \`computeFocalPageCost\` helper to compute minimum focal page token cost
- Rewrite \`buildCodeSnippetsWithProportionalBudget\` with two-pass allocation
- Fix \`clipAroundFocalRanges\` to skip files when focal pages exceed budget
- Add snapshot tests with realistic file content showing all three strategies
- Add specification document for all clipping strategies