### PR TITLE
Add 'launch' skill for Copilot Chat extension UI automation via agent-browser

### DIFF
--- a/.agents/skills/launch/SKILL.md
+++ b/.agents/skills/launch/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: launch
+description: "Launch and automate VS Code Insiders with the Copilot Chat extension using agent-browser via Chrome DevTools Protocol. Use when you need to interact with the VS Code UI, automate the chat panel, test the extension UI, or take screenshots. Triggers include 'automate VS Code', 'interact with chat', 'test the UI', 'take a screenshot', 'launch with debugging'."
+metadata:
+  allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*)
+---
+
+# VS Code Extension Automation
+
+Automate VS Code Insiders with the Copilot Chat extension using agent-browser. VS Code is built on Electron/Chromium and exposes a Chrome DevTools Protocol (CDP) port that agent-browser can connect to, enabling the same snapshot-interact workflow used for web pages.
+
+## Prerequisites
+
+- **`agent-browser` must be installed.** It's available in the project's devDependencies — run `npm install`. Use `npx agent-browser` if it's not on your PATH, or install globally with `npm install -g agent-browser`.
+- **`code-insiders` is required.** This extension uses 58 proposed VS Code APIs and targets `vscode ^1.110.0-20260223`. VS Code Stable will **not** activate it — you must use VS Code Insiders.
+- **The extension must be compiled first.** Use `npm run compile` for a one-shot build, or `npm run watch` for iterative development.
+- **CSS selectors are internal implementation details.** Selectors like `.interactive-input-part`, `.monaco-editor`, and `.view-line` are VS Code internals that may change across versions. If automation breaks after a VS Code update, re-snapshot and check for selector changes.
+
+## Core Workflow
+
+1. **Build** the extension
+2. **Launch** VS Code Insiders with the extension and remote debugging enabled
+3. **Connect** agent-browser to the CDP port
+4. **Snapshot** to discover interactive elements
+5. **Interact** using element refs
+6. **Re-snapshot** after navigation or state changes
+
+```bash
+# Build and launch with the extension
+npm run compile
+# Use a PERSISTENT user-data-dir so auth state is preserved across sessions
+code-insiders --extensionDevelopmentPath="$PWD" --remote-debugging-port=9223 --user-data-dir=~/.vscode-ext-debug
+# On Windows:
+# code-insiders --extensionDevelopmentPath="%CD%" --remote-debugging-port=9223 --user-data-dir=%APPDATA%\vscode-ext-debug
+
+# Wait for VS Code to start, retry until connected
+for i in 1 2 3 4 5; do agent-browser connect 9223 2>/dev/null && break || sleep 3; done
+agent-browser snapshot -i
+```
+
+## Connecting
+
+```bash
+# Connect to a specific port
+agent-browser connect 9223
+
+# Or use --cdp on each command
+agent-browser --cdp 9223 snapshot -i
+
+# Auto-discover a running Chromium-based app
+agent-browser --auto-connect snapshot -i
+```
+
+After `connect`, all subsequent commands target the connected app without needing `--cdp`.
+
+## Tab Management
+
+VS Code uses multiple webviews internally. Use tab commands to list and switch between them:
+
+```bash
+# List all available targets (windows, webviews, etc.)
+agent-browser tab
+
+# Switch to a specific tab by index
+agent-browser tab 2
+
+# Switch by URL pattern
+agent-browser tab --url "*settings*"
+```
+
+## Launching VS Code Extensions for Debugging
+
+To debug a VS Code extension via agent-browser, launch VS Code Insiders with `--extensionDevelopmentPath` pointing to your extension source and `--remote-debugging-port` for CDP. Use `--user-data-dir` to avoid conflicting with an already-running VS Code instance.
+
+```bash
+# Build the extension first (from the repo root)
+npm run compile
+
+# Launch VS Code Insiders with the extension and CDP
+# IMPORTANT: Use a persistent directory (not /tmp) so auth state is preserved
+code-insiders \
+  --extensionDevelopmentPath="$PWD" \
+  --remote-debugging-port=9223 \
+  --user-data-dir=~/.vscode-ext-debug
+
+# Wait for VS Code to start, retry until connected
+for i in 1 2 3 4 5; do agent-browser connect 9223 2>/dev/null && break || sleep 3; done
+agent-browser snapshot -i
+```
+
+**Key flags:**
+- `--extensionDevelopmentPath=<path>` — loads your extension from source (must be compiled first). Use `$PWD` when running from the repo root.
+- `--remote-debugging-port=9223` — enables CDP (use 9223 to avoid conflicts with other apps on 9222)
+- `--user-data-dir=<path>` — uses a separate profile so it starts a new process instead of sending to an existing VS Code instance. **Always use a persistent path** (e.g., `~/.vscode-ext-debug`) rather than `/tmp/...` so authentication, settings, and extension state survive across sessions.
+
+**Without `--user-data-dir`**, VS Code detects the running instance, forwards the args to it, and exits immediately — you'll see "Sent env to running instance. Terminating..." and CDP never starts.
+
+> **⚠️ Authentication is required.** The Copilot Chat extension needs an authenticated GitHub session to function. Using a temp directory (e.g., `/tmp/...`) creates a fresh profile with no auth — the agent will hit a "Sign in to use Copilot" wall and model resolution will fail with "Language model unavailable."
+>
+> **Always use a persistent `--user-data-dir`** like `~/.vscode-ext-debug` (macOS/Linux) or `%APPDATA%\vscode-ext-debug` (Windows). On first use, launch once and sign in manually. Subsequent launches will reuse the auth session.
+
+## Interacting with Monaco Editor (Chat Input, Code Editors)
+
+VS Code uses Monaco Editor for all text inputs including the Copilot Chat input. Monaco editors appear as textboxes in the accessibility snapshot but require specific agent-browser commands to interact with.
+
+### What Works
+
+#### `type @ref` — The Best Approach
+
+The `type` command with a snapshot ref handles focus and input in one step:
+
+```bash
+# Snapshot to find the chat input ref
+agent-browser snapshot -i
+# Look for: textbox "The editor is not accessible..." [ref=e51]
+
+# Type directly using the ref — handles focus automatically
+agent-browser type @e51 "Hello from George!"
+
+# Send the message
+agent-browser press Enter
+
+# Wait for the response to complete before re-snapshotting.
+# Poll until the "Stop generating" button disappears:
+for i in $(seq 1 30); do
+  agent-browser snapshot -i 2>/dev/null | grep -q "Stop generating" || break
+  sleep 1
+done
+agent-browser snapshot -i
+```
+
+This is the simplest and most reliable method. It works for both the main editor chat input and the sidebar chat panel.
+
+#### `keyboard type` / `keyboard inserttext` — After Focus
+
+If focus is already on a Monaco editor, `keyboard type` and `keyboard inserttext` both work:
+
+```bash
+# Focus first (via type @ref, or JS mouse events, or a prior interaction)
+agent-browser type @e51 ""
+# Then keyboard type works for subsequent input
+agent-browser keyboard type "More text here"
+agent-browser keyboard inserttext "And this too"
+```
+
+#### `press` — Individual Keystrokes
+
+Always works when focus is on a Monaco editor. Useful for special keys, keyboard shortcuts, and as a universal fallback for typing text character by character:
+
+```bash
+# Type text character by character (works on all builds)
+agent-browser press H
+agent-browser press e
+agent-browser press l
+agent-browser press l
+agent-browser press o
+agent-browser press Space  # Use "Space" for spaces
+
+# Select all
+# macOS:
+agent-browser press Meta+a
+# Linux / Windows:
+agent-browser press Control+a
+
+agent-browser press Backspace    # Delete selection
+agent-browser press Enter        # Send message / new line
+
+# Send to new chat
+# macOS:
+agent-browser press Meta+Shift+Enter
+# Linux / Windows:
+agent-browser press Control+Shift+Enter
+```
+
+### What Does NOT Work
+
+| Method | Result | Reason |
+|--------|--------|--------|
+| `click @ref` | "Element blocked by another element" | Monaco overlays a transparent div over the textarea |
+| `fill @ref "text"` | "Element not found or not visible" | The textbox is not a standard fillable input |
+| `document.execCommand("insertText")` via `eval` | No effect | Monaco intercepts and discards execCommand |
+| Setting `textarea.value` + dispatching `input` event via `eval` | No effect | Monaco doesn't read from the textarea's value property |
+
+### Fallback: Focus via JavaScript Mouse Events
+
+If `type @ref` doesn't work (e.g., ref is stale), you can focus the editor via JavaScript:
+
+```bash
+agent-browser eval '
+(() => {
+  const inputPart = document.querySelector(".interactive-input-part");
+  const editor = inputPart.querySelector(".monaco-editor");
+  const rect = editor.getBoundingClientRect();
+  const x = rect.x + rect.width / 2;
+  const y = rect.y + rect.height / 2;
+  editor.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: x, clientY: y }));
+  editor.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: x, clientY: y }));
+  editor.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: x, clientY: y }));
+  return "activeElement: " + document.activeElement?.className;
+})()'
+
+# After JS focus, keyboard type and press work
+agent-browser keyboard type "Text after JS focus"
+```
+
+After JS mouse events, `document.activeElement` becomes a `DIV` with class `native-edit-context` — this is VS Code's native text editing surface.
+
+### Verifying Text in Monaco
+
+Monaco renders text in `.view-line` elements, not the textarea:
+
+```bash
+agent-browser eval '
+(() => {
+  const inputPart = document.querySelector(".interactive-input-part");
+  return Array.from(inputPart.querySelectorAll(".view-line")).map(vl => vl.textContent).join("|");
+})()'
+```
+
+### Clearing Monaco Input
+
+```bash
+# macOS:
+agent-browser press Meta+a
+# Linux / Windows:
+agent-browser press Control+a
+
+agent-browser press Backspace
+```
+
+## Troubleshooting
+
+### "Connection refused" or "Cannot connect"
+
+- Make sure VS Code Insiders was launched with `--remote-debugging-port=9223`
+- If VS Code was already running, quit and relaunch with the flag
+- Check that the port isn't in use by another process:
+  - macOS / Linux: `lsof -i :9223`
+  - Windows: `netstat -ano | findstr 9223`
+
+### Elements not appearing in snapshot
+
+- VS Code uses multiple webviews. Use `agent-browser tab` to list targets and switch to the right one
+- Use `agent-browser snapshot -i -C` to include cursor-interactive elements (divs with onclick handlers)
+
+### Cannot type in Monaco inputs
+
+- Standard `click` and `fill` don't work on Monaco editors — see the "Interacting with Monaco Editor" section above for the full compatibility matrix
+- `type @ref` is the best approach; individual `press` commands work everywhere; `keyboard type` and `keyboard inserttext` work after focus is established
+
+### Screenshots fail with "Permission denied" (macOS)
+
+If `agent-browser screenshot` returns "Permission denied", your terminal needs Screen Recording permission. Grant it in **System Settings → Privacy & Security → Screen Recording**. As a fallback, use the `eval` verification snippet to confirm text was entered — this doesn't require screen permissions.
+
+## Cleanup / Disconnect
+
+```bash
+# Disconnect agent-browser from the current session
+agent-browser close
+
+# The VS Code instance continues running
+```
+
+To fully stop, quit VS Code separately (e.g., `Cmd+Q` / `Alt+F4`, or kill the process).

--- a/.claude/skills/launch
+++ b/.claude/skills/launch
@@ -1,0 +1,1 @@
+../../.agents/skills/launch

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
 				"@vscode/test-electron": "^2.5.2",
 				"@vscode/test-web": "^0.0.71",
 				"@vscode/vsce": "3.6.0",
+				"agent-browser": "^0.16.3",
 				"copyfiles": "^2.4.1",
 				"csv-parse": "^6.0.0",
 				"dotenv": "^17.2.0",
@@ -223,6 +224,37 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/@appium/logger": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@appium/logger/-/logger-1.7.1.tgz",
+			"integrity": "sha512-9C2o9X/lBEDBUnKfAi3mRo9oG7Z03nmISLwsGkWxIWjMAvBdJD0RRSJMekWVKzfXN3byrI1WlCXTITzN4LAoLw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"console-control-strings": "1.1.0",
+				"lodash": "4.17.21",
+				"lru-cache": "10.4.3",
+				"set-blocking": "2.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+				"npm": ">=8"
+			}
+		},
+		"node_modules/@appium/logger/node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@appium/logger/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/@azu/format-text": {
 			"version": "1.0.2",
@@ -5310,6 +5342,26 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@promptbook/utils": {
+			"version": "0.69.5",
+			"resolved": "https://registry.npmjs.org/@promptbook/utils/-/utils-0.69.5.tgz",
+			"integrity": "sha512-xm5Ti/Hp3o4xHrsK9Yy3MS6KbDxYbq485hDsFvxqaNA7equHLPdo8H8faTitTeb14QCDfLW4iwCxdVYu5sn6YQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://buymeacoffee.com/hejny"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/webgptorg/promptbook/blob/main/README.md#%EF%B8%8F-contributing"
+				}
+			],
+			"license": "CC-BY-4.0",
+			"dependencies": {
+				"spacetrim": "0.11.59"
+			}
+		},
 		"node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -5373,6 +5425,56 @@
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
 			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/@puppeteer/browsers": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+			"integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"extract-zip": "^2.0.1",
+				"progress": "^2.0.3",
+				"proxy-agent": "^6.5.0",
+				"semver": "^7.7.4",
+				"tar-fs": "^3.1.1",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"browsers": "lib/cjs/main-cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/tar-fs": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+			"integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0",
+				"tar-stream": "^3.1.5"
+			},
+			"optionalDependencies": {
+				"bare-fs": "^4.0.1",
+				"bare-path": "^3.0.0"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/tar-stream": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+			"integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"bare-fs": "^4.5.5",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
+			}
 		},
 		"node_modules/@rollup/plugin-virtual": {
 			"version": "3.0.2",
@@ -6395,6 +6497,13 @@
 				"@textlint/ast-node-types": "14.8.4"
 			}
 		},
+		"node_modules/@tootallnate/quickjs-emscripten": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -6731,10 +6840,11 @@
 			}
 		},
 		"node_modules/@types/sinonjs__fake-timers": {
-			"version": "8.1.3",
-			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.3.tgz",
-			"integrity": "sha512-4g+2YyWe0Ve+LBh+WUm1697PD0Kdi6coG1eU0YjQbwx61AZ8XbEpL1zIT6WjuUKrCMCROpEaYQPDjBnDouBVAQ==",
-			"dev": true
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+			"integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/source-map-support": {
 			"version": "0.5.10",
@@ -6799,6 +6909,23 @@
 			"integrity": "sha512-iBAUYNYkz+uk1kdsq05fEcoh8gJmwT3lqqFPN7MGyjQ3HVloViMdo7ZJ8DFIP8WOK74PjOEilosqAyxV2iUFUw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/ws": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.33",
@@ -8063,11 +8190,291 @@
 				"react": ">=16.9.0"
 			}
 		},
+		"node_modules/@wdio/config": {
+			"version": "9.24.0",
+			"resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.24.0.tgz",
+			"integrity": "sha512-rcHu0eG16rSEmHL0sEKDcr/vYFmGhQ5GOlmlx54r+1sgh6sf136q+kth4169s16XqviWGW3LjZbUfpTK29pGtw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@wdio/logger": "9.18.0",
+				"@wdio/types": "9.24.0",
+				"@wdio/utils": "9.24.0",
+				"deepmerge-ts": "^7.0.3",
+				"glob": "^10.2.2",
+				"import-meta-resolve": "^4.0.0",
+				"jiti": "^2.6.1"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/config/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@wdio/config/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@wdio/config/node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/@wdio/config/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@wdio/config/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@wdio/config/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/@wdio/config/node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@wdio/logger": {
+			"version": "9.18.0",
+			"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+			"integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.1.2",
+				"loglevel": "^1.6.0",
+				"loglevel-plugin-prefix": "^0.8.4",
+				"safe-regex2": "^5.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/logger/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@wdio/logger/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@wdio/logger/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@wdio/protocols": {
+			"version": "9.24.0",
+			"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.24.0.tgz",
+			"integrity": "sha512-ozQKYddBLT4TRvU9J+fGrhVUtx3iDAe+KNCJcTDMFMxNSdDMR2xFQdNp8HLHypspk58oXTYCvz6ZYjySthhqsw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wdio/repl": {
+			"version": "9.16.2",
+			"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.16.2.tgz",
+			"integrity": "sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^20.1.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/repl/node_modules/@types/node": {
+			"version": "20.19.35",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+			"integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@wdio/types": {
+			"version": "9.24.0",
+			"resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.24.0.tgz",
+			"integrity": "sha512-PYYunNl8Uq1r8YMJAK6ReRy/V/XIrCSyj5cpCtR5EqCL6heETOORFj7gt4uPnzidfgbtMBcCru0LgjjlMiH1UQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^20.1.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/types/node_modules/@types/node": {
+			"version": "20.19.35",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+			"integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@wdio/utils": {
+			"version": "9.24.0",
+			"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.24.0.tgz",
+			"integrity": "sha512-6WhtzC5SNCGRBTkaObX6A07Ofnnyyf+TQH/d/fuhZRqvBknrP4AMMZF+PFxGl1fwdySWdBn+gV2QLE+52Byowg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@puppeteer/browsers": "^2.2.0",
+				"@wdio/logger": "9.18.0",
+				"@wdio/types": "9.24.0",
+				"decamelize": "^6.0.0",
+				"deepmerge-ts": "^7.0.3",
+				"edgedriver": "^6.1.2",
+				"geckodriver": "^6.1.0",
+				"get-port": "^7.0.0",
+				"import-meta-resolve": "^4.0.0",
+				"locate-app": "^2.2.24",
+				"mitt": "^3.0.1",
+				"safaridriver": "^1.0.0",
+				"split2": "^4.2.0",
+				"wait-port": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/utils/node_modules/decamelize": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+			"integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@xterm/headless": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-5.5.0.tgz",
 			"integrity": "sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g==",
 			"license": "MIT"
+		},
+		"node_modules/@zip.js/zip.js": {
+			"version": "2.8.22",
+			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.22.tgz",
+			"integrity": "sha512-0KlzbVR6r8irIX2o3zvUlosBDef62VDl47oUfa1U/qgEs67h4/eGBrX/6HWa1RQbt+J6sAeVmtyFKbTHNdF8qQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"bun": ">=0.7.0",
+				"deno": ">=1.0.0",
+				"node": ">=18.0.0"
+			}
 		},
 		"node_modules/abbrev": {
 			"version": "2.0.0",
@@ -8078,6 +8485,19 @@
 			"optional": true,
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
 			}
 		},
 		"node_modules/accepts": {
@@ -8130,6 +8550,37 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/agent-browser": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/agent-browser/-/agent-browser-0.16.3.tgz",
+			"integrity": "sha512-dsg8PTJNBIQ7/LPp/La42KQwLTzsP8sudbCLpP1atsJXps4Fbuz1CeepUJAGrgxb8koc9y4yKobYVPAsds8hPQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"node-simctl": "^7.4.0",
+				"playwright-core": "^1.57.0",
+				"webdriverio": "^9.15.0",
+				"ws": "^8.19.0",
+				"zod": "^3.22.4"
+			},
+			"bin": {
+				"agent-browser": "bin/agent-browser.js"
+			}
+		},
+		"node_modules/agent-browser/node_modules/playwright-core": {
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/aggregate-error": {
@@ -8290,6 +8741,249 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/archiver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+			"integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"archiver-utils": "^5.0.2",
+				"async": "^3.2.4",
+				"buffer-crc32": "^1.0.0",
+				"readable-stream": "^4.0.0",
+				"readdir-glob": "^1.1.2",
+				"tar-stream": "^3.0.0",
+				"zip-stream": "^6.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/archiver-utils": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+			"integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"glob": "^10.0.0",
+				"graceful-fs": "^4.2.0",
+				"is-stream": "^2.0.1",
+				"lazystream": "^1.0.0",
+				"lodash": "^4.17.15",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/archiver-utils/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/archiver/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/archiver/node_modules/buffer-crc32": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+			"integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/archiver/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/archiver/node_modules/tar-stream": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+			"integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"bare-fs": "^4.5.5",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
+			}
+		},
 		"node_modules/are-docs-informative": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
@@ -8303,6 +8997,16 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+		},
+		"node_modules/aria-query": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/array-buffer-byte-length": {
 			"version": "1.0.2",
@@ -8436,6 +9140,19 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/ast-types": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/ast-v8-to-istanbul": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.3.tgz",
@@ -8464,6 +9181,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/async": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/async-function": {
 			"version": "1.0.0",
@@ -8504,6 +9228,21 @@
 			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"bin": {
 				"semver": "bin/semver"
+			}
+		},
+		"node_modules/asyncbox": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-3.0.0.tgz",
+			"integrity": "sha512-X7U0nedUMKV3nn9c4R0Zgvdvv6cw97tbDlHSZicq1snGPi/oX9DgGmFSURWtxDdnBWd3V0YviKhqAYAVvoWQ/A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bluebird": "^3.5.1",
+				"lodash": "^4.17.4",
+				"source-map-support": "^0.x"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/asynckit": {
@@ -8558,20 +9297,20 @@
 			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.0.tgz",
 			"integrity": "sha512-EKZ5BTXYExaNqi3I3f9RtEsaI/xBSGjE0XZCZilPzFAV/goswFHuPd9jEZlPIZ/iNZJwDSao9qRiScySz7MbQg==",
 			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true
+			"license": "Apache-2.0"
 		},
 		"node_modules/bare-fs": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.6.tgz",
-			"integrity": "sha512-25RsLF33BqooOEFNdMcEhMpJy8EoR88zSMrnOQOaM3USnOK2VmaJ1uaQEwPA6AQjrv1lXChScosN6CzbwbO9OQ==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
+			"integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"dependencies": {
 				"bare-events": "^2.5.4",
 				"bare-path": "^3.0.0",
-				"bare-stream": "^2.6.4"
+				"bare-stream": "^2.6.4",
+				"bare-url": "^2.2.2",
+				"fast-fifo": "^1.3.2"
 			},
 			"engines": {
 				"bare": ">=1.16.0"
@@ -8591,7 +9330,6 @@
 			"integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"engines": {
 				"bare": ">=1.14.0"
 			}
@@ -8602,7 +9340,6 @@
 			"integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"dependencies": {
 				"bare-os": "^3.0.1"
 			}
@@ -8613,7 +9350,6 @@
 			"integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"dependencies": {
 				"streamx": "^2.21.0"
 			},
@@ -8628,6 +9364,16 @@
 				"bare-events": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/bare-url": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+			"integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-path": "^3.0.0"
 			}
 		},
 		"node_modules/base64-js": {
@@ -8660,6 +9406,16 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/basic-ftp": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+			"integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/best-effort-json-parser": {
@@ -8740,6 +9496,13 @@
 			"engines": {
 				"node": ">= 6"
 			}
+		},
+		"node_modules/bluebird": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/body-parser": {
 			"version": "2.2.2",
@@ -9727,11 +10490,77 @@
 				"node": ">= 12.0.0"
 			}
 		},
+		"node_modules/compress-commons": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+			"integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"crc-32": "^1.2.0",
+				"crc32-stream": "^6.0.0",
+				"is-stream": "^2.0.1",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/compress-commons/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/compress-commons/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
+		},
+		"node_modules/console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/content-disposition": {
 			"version": "1.0.1",
@@ -9971,6 +10800,75 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/crc-32": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"crc32": "bin/crc32.njs"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/crc32-stream": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+			"integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"crc-32": "^1.2.0",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/crc32-stream/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/crc32-stream/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -10010,6 +10908,19 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
+		"node_modules/css-shorthand-properties": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.2.tgz",
+			"integrity": "sha512-C2AugXIpRGQTxaCW0N7n5jD/p5irUmCrwl03TrnMFBHDbdq44CFWR2zO7rK9xPN4Eo3pUxC4vQzQgbIpzrD1PQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/css-value": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
+			"integrity": "sha512-FUV3xaJ63buRLgHrLQVlVgQnQdR4yqdLGaDu7g8CQcWjInDfM9plBTPI9FRfpahju1UBSaMckeb2/46ApS/V1Q==",
+			"dev": true
+		},
 		"node_modules/css-what": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -10035,6 +10946,16 @@
 			"integrity": "sha512-6aB9WrymEruVDwQOwa5AuYk4/Gb+HaJgLHGKOA9BXTqgsIFvbdHzQzZOuqNCOooTGciPDaHzTlGkU5P6kYVUYw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
 		},
 		"node_modules/data-view-buffer": {
 			"version": "1.0.2",
@@ -10178,6 +11099,16 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
+		"node_modules/deepmerge-ts": {
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+			"integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/default-browser": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
@@ -10260,6 +11191,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/degenerator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/delayed-stream": {
@@ -10470,6 +11416,86 @@
 			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/edge-paths": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
+			"integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/which": "^2.0.1",
+				"which": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/shirshak55"
+			}
+		},
+		"node_modules/edgedriver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.3.0.tgz",
+			"integrity": "sha512-ggEQL+oEyIcM4nP2QC3AtCQ04o4kDNefRM3hja0odvlPSnsaxiruMxEZ93v3gDCKWYW6BXUr51PPradb+3nffw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"@wdio/logger": "^9.18.0",
+				"@zip.js/zip.js": "^2.8.11",
+				"decamelize": "^6.0.1",
+				"edge-paths": "^3.0.5",
+				"fast-xml-parser": "^5.3.3",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
+				"which": "^6.0.0"
+			},
+			"bin": {
+				"edgedriver": "bin/edgedriver.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/edgedriver/node_modules/decamelize": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+			"integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/edgedriver/node_modules/isexe": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+			"integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/edgedriver/node_modules/which": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+			"integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^4.0.0"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/editions": {
@@ -10918,6 +11944,28 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
 			}
 		},
 		"node_modules/eslint": {
@@ -11429,12 +12477,32 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/eventemitter3": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
 			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.x"
+			}
 		},
 		"node_modules/eventsource": {
 			"version": "3.0.7",
@@ -11711,6 +12779,39 @@
 				}
 			],
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+			"integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.2.tgz",
+			"integrity": "sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"fast-xml-builder": "^1.0.0",
+				"strnum": "^2.1.2"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
 		},
 		"node_modules/fastq": {
 			"version": "1.19.1",
@@ -12073,6 +13174,41 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/geckodriver": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.0.tgz",
+			"integrity": "sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"@wdio/logger": "^9.18.0",
+				"@zip.js/zip.js": "^2.8.11",
+				"decamelize": "^6.0.1",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
+				"modern-tar": "^0.7.2"
+			},
+			"bin": {
+				"geckodriver": "bin/geckodriver.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/geckodriver/node_modules/decamelize": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+			"integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -12116,6 +13252,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-port": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+			"integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-proto": {
@@ -12175,6 +13324,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
+		"node_modules/get-uri": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"basic-ftp": "^5.0.2",
+				"data-uri-to-buffer": "^6.0.2",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/github-from-package": {
@@ -12367,6 +13531,13 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true
 		},
+		"node_modules/grapheme-splitter": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -12541,6 +13712,13 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/htmlfy": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.8.1.tgz",
+			"integrity": "sha512-xWROBw9+MEGwxpotll0h672KCaLrKKiCYzsyN8ZgL9cQbVumFnyvsk2JqiB9ELAV1GLj1GG/jxZUjV9OZZi/yQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12770,6 +13948,17 @@
 				"module-details-from-path": "^1.0.3"
 			}
 		},
+		"node_modules/import-meta-resolve": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -12832,7 +14021,6 @@
 			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": ">= 12"
 			}
@@ -13528,6 +14716,16 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/jiti": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
 		"node_modules/jose": {
 			"version": "6.1.3",
 			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -13953,6 +15151,19 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/lazystream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+			"integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "^2.0.5"
+			},
+			"engines": {
+				"node": ">= 0.6.3"
+			}
+		},
 		"node_modules/leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -14339,6 +15550,28 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/locate-app": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.5.0.tgz",
+			"integrity": "sha512-xIqbzPMBYArJRmPGUZD9CzV9wOqmVtQnaAn3wrj3s6WYW0bQvPI7x+sPYUGmDTYMHefVK//zc6HEYZ1qnxIK+Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://buymeacoffee.com/hejny"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/hejny/locate-app/blob/main/README.md#%EF%B8%8F-contributing"
+				}
+			],
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@promptbook/utils": "0.69.5",
+				"type-fest": "4.26.0",
+				"userhome": "1.0.1"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -14365,6 +15598,13 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.includes": {
@@ -14426,6 +15666,13 @@
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
 			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.zip": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+			"integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -14582,6 +15829,27 @@
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
+		},
+		"node_modules/loglevel": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+			"integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			},
+			"funding": {
+				"type": "tidelift",
+				"url": "https://tidelift.com/funding/github/npm/loglevel"
+			}
+		},
+		"node_modules/loglevel-plugin-prefix": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+			"integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/long": {
 			"version": "5.3.2",
@@ -15100,6 +16368,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/mitt": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+			"integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/mkdirp": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -15394,6 +16669,16 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/modern-tar": {
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.5.tgz",
+			"integrity": "sha512-YTefgdpKKFgoTDbEUqXqgUJct2OG6/4hs4XWLsxcHkDLj/x/V8WmKIRppPnXP5feQ7d1vuYWSp3qKkxfwaFaxA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/module-details-from-path": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
@@ -15520,6 +16805,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/netmask": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4.0"
 			}
 		},
 		"node_modules/nice-try": {
@@ -15807,6 +17102,183 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/node-simctl": {
+			"version": "7.7.5",
+			"resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-7.7.5.tgz",
+			"integrity": "sha512-lWflzDW9xLuOOvR6mTJ9efbDtO/iSCH6rEGjxFxTV0vGgz5XjoZlW2BkNCCZib0B6Y23tCOiYhYJaMQYB8FKIQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@appium/logger": "^1.3.0",
+				"asyncbox": "^3.0.0",
+				"bluebird": "^3.5.1",
+				"lodash": "^4.2.1",
+				"rimraf": "^5.0.0",
+				"semver": "^7.0.0",
+				"source-map-support": "^0.x",
+				"teen_process": "^2.2.0",
+				"uuid": "^11.0.1",
+				"which": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">=8"
+			}
+		},
+		"node_modules/node-simctl/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/node-simctl/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/node-simctl/node_modules/isexe": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/node-simctl/node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/node-simctl/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/node-simctl/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/node-simctl/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/node-simctl/node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/node-simctl/node_modules/rimraf": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/node-simctl/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
+		"node_modules/node-simctl/node_modules/which": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^3.1.1"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/noms": {
@@ -16523,6 +17995,40 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/pac-proxy-agent": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tootallnate/quickjs-emscripten": "^0.23.0",
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"get-uri": "^6.0.1",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.6",
+				"pac-resolver": "^7.0.1",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/pac-resolver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"degenerator": "^5.0.0",
+				"netmask": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
@@ -17013,6 +18519,16 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -17112,6 +18628,43 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/proxy-agent": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "^7.0.1",
+				"https-proxy-agent": "^7.0.6",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "^7.1.0",
+				"proxy-from-env": "^1.1.0",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -17183,6 +18736,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/query-selector-shadow-dom": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+			"integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -17419,6 +18979,39 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
+		"node_modules/readdir-glob": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+			"integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"minimatch": "^5.1.0"
+			}
+		},
+		"node_modules/readdir-glob/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/readdir-glob/node_modules/minimatch": {
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -17636,6 +19229,23 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/resq": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/resq/-/resq-1.11.0.tgz",
+			"integrity": "sha512-G10EBz+zAAy3zUd/CDoBbXRL6ia9kOo3xRHrMDsHljI0GDkhYlyjwoCx5+3eCC4swi1uCoZQhskuJkj7Gp57Bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^2.0.1"
+			}
+		},
+		"node_modules/resq/node_modules/fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/restore-cursor": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -17651,6 +19261,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ret": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+			"integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/retry": {
@@ -17678,6 +19298,13 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
 			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/rgb2hex": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.5.tgz",
+			"integrity": "sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -17845,6 +19472,16 @@
 				"run-script-os": "index.js"
 			}
 		},
+		"node_modules/safaridriver": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.1.tgz",
+			"integrity": "sha512-jkg4434cYgtrIF2AeY/X0Wmd2W73cK5qIEFE3hDrrQenJH/2SDJIXGvPAigfvQTcE9+H31zkiNHbUqcihEiMRA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/safe-array-concat": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -17917,6 +19554,26 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-regex2": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
+			"integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"ret": "~0.5.0"
 			}
 		},
 		"node_modules/safer-buffer": {
@@ -18031,9 +19688,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -18166,6 +19823,13 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
 			}
+		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
@@ -18487,7 +20151,6 @@
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
@@ -18499,7 +20162,6 @@
 			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"ip-address": "^10.0.1",
 				"smart-buffer": "^4.2.0"
@@ -18515,7 +20177,6 @@
 			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"agent-base": "^7.1.2",
 				"debug": "^4.3.4",
@@ -18553,6 +20214,23 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"node_modules/spacetrim": {
+			"version": "0.11.59",
+			"resolved": "https://registry.npmjs.org/spacetrim/-/spacetrim-0.11.59.tgz",
+			"integrity": "sha512-lLYsktklSRKprreOm7NXReW8YiX2VBjbgmXYEziOoGf/qsJqAEACaDvoTtUOycwjpaSh+bT8eu0KrJn7UNxiCg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://buymeacoffee.com/hejny"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/hejny/spacetrim/blob/main/README.md#%EF%B8%8F-contributing"
+				}
+			],
+			"license": "Apache-2.0"
+		},
 		"node_modules/spdx-correct": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -18584,6 +20262,16 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
 			"integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
 			"dev": true
+		},
+		"node_modules/split2": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 10.x"
+			}
 		},
 		"node_modules/sprintf-js": {
 			"version": "1.1.3",
@@ -19004,6 +20692,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/strnum": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+			"integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/structured-source": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
@@ -19293,6 +20994,23 @@
 			"version": "0.2.33",
 			"resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.2.33.tgz",
 			"integrity": "sha512-V+uqV66BOQnWxvI6HjDnE4VkInmYZUQ4dgB7gzaDyFyFSK1i1nF/j7DpS9UbQAgV9NaF1XpcyuavnM1qOeiEIg=="
+		},
+		"node_modules/teen_process": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.3.3.tgz",
+			"integrity": "sha512-NIdeetf/6gyEqLjnzvfgQe7PfipSceq2xDQM2Py2BkBnIIeWh3HRD3vNhulyO5WppfCv9z4mtsEHyq8kdiULTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bluebird": "^3.7.2",
+				"lodash": "^4.17.21",
+				"shell-quote": "^1.8.1",
+				"source-map-support": "^0.x"
+			},
+			"engines": {
+				"node": "^16.13.0 || >=18.0.0",
+				"npm": ">=8"
+			}
 		},
 		"node_modules/terminal-link": {
 			"version": "2.1.1",
@@ -19714,6 +21432,19 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/type-fest": {
+			"version": "4.26.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
+			"integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/type-is": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -20059,6 +21790,13 @@
 			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
 			"dev": true
 		},
+		"node_modules/urlpattern-polyfill": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+			"integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/use-disposable": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/use-disposable/-/use-disposable-1.0.4.tgz",
@@ -20080,6 +21818,16 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/userhome": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.1.tgz",
+			"integrity": "sha512-5cnLm4gseXjAclKowC4IjByaGsjtAoV6PrOQOljplNB54ReUYJP8HdAFq2muHinSDAh09PPX/uXDPfdxRHvuSA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -20437,11 +22185,179 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/wait-port": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
+			"integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"commander": "^9.3.0",
+				"debug": "^4.3.4"
+			},
+			"bin": {
+				"wait-port": "bin/wait-port.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/wait-port/node_modules/commander": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || >=14"
+			}
+		},
 		"node_modules/web-tree-sitter": {
 			"version": "0.23.2",
 			"resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.23.2.tgz",
 			"integrity": "sha512-BMZtm7sKtnmTGO7L4pcFOBidVlBxL+aUxm0O5yr3nKf5Fqz8RyvTOSjWFtqmzScyak/YFq9f5PSMRdhg2WXAJQ==",
 			"license": "MIT"
+		},
+		"node_modules/webdriver": {
+			"version": "9.24.0",
+			"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.24.0.tgz",
+			"integrity": "sha512-2R31Ey83NzMsafkl4hdFq6GlIBvOODQMkueLjeRqYAITu3QCYiq9oqBdnWA6CdePuV4dbKlYsKRX0mwMiPclDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^20.1.0",
+				"@types/ws": "^8.5.3",
+				"@wdio/config": "9.24.0",
+				"@wdio/logger": "9.18.0",
+				"@wdio/protocols": "9.24.0",
+				"@wdio/types": "9.24.0",
+				"@wdio/utils": "9.24.0",
+				"deepmerge-ts": "^7.0.3",
+				"https-proxy-agent": "^7.0.6",
+				"undici": "^6.21.3",
+				"ws": "^8.8.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/webdriver/node_modules/@types/node": {
+			"version": "20.19.35",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+			"integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/webdriver/node_modules/undici": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+			"integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
+			}
+		},
+		"node_modules/webdriverio": {
+			"version": "9.24.0",
+			"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.24.0.tgz",
+			"integrity": "sha512-LTJt6Z/iDM0ne/4ytd3BykoPv9CuJ+CAILOzlwFeMGn4Mj02i4Bk2Rg9o/jeJ89f52hnv4OPmNjD0e8nzWAy5g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^20.11.30",
+				"@types/sinonjs__fake-timers": "^8.1.5",
+				"@wdio/config": "9.24.0",
+				"@wdio/logger": "9.18.0",
+				"@wdio/protocols": "9.24.0",
+				"@wdio/repl": "9.16.2",
+				"@wdio/types": "9.24.0",
+				"@wdio/utils": "9.24.0",
+				"archiver": "^7.0.1",
+				"aria-query": "^5.3.0",
+				"cheerio": "^1.0.0-rc.12",
+				"css-shorthand-properties": "^1.1.1",
+				"css-value": "^0.0.1",
+				"grapheme-splitter": "^1.0.4",
+				"htmlfy": "^0.8.1",
+				"is-plain-obj": "^4.1.0",
+				"jszip": "^3.10.1",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.zip": "^4.2.0",
+				"query-selector-shadow-dom": "^1.0.1",
+				"resq": "^1.11.0",
+				"rgb2hex": "0.2.5",
+				"serialize-error": "^12.0.0",
+				"urlpattern-polyfill": "^10.0.0",
+				"webdriver": "9.24.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			},
+			"peerDependencies": {
+				"puppeteer-core": ">=22.x || <=24.x"
+			},
+			"peerDependenciesMeta": {
+				"puppeteer-core": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/webdriverio/node_modules/@types/node": {
+			"version": "20.19.35",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+			"integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/webdriverio/node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/webdriverio/node_modules/serialize-error": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-12.0.0.tgz",
+			"integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^4.31.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/webdriverio/node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
@@ -20710,9 +22626,9 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
 		"node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -20904,6 +22820,63 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zip-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+			"integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"archiver-utils": "^5.0.0",
+				"compress-commons": "^6.0.2",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/zip-stream/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/zip-stream/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -5952,6 +5952,7 @@
 		"@vscode/test-electron": "^2.5.2",
 		"@vscode/test-web": "^0.0.71",
 		"@vscode/vsce": "3.6.0",
+		"agent-browser": "^0.16.3",
 		"copyfiles": "^2.4.1",
 		"csv-parse": "^6.0.0",
 		"dotenv": "^17.2.0",


### PR DESCRIPTION
## Summary

Adds a new agent skill (`.agents/skills/launch/`) that teaches agents how to launch VS Code Insiders with the Copilot Chat extension for debugging and automate the UI using agent-browser.

## What's included

- **Launch skill** (`SKILL.md`) — how to build, launch with `--extensionDevelopmentPath`, connect agent-browser, and interact with the Copilot Chat UI
- **`agent-browser`** added to devDependencies
- **Symlink** in `.claude/skills/launch` for skill discovery

## Key content

- **Prerequisites** — `code-insiders` required (58 proposed APIs), extension must be compiled first
- **Launching** with `--extensionDevelopmentPath`, `--remote-debugging-port`, and `--user-data-dir`
- **Authentication warning** — fresh user-data-dir means no Copilot auth; use a persistent profile or sign in manually
- **Monaco Editor interaction** — `type @ref` works on Insiders (primary), `press` per key as universal fallback, compatibility matrix
- **Cross-platform** keyboard shortcuts (macOS, Linux, Windows) and Windows-friendly paths
- **Response polling** — wait for 'Stop generating' to disappear instead of magic sleep values
- **Troubleshooting** — connection issues, screenshot permissions, Monaco quirks

## How it was built

Hands-on experimentation: launched VS Code Insiders with the extension via CDP, connected agent-browser, tried every input method on the Chat panel's Monaco editor, documented what worked and what didn't. Then reviewed by agents, field-tested, and refined based on Copilot Code Review feedback.