### PR TITLE
feat(openrouter): add app attribution headers for OpenRouter provider

### DIFF
--- a/src/extension/byok/vscode-node/openRouterProvider.ts
+++ b/src/extension/byok/vscode-node/openRouterProvider.ts
@@ -61,7 +61,11 @@ export class OpenRouterLMProvider extends AbstractOpenAICompatibleLMProvider {
 			toolCalling: openRouterModelData.supported_parameters?.includes('tools') ?? false,
 			vision: openRouterModelData.architecture?.input_modalities?.includes('image') ?? false,
 			maxInputTokens: openRouterModelData.top_provider.context_length - 16000,
-			maxOutputTokens: 16000
+			maxOutputTokens: 16000,
+			requestHeaders: {
+				'HTTP-Referer': 'https://code.visualstudio.com/',
+				'X-OpenRouter-Title': 'vscode'
+			}
 		};
 	}
 


### PR DESCRIPTION

Adds App Attribution support to the OpenRouter provider, enabling VS Code to appear in OpenRouter's public rankings and analytics. This feature allows users to gain insights into their model usage patterns while increasing visibility for VS Code in the OpenRouter ecosystem.

### Motivation

OpenRouter's App Attribution feature enables developers to associate their API usage with their application through simple HTTP headers. By including these headers in requests, apps can:
- Appear in OpenRouter's public leaderboards
- Gain visibility in rankings and analytics
- Get insights into model usage patterns

This aligns with VS Code's integration with OpenRouter BYOK (Bring Your Own Key) feature.

### Changes

Modified [`openRouterProvider.ts`](src/extension/byok/vscode-node/openRouterProvider.ts:65):

- Added `HTTP-Referer` header pointing to `https://code.visualstudio.com/`
- Added `X-OpenRouter-Title` header with value `vscode`

These headers are automatically included in all API requests to OpenRouter, enabling the App Attribution feature.

### Documentation

- OpenRouter App Attribution: https://openrouter.ai/docs/app-attribution
