### PR TITLE
intents: safely handle empty hook return values

### DIFF
--- a/src/extension/intents/node/toolCallingLoop.ts
+++ b/src/extension/intents/node/toolCallingLoop.ts
@@ -341,8 +341,8 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 				logService: this._logService,
 				onSuccess: (output) => {
 					if (typeof output === 'object' && output !== null) {
-						const hookOutput = output as SessionStartHookOutput;
-						const additionalContext = hookOutput.hookSpecificOutput?.additionalContext;
+						const hookOutput = output as SessionStartHookOutput | undefined;
+						const additionalContext = hookOutput?.hookSpecificOutput?.additionalContext;
 						if (additionalContext) {
 							additionalContexts.push(additionalContext);
 							this._logService.trace(`[ToolCallingLoop] SessionStart hook provided context: ${additionalContext.substring(0, 100)}...`);
@@ -384,8 +384,8 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 				logService: this._logService,
 				onSuccess: (output) => {
 					if (typeof output === 'object' && output !== null) {
-						const hookOutput = output as SubagentStartHookOutput;
-						const additionalContext = hookOutput.hookSpecificOutput?.additionalContext;
+						const hookOutput = output as SubagentStartHookOutput | undefined;
+						const additionalContext = hookOutput?.hookSpecificOutput?.additionalContext;
 						if (additionalContext) {
 							additionalContexts.push(additionalContext);
 							this._logService.trace(`[ToolCallingLoop] SubagentStart hook provided context: ${additionalContext.substring(0, 100)}...`);

--- a/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -356,8 +356,8 @@ export class DefaultIntentRequestHandler {
 				outputStream: this.stream,
 				logService: this._logService,
 				onSuccess: (output) => {
-					const typedOutput = output as UserPromptSubmitHookOutput & { additionalContext?: string };
-					const additionalContext = typedOutput.hookSpecificOutput?.additionalContext ?? typedOutput.additionalContext;
+					const typedOutput = output as UserPromptSubmitHookOutput & { additionalContext?: string } | undefined;
+					const additionalContext = typedOutput?.hookSpecificOutput?.additionalContext ?? typedOutput?.additionalContext;
 					if (additionalContext) {
 						additionalContexts.push(additionalContext);
 					}


### PR DESCRIPTION
Adds optional chaining to safely access nested properties in hook outputs. This prevents exceptions when hooks like hookify return empty objects that don't contain the expected hookSpecificOutput structure.

Changes:
- toolCallingLoop.ts: Add optional chaining for SessionStart and SubagentStart hook output handling
- defaultIntentRequestHandler.ts: Add optional chaining for UserPromptSubmit hook output handling

(Commit message generated by Copilot)