### PR TITLE
Move useMessagesApi to stable config

### DIFF
--- a/package.json
+++ b/package.json
@@ -3033,6 +3033,14 @@
 								}
 							]
 						]
+					},
+					"github.copilot.chat.anthropic.useMessagesApi": {
+						"type": "boolean",
+						"default": true,
+						"markdownDescription": "%github.copilot.config.useMessagesApi%",
+						"tags": [
+							"onExp"
+						]
 					}
 				}
 			},
@@ -3085,15 +3093,6 @@
 						"markdownDescription": "%github.copilot.config.tools.memory.enabled%",
 						"tags": [
 							"preview"
-						]
-					},
-					"github.copilot.chat.anthropic.useMessagesApi": {
-						"type": "boolean",
-						"default": true,
-						"markdownDescription": "%github.copilot.config.useMessagesApi%",
-						"tags": [
-							"preview",
-							"onExp"
 						]
 					},
 					"github.copilot.chat.anthropic.thinking.budgetTokens": {


### PR DESCRIPTION
## Summary
- move  from preview to stable configuration
- keep the  tag so experiment rollout can still disable it when needed
