### PR TITLE
Add image hard gate to bypass router for image requests

### DIFF
--- a/src/platform/endpoint/node/automodeService.ts
+++ b/src/platform/endpoint/node/automodeService.ts
@@ -195,7 +195,30 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 
 		// Only use router model for panel chat to avoid latency penalty in inline chat
 		const isPanelChat = !chatRequest?.location || chatRequest?.location === ChatLocation.Panel;
-		const usingRouterModel = isPanelChat && this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.AutoModeRouterUrl, this._expService) !== undefined;
+		const routerConfigured = isPanelChat && this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.AutoModeRouterUrl, this._expService) !== undefined;
+
+		// Image hard gate: if the request contains an image, bypass the router model
+		// entirely and use the heuristic-based path instead. The router is text-only
+		// and cannot reason about image content, so the vision-aware heuristic in
+		// _resolveWithoutRouterModel (which calls _applyVisionFallback) is the
+		// correct path for image requests.
+		const requestHasImage = hasImage(chatRequest);
+		const usingRouterModel = routerConfigured && !requestHasImage;
+
+		if (requestHasImage && routerConfigured) {
+			this._logService.trace('[AutomodeService] Image hard gate: bypassing router for image request, using heuristic path');
+			/* __GDPR__
+				"automode.imageHardGate" : {
+					"owner": "tyleonha",
+					"comment": "Reports when the image hard gate bypasses the router model for an image request",
+					"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The conversation ID of the request" }
+				}
+			*/
+			this._telemetryService.sendMSFTTelemetryEvent('automode.imageHardGate', {
+				conversationId: getConversationId(chatRequest),
+			});
+		}
+
 		if (usingRouterModel) {
 			return this._resolveWithRouterModel(chatRequest, knownEndpoints);
 		}

--- a/src/platform/endpoint/node/routerDecisionFetcher.ts
+++ b/src/platform/endpoint/node/routerDecisionFetcher.ts
@@ -57,7 +57,7 @@ export class RouterDecisionFetcher extends Disposable {
 		super();
 	}
 
-	async getRoutedModel(query: string, availableModels: string[], preferredModels: string[]): Promise<string> {
+	async getRoutedModel(query: string, availableModels: string[], preferredModels: string[], hasImage?: boolean): Promise<string> {
 		const routerApiUrl = this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.AutoModeRouterUrl, this._experimentationService);
 		if (!routerApiUrl) {
 			throw new Error('Router API URL not configured');
@@ -83,7 +83,7 @@ export class RouterDecisionFetcher extends Disposable {
 					method: 'POST',
 					headers,
 					retryFallbacks: true,
-					body: JSON.stringify({ prompt: query, available_models: availableModels, preferred_models: preferredModels })
+					body: JSON.stringify({ prompt: query, available_models: availableModels, preferred_models: preferredModels, ...(hasImage ? { has_image: true } : {}) })
 				});
 			} catch (error) {
 				// Network error - retry

--- a/src/platform/endpoint/node/test/routerDecisionFetcher.spec.ts
+++ b/src/platform/endpoint/node/test/routerDecisionFetcher.spec.ts
@@ -153,6 +153,34 @@ describe('RouterDecisionFetcher', () => {
 			expect(authService.getCopilotToken).not.toHaveBeenCalled();
 		});
 
+		it('should send has_image flag when provided', async () => {
+			(configurationService as InMemoryConfigurationService).setConfig(
+				ConfigKey.TeamInternal.AutoModeRouterUrl,
+				'https://router.example.com/api'
+			);
+			mockFetch.mockResolvedValue(createFakeResponse(200, createValidRouterResponse()));
+
+			await routerDecisionFetcher.getRoutedModel('query', ['gpt-4o'], [], true);
+
+			const callArgs = mockFetch.mock.calls[0];
+			const body = JSON.parse(callArgs[1].body);
+			expect(body.has_image).toBe(true);
+		});
+
+		it('should not send has_image when not provided', async () => {
+			(configurationService as InMemoryConfigurationService).setConfig(
+				ConfigKey.TeamInternal.AutoModeRouterUrl,
+				'https://router.example.com/api'
+			);
+			mockFetch.mockResolvedValue(createFakeResponse(200, createValidRouterResponse()));
+
+			await routerDecisionFetcher.getRoutedModel('query', ['gpt-4o'], []);
+
+			const callArgs = mockFetch.mock.calls[0];
+			const body = JSON.parse(callArgs[1].body);
+			expect(body.has_image).toBeUndefined();
+		});
+
 		it('should log trace message with prediction details', async () => {
 			mockFetch.mockResolvedValue(createFakeResponse(200, createValidRouterResponse('gpt-4o')));
 


### PR DESCRIPTION
When a chat request contains an image attachment, bypass the model router entirely and use the heuristic-based path (_resolveWithoutRouterModel) which already handles vision-capable model selection via _applyVisionFallback.

The router model is text-only and cannot reason about image content, so sending image requests through the router would produce unreliable routing decisions. Instead, the existing vision fallback heuristic is the correct path.

Changes in automodeService.ts:
- Check hasImage(chatRequest) before deciding to use router
- When image detected and router configured, emit automode.imageHardGate telemetry event and fall through to heuristic path
- usingRouterModel = routerConfigured && !requestHasImage

Changes in routerDecisionFetcher.ts:
- Add optional hasImage parameter to getRoutedModel()
- Pass has_image: true in request body when set (defense-in-depth for server-side gating in auto-intent-service)

Tests:
- Add test: should send has_image flag when provided
- Add test: should not send has_image when not provided