### PR TITLE
Fix simulate task on Windows

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -123,6 +123,10 @@
 			"label": "simulate",
 			"type": "process",
 			"command": "${workspaceFolder}/script/simulate.sh",
+			"windows": {
+				"command": "powershell",
+				"args": ["-ExecutionPolicy", "Bypass", "-File", "${workspaceFolder}/script/simulate.ps1"]
+			},
 			"args": [],
 			"group": {
 				"kind": "test",


### PR DESCRIPTION
Fixes the `simulate` task on Windows.

Before the change I got this on my Windows machine when running the task: 
`*  The terminal process failed to launch: A native exception occurred during launch (Cannot create process, error code: 193).`

This was because it ran the `simulate.sh` instead of the `simulate.ps1` script.