### PR TITLE
nes: don't show arrow for ghost text completions when unification is enabled

### DIFF
--- a/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
+++ b/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
@@ -433,7 +433,7 @@ export class InlineCompletionProviderImpl extends Disposable implements InlineCo
 				telemetryBuilder,
 				action: learnMoreAction,
 				isInlineEdit: !isInlineCompletion,
-				showInlineEditMenu: !serveAsCompletionsProvider,
+				showInlineEditMenu: !(unification && isInlineCompletion),
 				wasShown: false,
 				supportsRename,
 				correlationId,


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/299150