### PR TITLE
Fix Gemini tool calling errors by stripping orphaned tool_calls without response

### DIFF
--- a/src/extension/intents/node/toolCallingLoop.ts
+++ b/src/extension/intents/node/toolCallingLoop.ts
@@ -1189,8 +1189,9 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 	 *
 	 * Returns the validated messages and an array of reasons for any corrections made.
 	 */
-	public static validateToolMessagesCore(messages: Raw.ChatMessage[], options?: { stripOrphanedToolCalls?: boolean }): { messages: Raw.ChatMessage[]; filterReasons: string[] } {
+	public static validateToolMessagesCore(messages: Raw.ChatMessage[], options?: { stripOrphanedToolCalls?: boolean }): { messages: Raw.ChatMessage[]; filterReasons: string[]; strippedToolCallCount: number } {
 		const filterReasons: string[] = [];
+		let strippedToolCallCount = 0;
 		let previousAssistantMessage: Raw.AssistantChatMessage | undefined;
 		const filtered = messages.filter(m => {
 			if (m.role === Raw.ChatRole.Assistant) {
@@ -1223,7 +1224,7 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 		// which strictly require every function_call to have a corresponding function_response.
 		// Gated behind stripOrphanedToolCalls to limit scope to models that need it.
 		if (!options?.stripOrphanedToolCalls) {
-			return { messages: filtered, filterReasons };
+			return { messages: filtered, filterReasons, strippedToolCallCount };
 		}
 
 		for (let i = 0; i < filtered.length; i++) {
@@ -1246,34 +1247,37 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 
 			const orphanedToolCalls = m.toolCalls.filter(tc => !toolResultIds.has(tc.id));
 			if (orphanedToolCalls.length > 0) {
-				filterReasons.push(`orphanedToolCalls:${orphanedToolCalls.length}`);
+				strippedToolCallCount += orphanedToolCalls.length;
 				const validToolCalls = m.toolCalls.filter(tc => toolResultIds.has(tc.id));
 				// Mutate in place — the assistant message was already shallow-copied by stripInternalToolCallIds
 				(m as Mutable<Raw.AssistantChatMessage>).toolCalls = validToolCalls.length > 0 ? validToolCalls : undefined;
 			}
 		}
 
-		return { messages: filtered, filterReasons };
+		return { messages: filtered, filterReasons, strippedToolCallCount };
 	}
 
 	private validateToolMessages(messages: Raw.ChatMessage[], options?: { stripOrphanedToolCalls?: boolean }): Raw.ChatMessage[] {
-		const { messages: filtered, filterReasons } = ToolCallingLoop.validateToolMessagesCore(messages, options);
+		const { messages: filtered, filterReasons, strippedToolCallCount } = ToolCallingLoop.validateToolMessagesCore(messages, options);
 
-		if (filterReasons.length) {
-			const filterReasonsStr = filterReasons.join(', ');
+		if (filterReasons.length || strippedToolCallCount > 0) {
+			const allReasons = strippedToolCallCount > 0 ? [...filterReasons, `orphanedToolCalls:${strippedToolCallCount}`] : filterReasons;
+			const filterReasonsStr = allReasons.join(', ');
 			this._logService.warn('Filtered invalid tool messages: ' + filterReasonsStr);
 			/* __GDPR__
 					"toolCalling.invalidToolMessages" : {
 						"owner": "roblourens",
 						"comment": "Provides info about invalid tool messages that were rendered in a prompt",
-						"filterReasons": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Reasons for filtering the messages." },
-						"filterCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Count of filtered messages." }
+						"filterReasons": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Reasons for filtering the messages and stripping orphaned tool calls." },
+						"filterCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Count of filtered messages." },
+						"strippedToolCallCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Count of orphaned tool_calls stripped from assistant messages." }
 					}
 				*/
 			this._telemetryService.sendMSFTTelemetryEvent('toolCalling.invalidToolMessages', {
 				filterReasons: filterReasonsStr,
 			}, {
-				filterCount: filterReasons.length
+				filterCount: filterReasons.length,
+				strippedToolCallCount,
 			});
 		}
 

--- a/src/extension/intents/test/node/validateToolMessages.spec.ts
+++ b/src/extension/intents/test/node/validateToolMessages.spec.ts
@@ -99,12 +99,13 @@ describe('validateToolMessagesCore', () => {
 			// tool results for '2' and '3' are missing
 		];
 
-		const { messages: result, filterReasons } = ToolCallingLoop.validateToolMessagesCore(messages, geminiOpts);
+		const { messages: result, filterReasons, strippedToolCallCount } = ToolCallingLoop.validateToolMessagesCore(messages, geminiOpts);
 		expect(result).toHaveLength(2);
 		const asstMsg = result[0] as Raw.AssistantChatMessage;
 		expect(asstMsg.toolCalls).toHaveLength(1);
 		expect(asstMsg.toolCalls![0].id).toBe('1');
-		expect(filterReasons).toContain('orphanedToolCalls:2');
+		expect(filterReasons).toHaveLength(0);
+		expect(strippedToolCallCount).toBe(2);
 	});
 
 	it('clears toolCalls entirely when no results exist for any tool_call', () => {
@@ -113,10 +114,11 @@ describe('validateToolMessagesCore', () => {
 			userMsg('next message'),
 		];
 
-		const { messages: result, filterReasons } = ToolCallingLoop.validateToolMessagesCore(messages, geminiOpts);
+		const { messages: result, filterReasons, strippedToolCallCount } = ToolCallingLoop.validateToolMessagesCore(messages, geminiOpts);
 		const asstMsg = result[0] as Raw.AssistantChatMessage;
 		expect(asstMsg.toolCalls).toBeUndefined();
-		expect(filterReasons).toContain('orphanedToolCalls:2');
+		expect(filterReasons).toHaveLength(0);
+		expect(strippedToolCallCount).toBe(2);
 	});
 
 	it('handles multiple assistant turns with mixed valid/orphaned tool_calls', () => {
@@ -131,7 +133,7 @@ describe('validateToolMessagesCore', () => {
 			// '4' is missing
 		];
 
-		const { messages: result, filterReasons } = ToolCallingLoop.validateToolMessagesCore(messages, geminiOpts);
+		const { messages: result, filterReasons, strippedToolCallCount } = ToolCallingLoop.validateToolMessagesCore(messages, geminiOpts);
 		expect(result).toHaveLength(5);
 
 		const round1Asst = result[0] as Raw.AssistantChatMessage;
@@ -140,7 +142,8 @@ describe('validateToolMessagesCore', () => {
 		const round2Asst = result[3] as Raw.AssistantChatMessage;
 		expect(round2Asst.toolCalls).toHaveLength(1);
 		expect(round2Asst.toolCalls![0].id).toBe('3');
-		expect(filterReasons).toContain('orphanedToolCalls:1');
+		expect(filterReasons).toHaveLength(0);
+		expect(strippedToolCallCount).toBe(1);
 	});
 
 	it('does not strip tool_calls when assistant has no toolCalls', () => {
@@ -178,11 +181,12 @@ describe('validateToolMessagesCore', () => {
 			// No tool results — tool call limit exceeded
 		];
 
-		const { messages: result, filterReasons } = ToolCallingLoop.validateToolMessagesCore(messages, geminiOpts);
+		const { messages: result, filterReasons, strippedToolCallCount } = ToolCallingLoop.validateToolMessagesCore(messages, geminiOpts);
 		expect(result).toHaveLength(4);
 		const lastAsst = result[3] as Raw.AssistantChatMessage;
 		expect(lastAsst.toolCalls).toBeUndefined();
-		expect(filterReasons).toContain('orphanedToolCalls:2');
+		expect(filterReasons).toHaveLength(0);
+		expect(strippedToolCallCount).toBe(2);
 	});
 
 	it('does not strip orphaned tool_calls when stripOrphanedToolCalls is not set', () => {
@@ -199,5 +203,45 @@ describe('validateToolMessagesCore', () => {
 		// tool_calls preserved — no stripping for non-Gemini models
 		expect(asstMsg.toolCalls).toHaveLength(2);
 		expect(filterReasons).toHaveLength(0);
+	});
+
+	it('matches tool results across an intervening user message', () => {
+		// Regression: Assistant(toolCalls) → User → Tool should still pair correctly
+		const messages: Raw.ChatMessage[] = [
+			assistantMsg('calling', [tc('1', 'readFile')]),
+			userMsg('some user message'),
+			toolMsg('1', 'result'),
+		];
+
+		// First-pass keeps the tool result (previousAssistantMessage is not reset by user messages)
+		const { messages: result, filterReasons } = ToolCallingLoop.validateToolMessagesCore(messages, geminiOpts);
+		expect(result).toHaveLength(3);
+		// Second-pass should NOT strip the tool_call — the result exists after the user message
+		const asstMsg = result[0] as Raw.AssistantChatMessage;
+		expect(asstMsg.toolCalls).toHaveLength(1);
+		expect(asstMsg.toolCalls![0].id).toBe('1');
+		expect(filterReasons).toHaveLength(0);
+	});
+
+	it('strips orphaned tool_calls when tool result is separated by a second assistant message', () => {
+		// Assistant(toolCalls) → User → Assistant → Tool should NOT pair across the second assistant
+		const messages: Raw.ChatMessage[] = [
+			assistantMsg('first', [tc('1', 'readFile')]),
+			userMsg('some user message'),
+			assistantMsg('second', [tc('2', 'listDir')]),
+			toolMsg('2', 'result for second'),
+		];
+
+		const { messages: result, filterReasons, strippedToolCallCount } = ToolCallingLoop.validateToolMessagesCore(messages, geminiOpts);
+		expect(result).toHaveLength(4);
+		// First assistant's tool_call '1' has no matching result — should be stripped
+		const firstAsst = result[0] as Raw.AssistantChatMessage;
+		expect(firstAsst.toolCalls).toBeUndefined();
+		// Second assistant's tool_call '2' is properly matched
+		const secondAsst = result[2] as Raw.AssistantChatMessage;
+		expect(secondAsst.toolCalls).toHaveLength(1);
+		expect(secondAsst.toolCalls![0].id).toBe('2');
+		expect(filterReasons).toHaveLength(0);
+		expect(strippedToolCallCount).toBe(1);
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/299295

Gemini models strictly require a 1:1 pairing between function_call and function_response messages. When our prompt rendering produces assistant messages with tool_calls that lack corresponding tool result messages (e.g., due to context window compaction or turn truncation), Gemini rejects the request.

**Changes**
- Add a second validation pass in validateToolMessages that detects orphaned tool_calls in assistant messages (those without a matching tool result message following them) and strips them out.
- Gate this new behavior behind a stripOrphanedToolCalls option, enabled only for Gemini models via isGeminiFamily(endpoint), so non-Gemini models are completely unaffected.
- Refactor validateToolMessages into a public static validateToolMessagesCore to enable unit testing of the validation logic independently

