### PR TITLE
Minimize response time for low aggressiveness settings

### DIFF
--- a/src/extension/inlineEdits/common/delay.ts
+++ b/src/extension/inlineEdits/common/delay.ts
@@ -9,7 +9,7 @@ export class DelaySession {
 
 	constructor(
 		private baseDebounceTime: number,
-		private readonly expectedTotalTime: number | undefined,
+		private expectedTotalTime: number | undefined,
 		private readonly providerInvocationTime: number = Date.now(),
 	) {
 	}
@@ -20,6 +20,10 @@ export class DelaySession {
 
 	public setBaseDebounceTime(baseDebounceTime: number): void {
 		this.baseDebounceTime = baseDebounceTime;
+	}
+
+	public setExpectedTotalTime(expectedTotalTime: number): void {
+		this.expectedTotalTime = expectedTotalTime;
 	}
 
 	getDebounceTime() {

--- a/src/extension/inlineEdits/common/userInteractionMonitor.ts
+++ b/src/extension/inlineEdits/common/userInteractionMonitor.ts
@@ -167,6 +167,8 @@ export class UserInteractionMonitor {
 	 */
 	protected _recentUserActionsForTiming: (NESUserAction & { kind: ActionKind.Accepted | ActionKind.Rejected })[] = [];
 
+	private _lastActionWasAcceptance = false;
+
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IExperimentationService private readonly _experimentationService: IExperimentationService,
@@ -188,8 +190,18 @@ export class UserInteractionMonitor {
 		this._recordUserAction(ActionKind.Ignored);
 	}
 
+	/**
+	 * Returns true if the last recorded user action was an acceptance.
+	 * Used to skip aggressiveness min-response-time delay after accepts.
+	 */
+	get wasLastActionAcceptance(): boolean {
+		return this._lastActionWasAcceptance;
+	}
+
 	private _recordUserAction(kind: ActionKind): void {
 		const now = Date.now();
+
+		this._lastActionWasAcceptance = kind === ActionKind.Accepted;
 
 		// Always record for aggressiveness calculation
 		this._recentUserActionsForAggressiveness.push({ time: now, kind });

--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -247,7 +247,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 
 		// Adjust debounce based on user aggressiveness setting for non-aggressiveness models
 		if (!isAggressivenessStrategy(promptOptions.promptingStrategy)) {
-			this._applyAggressivenessDebounce(delaySession, tracer);
+			this._applyAggressivenessSettings(delaySession, tracer);
 		}
 
 		const areaAroundEditWindowLinesRange = computeAreaAroundEditWindowLinesRange(currentDocument);
@@ -415,19 +415,39 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		);
 	}
 
-	private _applyAggressivenessDebounce(delaySession: DelaySession, tracer: ILogger): void {
+	private _applyAggressivenessSettings(delaySession: DelaySession, tracer: ILogger): void {
 		const userAggressiveness = this.configService.getExperimentBasedConfig(ConfigKey.Advanced.InlineEditsAggressiveness, this.expService);
-		const debounceConfigByLevel: Record<AggressivenessSetting, { configKey: typeof ConfigKey.TeamInternal.InlineEditsAggressivenessLowDebounceMs } | undefined> = {
-			[AggressivenessSetting.Low]: { configKey: ConfigKey.TeamInternal.InlineEditsAggressivenessLowDebounceMs },
-			[AggressivenessSetting.Medium]: { configKey: ConfigKey.TeamInternal.InlineEditsAggressivenessMediumDebounceMs },
-			[AggressivenessSetting.High]: { configKey: ConfigKey.TeamInternal.InlineEditsAggressivenessHighDebounceMs },
+		type MinResponseTimeConfigKey = typeof ConfigKey.TeamInternal.InlineEditsAggressivenessLowMinResponseTimeMs;
+		type DebounceConfigKey = typeof ConfigKey.TeamInternal.InlineEditsAggressivenessHighDebounceMs;
+		const configsByLevel: Record<AggressivenessSetting, { debounceConfigKey?: DebounceConfigKey; minResponseConfigKey?: MinResponseTimeConfigKey } | undefined> = {
+			[AggressivenessSetting.Low]: { minResponseConfigKey: ConfigKey.TeamInternal.InlineEditsAggressivenessLowMinResponseTimeMs },
+			[AggressivenessSetting.Medium]: { minResponseConfigKey: ConfigKey.TeamInternal.InlineEditsAggressivenessMediumMinResponseTimeMs },
+			[AggressivenessSetting.High]: { debounceConfigKey: ConfigKey.TeamInternal.InlineEditsAggressivenessHighDebounceMs },
 			[AggressivenessSetting.Default]: undefined,
 		};
-		const entry = debounceConfigByLevel[userAggressiveness];
-		if (entry) {
-			const debounceMs = this.configService.getExperimentBasedConfig(entry.configKey, this.expService);
+		const entry = configsByLevel[userAggressiveness];
+		if (!entry) {
+			return;
+		}
+
+		// Apply debounce override if configured for this level
+		if (entry.debounceConfigKey) {
+			const debounceMs = this.configService.getExperimentBasedConfig(entry.debounceConfigKey, this.expService);
 			delaySession.setBaseDebounceTime(debounceMs);
 			tracer.trace(`Aggressiveness ${userAggressiveness}: debounce set to ${debounceMs}ms`);
+		}
+
+		// Apply min response time if configured for this level
+		if (entry.minResponseConfigKey) {
+			// Skip min response time delay if the user just accepted a suggestion
+			if (this.userInteractionMonitor.wasLastActionAcceptance) {
+				tracer.trace(`Aggressiveness ${userAggressiveness}: skipping min response time (last action was acceptance)`);
+				return;
+			}
+
+			const minResponseTimeMs = this.configService.getExperimentBasedConfig(entry.minResponseConfigKey, this.expService);
+			delaySession.setExpectedTotalTime(minResponseTimeMs);
+			tracer.trace(`Aggressiveness ${userAggressiveness}: min response time set to ${minResponseTimeMs}ms`);
 		}
 	}
 

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -835,8 +835,8 @@ export namespace ConfigKey {
 		export const InlineEditsXtabMaxMergeConflictLines = defineTeamInternalSetting<number | undefined>('chat.advanced.inlineEdits.xtabProvider.maxMergeConflictLines', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsXtabOnlyMergeConflictLines = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.xtabProvider.onlyMergeConflictLines', ConfigType.ExperimentBased, false);
 		export const InlineEditsXtabAggressivenessLevel = defineTeamInternalSetting<xtabPromptOptions.AggressivenessLevel | undefined>('chat.advanced.inlineEdits.xtabProvider.aggressivenessLevel', ConfigType.ExperimentBased, undefined);
-		export const InlineEditsAggressivenessLowDebounceMs = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.aggressiveness.lowDebounceMs', ConfigType.ExperimentBased, 300);
-		export const InlineEditsAggressivenessMediumDebounceMs = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.aggressiveness.mediumDebounceMs', ConfigType.ExperimentBased, 100);
+		export const InlineEditsAggressivenessLowMinResponseTimeMs = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.aggressiveness.lowMinResponseTimeMs', ConfigType.ExperimentBased, 1500);
+		export const InlineEditsAggressivenessMediumMinResponseTimeMs = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.aggressiveness.mediumMinResponseTimeMs', ConfigType.ExperimentBased, 700);
 		export const InlineEditsAggressivenessHighDebounceMs = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.aggressiveness.highDebounceMs', ConfigType.ExperimentBased, 0);
 		export const InlineEditsUserHappinessScoreConfigurationString = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineEdits.adaptiveAggressivenessConfigurationString', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsUndoInsertionFiltering = defineTeamInternalSetting<'v1' | 'v2' | undefined>('chat.advanced.inlineEdits.undoInsertionFiltering', ConfigType.ExperimentBased, 'v1');


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a mechanism to set a minimum response time for low aggressiveness settings, allowing for more responsive interactions. Adjustments include new configuration keys and logic to skip the minimum response time delay if the last user action was an acceptance.