### PR TITLE
[release/0.38] Hold external repo info telemetry (cherry-pick #4075)

### DIFF
--- a/src/extension/prompt/node/repoInfoTelemetry.ts
+++ b/src/extension/prompt/node/repoInfoTelemetry.ts
@@ -79,8 +79,7 @@ function shouldSendEndTelemetry(result: RepoInfoTelemetryResult | undefined): bo
 
 /*
 * Handles sending telemetry about the current git repository.
-* headCommitHash and repoId are sent for all users via sendMSFTTelemetryEvent.
-* Full data (remoteUrl, diffs) is only sent for internal users via sendInternalMSFTTelemetryEvent.
+* Full repo info telemetry (remoteUrl, repoId, repoType, diffsJSON, headCommitHash) is only sent for internal users via sendInternalMSFTTelemetryEvent.
 */
 export class RepoInfoTelemetry {
 	private _beginTelemetrySent = false;
@@ -157,16 +156,6 @@ export class RepoInfoTelemetry {
 			return repoInfo;
 		}
 
-		const metadata = await this._getRepoMetadata();
-		if (metadata) {
-			this._telemetryService.sendMSFTTelemetryEvent('request.repoInfo', {
-				repoType: metadata.repoType,
-				headCommitHash: metadata.headCommitHash,
-				location,
-				telemetryMessageId: this._telemetryMessageId,
-			});
-		}
-
 		return undefined;
 	}
 
@@ -201,18 +190,6 @@ export class RepoInfoTelemetry {
 		}
 
 		return { repoContext, repoInfo, repository, upstreamCommit };
-	}
-
-	private async _getRepoMetadata(): Promise<{ repoType: 'github' | 'ado'; headCommitHash: string } | undefined> {
-		const ctx = await this._resolveRepoContext();
-		if (!ctx) {
-			return;
-		}
-
-		return {
-			repoType: ctx.repoInfo.repoId.type,
-			headCommitHash: ctx.upstreamCommit,
-		};
 	}
 
 	private async _getRepoInfoTelemetry(): Promise<RepoInfoTelemetryData | undefined> {

--- a/src/extension/prompt/node/test/repoInfoTelemetry.spec.ts
+++ b/src/extension/prompt/node/test/repoInfoTelemetry.spec.ts
@@ -125,7 +125,7 @@ suite('RepoInfoTelemetry', () => {
 	// Basic Telemetry Flow Tests
 	// ========================================
 
-	test('should send external telemetry for all users but internal only for internal users', async () => {
+	test('should not send any telemetry for non-internal users', async () => {
 		// Setup: non-internal user
 		const nonInternalToken = new CopilotToken(createTestExtendedTokenInfo({
 			token: 'test-token',
@@ -159,17 +159,8 @@ suite('RepoInfoTelemetry', () => {
 		await repoTelemetry.sendBeginTelemetryIfNeeded();
 		await repoTelemetry.sendEndTelemetry();
 
-		// Assert: external MSFT telemetry sent with limited data (headCommitHash only, no repoId)
-		assert.ok((telemetryService.sendMSFTTelemetryEvent as any).mock.calls.length > 0, 'sendMSFTTelemetryEvent should be called for external users');
-		const msftCall = (telemetryService.sendMSFTTelemetryEvent as any).mock.calls[0];
-		assert.strictEqual(msftCall[0], 'request.repoInfo');
-		assert.strictEqual(msftCall[1].headCommitHash, 'abc123');
-		assert.strictEqual(msftCall[1].repoId, undefined);
-		// External telemetry should NOT contain remoteUrl or diffsJSON
-		assert.strictEqual(msftCall[1].remoteUrl, undefined);
-		assert.strictEqual(msftCall[1].diffsJSON, undefined);
-
-		// Assert: internal telemetry NOT sent for non-internal users (diff computation skipped)
+		// Assert: no telemetry sent for non-internal users
+		assert.strictEqual((telemetryService.sendMSFTTelemetryEvent as any).mock.calls.length, 0, 'sendMSFTTelemetryEvent should not be called for non-internal users');
 		assert.strictEqual((telemetryService.sendInternalMSFTTelemetryEvent as any).mock.calls.length, 0, 'sendInternalMSFTTelemetryEvent should not be called for non-internal users');
 	});
 


### PR DESCRIPTION
Cherry-pick of #4075 into `release/0.38`.

Disables the external `sendMSFTTelemetryEvent` call in `RepoInfoTelemetry` for now.

Internal users continue to receive full telemetry via `sendInternalMSFTTelemetryEvent` (gated to MSFT employees only).

Also removes the now-unused `_getRepoMetadata()` private method.

(cherry picked from commit 0691e8c4)