### PR TITLE
Follow-up fixes for v2 taxonomy (#4071)

### DIFF
--- a/src/extension/prompt/common/promptCategorizationTaxonomy.ts
+++ b/src/extension/prompt/common/promptCategorizationTaxonomy.ts
@@ -277,7 +277,7 @@ function formatCategoryForPrompt(key: string, def: CategoryDefinition): string {
 		parts.push(`- Keywords: ${def.keywords.join(', ')}`);
 	}
 	if (def.signals?.length) {
-		parts.push(`Signals: ${def.signals.join(', ')}`);
+		parts.push(`- Signals: ${def.signals.join(', ')}`);
 	}
 	if (def.examples?.length) {
 		parts.push(`Examples: ${def.examples.map(e => `"${e}"`).join(', ')}`);

--- a/src/extension/prompt/node/promptCategorizer.ts
+++ b/src/extension/prompt/node/promptCategorizer.ts
@@ -285,6 +285,7 @@ export class PromptCategorizerService implements IPromptCategorizerService {
 			"promptCategorization" : {
 				"owner": "digitarald",
 				"comment": "Classifies agent requests for understanding user intent and response quality",
+				"taxonomyVersion": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The taxonomy version used for classification (e.g. v2). Used to segment data when taxonomy keys change." },
 				"sessionId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The chat session identifier" },
 				"requestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The extension-generated request identifier, matches panel.request requestId" },
 				"vscodeRequestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The VS Code chat request id, for joining with VS Code telemetry events" },
@@ -306,6 +307,7 @@ export class PromptCategorizerService implements IPromptCategorizerService {
 		this.telemetryService.sendMSFTTelemetryEvent(
 			'promptCategorization',
 			{
+				taxonomyVersion: 'v2',
 				sessionId: request.sessionId ?? '',
 				requestId: telemetryMessageId,
 				vscodeRequestId: request.id ?? '',
@@ -337,6 +339,7 @@ export class PromptCategorizerService implements IPromptCategorizerService {
 		this.telemetryService.sendInternalMSFTTelemetryEvent(
 			'promptCategorization',
 			{
+				taxonomyVersion: 'v2',
 				sessionId: request.sessionId ?? '',
 				requestId: telemetryMessageId,
 				vscodeRequestId: request.id ?? '',

--- a/src/extension/prompts/node/panel/promptCategorization.tsx
+++ b/src/extension/prompts/node/panel/promptCategorization.tsx
@@ -22,7 +22,7 @@ export class PromptCategorizationPrompt extends PromptElement<PromptCategorizati
 			'You are an expert classifier for AI coding assistant prompts. Classify developer requests in context of their workspace and active file across domain, intent, time estimate, and scope.',
 			'You MUST use the categorize_prompt tool to provide your classification.',
 			generateTaxonomyPrompt(),
-		].join('\n\n');
+		].join('\n\n') + '\n\n';
 
 		return (
 			<>


### PR DESCRIPTION
Follow-up to #4071 addressing review comments.

### Changes

1. **Add `taxonomyVersion` to telemetry** — Adds a `taxonomyVersion: 'v2'` field to both the MSFT and internal `promptCategorization` telemetry events so dashboards can distinguish v1 vs v2 taxonomy data.

2. **Fix prompt/SafetyRules boundary** — The system prompt string was rendered immediately before `<SafetyRules />` with no separator, causing the taxonomy's last line to run together with safety rules. Adds a trailing `\n\n`.

3. **Consistent signals formatting** — Kept `signals` rendering (used by scope definitions) but aligned bullet formatting (`- Signals:`) with the new `- Keywords:` style from v2.

cc @kevin-m-kent