### PR TITLE
Bump minor version to 0.39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "copilot-chat",
-	"version": "0.38.0",
+	"version": "0.39.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "copilot-chat",
-			"version": "0.38.0",
+			"version": "0.39.0",
 			"hasInstallScript": true,
 			"license": "SEE LICENSE IN LICENSE.txt",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "copilot-chat",
 	"displayName": "GitHub Copilot Chat",
 	"description": "AI chat features powered by Copilot",
-	"version": "0.38.0",
+	"version": "0.39.0",
 	"build": "1",
 	"internalAIKey": "1058ec22-3c95-4951-8443-f26c1f325911",
 	"completionsCoreVersion": "1.378.1799",


### PR DESCRIPTION
0.38 exists at [release/0.38](https://github.com/microsoft/vscode-copilot-chat/tree/release/0.38)