### PR TITLE
fix: use base64 for image attachments on Anthropic models

### DIFF
--- a/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -188,9 +188,11 @@ export function modelCanUseMcpResultImageURL(model: LanguageModelChat | IChatEnd
 
 /**
  * The model can accept image urls as the `image_url` parameter in requests.
+ * Anthropic models using the messages API only support base64-encoded images,
+ * not URL-based image references.
  */
 export function modelCanUseImageURL(model: LanguageModelChat | IChatEndpoint): boolean {
-	return true;
+	return !isAnthropicFamily(model);
 }
 
 /**


### PR DESCRIPTION
Workaround for microsoft/vscode#297891

fyi @justschen 