### PR TITLE
Fix stale diagnostics throwing

### DIFF
--- a/src/extension/xtab/common/lintErrors.ts
+++ b/src/extension/xtab/common/lintErrors.ts
@@ -170,7 +170,8 @@ function formatCodeLines(diagnosticRange: Range, lintOptions: LintOptions, docum
 
 	const lineRange = lineRangeToInclude.intersect(new OffsetRange(0, documentLines.length));
 	if (!lineRange) {
-		throw new BugIndicatingError('Unexpected: line range to include is out of document bounds.');
+		// Diagnostic refers to lines that no longer exist (stale diagnostic after document edit)
+		return [];
 	}
 
 	const codeLines: string[] = [];

--- a/src/extension/xtab/test/common/lintErrors.spec.ts
+++ b/src/extension/xtab/test/common/lintErrors.spec.ts
@@ -667,6 +667,50 @@ describe('LintErrors', () => {
 
 			expect(result).toBe(expected);
 		});
+
+		it('should handle stale diagnostic referencing lines beyond document length', () => {
+			const document = createDocument(['line1', 'line2'], 1, 1);
+			// Diagnostic references line 10 which doesn't exist in a 2-line document
+			diagnosticsService.setDiagnostics(fileUri, [
+				{
+					message: 'Stale diagnostic',
+					range: new Range(10, 0, 10, 5),
+					severity: DiagnosticSeverity.Error
+				}
+			]);
+
+			const optionsWithCode: LintOptions = {
+				...defaultLintOptions,
+				showCode: LintOptionShowCode.YES
+			};
+
+			const lintErrors = createLintErrors(document);
+
+			// Should not throw, should gracefully handle stale diagnostic
+			const result = lintErrors.getFormattedLintErrors(optionsWithCode);
+			expect(result).toContain('Stale diagnostic');
+		});
+
+		it('should handle stale diagnostic with YES_WITH_SURROUNDING beyond document length', () => {
+			const document = createDocument(['line1', 'line2'], 1, 1);
+			diagnosticsService.setDiagnostics(fileUri, [
+				{
+					message: 'Stale diagnostic',
+					range: new Range(10, 0, 10, 5),
+					severity: DiagnosticSeverity.Error
+				}
+			]);
+
+			const optionsWithSurrounding: LintOptions = {
+				...defaultLintOptions,
+				showCode: LintOptionShowCode.YES_WITH_SURROUNDING
+			};
+
+			const lintErrors = createLintErrors(document);
+
+			const result = lintErrors.getFormattedLintErrors(optionsWithSurrounding);
+			expect(result).toContain('Stale diagnostic');
+		});
 	});
 
 	describe('lineNumberInPreviousFormattedPrompt', () => {


### PR DESCRIPTION
```Copilot Generated Description:``` Handle stale diagnostics that reference lines beyond the document length without throwing an error. Add tests to ensure proper handling of such cases.