### PR TITLE
feat(otel): add github.copilot.chat.otel.flush command for explicit flush control

### DIFF
--- a/src/extension/otel/vscode-node/otelContrib.ts
+++ b/src/extension/otel/vscode-node/otelContrib.ts
@@ -26,8 +26,6 @@ export class OTelContrib extends Disposable implements IExtensionContribution {
 			this._logService.trace('[OTel] Instrumentation disabled');
 		}
 
-		// Register flush command for eval runtime to call before VS Code exits.
-		// This ensures all buffered spans/metrics/events are exported to the configured backend.
 		this._register(vscode.commands.registerCommand('github.copilot.chat.otel.flush', async () => {
 			if (!this._otelService.config.enabled) {
 				return;


### PR DESCRIPTION
Registers a VS Code command that calls IOTelService.flush() to export all buffered spans, metrics, and events. This allows to trigger a deterministic flush before killing VS Code, ensuring no OTel data is lost (especially the invoke_agent root span).