### PR TITLE
chat: fix hook event name casing to match Claude API spec

### DIFF
--- a/src/extension/chat/vscode-node/chatHookService.ts
+++ b/src/extension/chat/vscode-node/chatHookService.ts
@@ -103,7 +103,7 @@ export class ChatHookService implements IChatHookService {
 			// Build common input properties merged with caller-specific input
 			const commonInput = {
 				timestamp: new Date().toISOString(),
-				hookEventName: hookType,
+				hook_event_name: hookType,
 				...(sessionId ? { sessionId } : undefined),
 				...(transcriptPath ? { transcript_path: transcriptPath.fsPath } : undefined),
 			};


### PR DESCRIPTION
Updates the hook event name from camelCase (hookEventName) to snake_case (hook_event_name) to align with the Claude hooks API specification as documented at: https://code.claude.com/docs/en/hooks#common-input-fields

Changes:
- chatHookService.ts: Correct the event name casing in common hook input properties

(Commit message generated by Copilot)