### PR TITLE
Background - clean worktree changes cache at the end of the turn

### DIFF
--- a/src/extension/chatSessions/vscode-node/chatSessionWorktreeServiceImpl.ts
+++ b/src/extension/chatSessions/vscode-node/chatSessionWorktreeServiceImpl.ts
@@ -394,6 +394,13 @@ export class ChatSessionWorktreeService extends Disposable implements IChatSessi
 
 		if (repository.state.workingTreeChanges.length === 0 && repository.state.indexChanges.length === 0 && repository.state.untrackedChanges.length === 0) {
 			this.logService.trace(`[ChatSessionWorktreeService][handleRequestCompleted] No changes to commit in working directory ${worktreePath}`);
+
+			// Delete worktree changes cache
+			this.setWorktreeProperties(sessionId, {
+				...worktreeProperties,
+				changes: undefined
+			});
+
 			return;
 		}
 


### PR DESCRIPTION
Related https://github.com/microsoft/vscode-internalbacklog/issues/6908