### PR TITLE
calling centralize prompt API 

### DIFF
--- a/src/extension/tools/common/agentMemoryService.ts
+++ b/src/extension/tools/common/agentMemoryService.ts
@@ -23,7 +23,32 @@ export interface RepoMemoryEntry {
 	fact: string;
 	citations?: string | string[];
 	reason?: string;
-	category?: string;
+	category?: string; // Note: category is client-side only, not sent to sweagentd
+}
+
+/**
+ * Store instructions prompt from sweagentd /prompt endpoint.
+ */
+export interface StoreInstructionsPrompt {
+	prompt: string;
+	promptVersion: string;
+}
+
+/**
+ * Memories context prompt from sweagentd /prompt endpoint.
+ */
+export interface MemoriesContextPrompt {
+	prompt: string;
+	promptVersion: string;
+	memoriesCount: number;
+}
+
+/**
+ * Response from GET /prompt endpoint bundling store instructions and memories context.
+ */
+export interface MemoryPromptResponse {
+	storeInstructions: StoreInstructionsPrompt;
+	memoriesContext: MemoriesContextPrompt;
 }
 
 /**
@@ -100,6 +125,13 @@ export interface IAgentMemoryService {
 	 * Returns true if stored successfully, false if Copilot Memory is not enabled or if storing fails.
 	 */
 	storeRepoMemory(memory: RepoMemoryEntry): Promise<boolean>;
+
+	/**
+	 * Get memory prompts from Copilot Memory service.
+	 * Returns server-side prompts for store instructions and memories context.
+	 * Returns undefined if Copilot Memory is not enabled or if fetching fails.
+	 */
+	getMemoryPrompts(): Promise<MemoryPromptResponse | undefined>;
 }
 
 export const IAgentMemoryService = createServiceIdentifier<IAgentMemoryService>('IAgentMemoryService');
@@ -309,9 +341,10 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 					subject: memory.subject,
 					fact: memory.fact,
 					citations,
-					reason: memory.reason,
-					category: memory.category,
-					source: { agent: 'vscode' }
+					reason: memory.reason ?? '',
+					source: {
+						agent: 'vscode'
+					}
 				}
 			}, {
 				type: RequestType.CopilotAgentMemory,
@@ -328,6 +361,50 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 		} catch (error) {
 			this.logService.warn(`[AgentMemoryService] Failed to store repo memory: ${error}`);
 			return false;
+		}
+	}
+
+	async getMemoryPrompts(): Promise<MemoryPromptResponse | undefined> {
+		try {
+			const enabled = await this.checkMemoryEnabled();
+			if (!enabled) {
+				this.logService.debug('[AgentMemoryService] Copilot Memory not enabled, skipping prompt fetch');
+				return undefined;
+			}
+
+			const repoNwo = await this.getRepoNwo();
+			if (!repoNwo) {
+				return undefined;
+			}
+
+			const session = await this.authenticationService.getGitHubSession('any', { silent: true });
+			if (!session) {
+				this.logService.warn('[AgentMemoryService] No GitHub session available for fetching prompts');
+				return undefined;
+			}
+
+			const response = await this.capiClientService.makeRequest<Response>({
+				method: 'GET',
+				headers: {
+					'Authorization': `Bearer ${session.accessToken}`
+				}
+			}, {
+				type: RequestType.CopilotAgentMemory,
+				repo: repoNwo,
+				action: 'prompt'
+			});
+
+			if (!response.ok) {
+				this.logService.warn(`[AgentMemoryService] Failed to fetch prompts: ${response.statusText}`);
+				return undefined;
+			}
+
+			const data = await response.json() as MemoryPromptResponse;
+			this.logService.info(`[AgentMemoryService] Fetched memory prompts (${data.memoriesContext.memoriesCount} memories)`);
+			return data;
+		} catch (error) {
+			this.logService.warn(`[AgentMemoryService] Failed to fetch memory prompts: ${error}`);
+			return undefined;
 		}
 	}
 }

--- a/src/extension/tools/node/memoryContextPrompt.tsx
+++ b/src/extension/tools/node/memoryContextPrompt.tsx
@@ -12,7 +12,7 @@ import { IExperimentationService } from '../../../platform/telemetry/common/null
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
 import { URI } from '../../../util/vs/base/common/uri';
 import { Tag } from '../../prompts/node/base/tag';
-import { IAgentMemoryService, normalizeCitations, RepoMemoryEntry } from '../common/agentMemoryService';
+import { IAgentMemoryService } from '../common/agentMemoryService';
 import { ToolName } from '../common/toolNames';
 import { extractSessionId } from './memoryTool';
 
@@ -42,7 +42,7 @@ export class MemoryContextPrompt extends PromptElement<MemoryContextPromptProps>
 
 		const userMemoryContent = enableMemoryTool ? await this.getUserMemoryContent() : undefined;
 		const sessionMemoryFiles = enableMemoryTool ? await this.getSessionMemoryFiles(this.props.sessionResource) : undefined;
-		const repoMemories = enableCopilotMemory ? await this.agentMemoryService.getRepoMemories() : undefined;
+		const memoryPrompts = enableCopilotMemory ? await this.agentMemoryService.getMemoryPrompts() : undefined;
 		const localRepoMemoryFiles = (enableMemoryTool && !enableCopilotMemory) ? await this.getLocalRepoMemoryFiles() : undefined;
 
 		if (!enableMemoryTool && !enableCopilotMemory) {
@@ -54,8 +54,8 @@ export class MemoryContextPrompt extends PromptElement<MemoryContextPromptProps>
 			userMemoryContent?.length ?? 0,
 			sessionMemoryFiles?.length ?? 0,
 			sessionMemoryFiles?.join('\n').length ?? 0,
-			repoMemories?.length ?? 0,
-			repoMemories ? this.formatMemories(repoMemories).length : 0,
+			memoryPrompts?.memoriesContext?.memoriesCount ?? 0,
+			memoryPrompts?.memoriesContext?.prompt?.length ?? 0,
 		);
 
 		return (
@@ -84,16 +84,9 @@ export class MemoryContextPrompt extends PromptElement<MemoryContextPromptProps>
 						}
 					</Tag>
 				)}
-				{repoMemories && repoMemories.length > 0 && (
+				{memoryPrompts?.memoriesContext && memoryPrompts.memoriesContext.memoriesCount > 0 && (
 					<Tag name='repository_memories'>
-						The following are recent memories stored for this repository from previous agent interactions. These memories may contain useful context about the codebase conventions, patterns, and practices. However, be aware that memories might be obsolete or incorrect or may not apply to your current task. Use the citations provided to verify the accuracy of any relevant memory before relying on it.<br />
-						<br />
-						{this.formatMemories(repoMemories)}
-						<br />
-						Be sure to consider these stored facts carefully. Consider whether any are relevant to your current task. If they are, verify their current applicability before using them to inform your work.<br />
-						<br />
-						If you come across a memory that you're able to verify and that you find useful, you should use the {ToolName.Memory} tool to store the same fact again. Only recent memories are retained, so storing the fact again will cause it to be retained longer.<br />
-						If you come across a fact that's incorrect or outdated, you should use the {ToolName.Memory} tool to store a new fact that reflects the current reality.<br />
+						{memoryPrompts.memoriesContext.prompt}
 					</Tag>
 				)}
 			</>
@@ -197,27 +190,6 @@ export class MemoryContextPrompt extends PromptElement<MemoryContextPromptProps>
 		return files.length > 0 ? files : undefined;
 	}
 
-	private formatMemories(memories: RepoMemoryEntry[]): string {
-		return memories.map(m => {
-			const lines = [`**${m.subject}**`, `- Fact: ${m.fact}`];
-
-			// Format citations (handle both string and string[] formats)
-			if (m.citations) {
-				const citationsArray = normalizeCitations(m.citations) ?? [];
-				if (citationsArray.length > 0) {
-					lines.push(`- Citations: ${citationsArray.join(', ')}`);
-				}
-			}
-
-			// Include reason if present (from CAPI format)
-			if (m.reason) {
-				lines.push(`- Reason: ${m.reason}`);
-			}
-
-			return lines.join('\n');
-		}).join('\n\n');
-	}
-
 	private _sendContextReadTelemetry(hasUserMemory: boolean, userMemoryLength: number, sessionFileCount: number, sessionMemoryLength: number, repoMemoryCount: number, repoMemoryLength: number): void {
 		/* __GDPR__
 			"memoryContextRead" : {
@@ -252,6 +224,7 @@ export class MemoryInstructionsPrompt extends PromptElement<BasePromptElementPro
 		props: PromptElementProps<BasePromptElementProps>,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IExperimentationService private readonly experimentationService: IExperimentationService,
+		@IAgentMemoryService private readonly agentMemoryService: IAgentMemoryService,
 	) {
 		super(props);
 	}
@@ -262,6 +235,8 @@ export class MemoryInstructionsPrompt extends PromptElement<BasePromptElementPro
 		if (!enableCopilotMemory && !enableMemoryTool) {
 			return null;
 		}
+
+		const memoryPrompts = enableCopilotMemory ? await this.agentMemoryService.getMemoryPrompts() : undefined;
 
 		return <Tag name='memoryInstructions'>
 			As you work, consult your memory files to build on previous experience. When you encounter a mistake that seems like it could be common, check your memory for relevant notes — and if nothing is written yet, record what you learned.<br />
@@ -288,35 +263,11 @@ export class MemoryInstructionsPrompt extends PromptElement<BasePromptElementPro
 				</Tag>
 			</>}
 			<br />
-			{enableCopilotMemory && <>
+			{enableCopilotMemory && memoryPrompts?.storeInstructions?.prompt && (
 				<Tag name='repoMemoryInstructions'>
-					If you come across an important fact about the codebase that could help in future code review or generation tasks, beyond the current task, use the {ToolName.Memory} tool to store it. Use the `create` command with a path under `/memories/repo/` to store repository-scoped facts. The file content should be a JSON object with these fields: `subject`, `fact`, `citations`, `reason`, and `category`.<br />
-					Facts may be gleaned from the codebase itself or learned from user input or feedback. Such facts might include:<br />
-					- Conventions, preferences, or best practices specific to this codebase that might be overlooked when inspecting only a limited code sample<br />
-					- Important information about the structure or logic of the codebase<br />
-					- Commands for linting, building, or running tests that have been verified through a successful run<br />
-					<Tag name='examples'>
-						- "Use ErrKind wrapper for every public API error"<br />
-						- "Prefer ExpectNoLog helper over silent nil checks in tests"<br />
-						- "Always use Python typing"<br />
-						- "Follow the Google JavaScript Style Guide"<br />
-						- "Use html_escape as a sanitizer to avoid cross site scripting vulnerabilities"<br />
-						- "The code can be built with `npm run build` and tested with `npm run test`"<br />
-					</Tag>
-					Only store facts that meet the following criteria:<br />
-					<Tag name='factsCriteria'>
-						- Are likely to have actionable implications for a future task<br />
-						- Are independent of changes you are making as part of your current task, and will remain relevant if your current code isn't merged<br />
-						- Are unlikely to change over time<br />
-						- Cannot always be inferred from a limited code sample<br />
-						- Contain no secrets or sensitive data<br />
-					</Tag>
-					Always include the reason and citations fields.<br />
-					Before storing, ask yourself: Will this help with future coding or code review tasks across the repository? If unsure, skip storing it.<br />
-					Note: Only `create` is supported for `/memories/repo/` paths.<br />
-					If the user asks how to view or manage their repo memories refer them to https://docs.github.com/en/copilot/how-tos/use-copilot-agents/copilot-memory.<br />
+					{memoryPrompts.storeInstructions.prompt}
 				</Tag>
-			</>}
+			)}
 		</Tag>;
 	}
 }

--- a/src/extension/tools/node/test/memoryTool.spec.tsx
+++ b/src/extension/tools/node/test/memoryTool.spec.tsx
@@ -16,7 +16,7 @@ import { URI } from '../../../../util/vs/base/common/uri';
 import { SyncDescriptor } from '../../../../util/vs/platform/instantiation/common/descriptors';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
-import { IAgentMemoryService, RepoMemoryEntry } from '../../common/agentMemoryService';
+import { IAgentMemoryService, MemoryPromptResponse, RepoMemoryEntry } from '../../common/agentMemoryService';
 import { MemoryTool } from '../memoryTool';
 
 /**
@@ -58,6 +58,10 @@ class MockAgentMemoryService implements IAgentMemoryService {
 		return true;
 	}
 
+	async getMemoryPrompts(): Promise<MemoryPromptResponse | undefined> {
+		return undefined;
+	}
+
 	clearMemories(): void {
 		this.storedMemories = [];
 	}
@@ -79,6 +83,10 @@ class DisabledMockAgentMemoryService implements IAgentMemoryService {
 
 	async storeRepoMemory(_memory: RepoMemoryEntry): Promise<boolean> {
 		return false;
+	}
+
+	async getMemoryPrompts(): Promise<MemoryPromptResponse | undefined> {
+		return undefined;
 	}
 }
 


### PR DESCRIPTION
This change aims to call central prompting API and avoid hardcoding / formatting them by the client.  We have a new endpoint which returns prompt with memory context and this makes that change.

Key things to look out in review
- The prompt itself is very similar but had slight differences when compared including
     - adding a doc link https://github.com/microsoft/vscode-copilot-chat/blob/b6bbe6ecb0b7340e111e9c752bf30cf1be38dcde/src/extension/tools/node/memoryContextPrompt.tsx#L317
     - adding file path instruction to use create command https://github.com/microsoft/vscode-copilot-chat/blob/b6bbe6ecb0b7340e111e9c752bf30cf1be38dcde/src/extension/tools/node/memoryContextPrompt.tsx#L316
     - some styling difference which might not have real impact, bullets are using`-` and not `*` 
     
- Additionally, Category field is not part of the API spec - so might be just getting ignored, hence removed that 
- `Reason` is not included in the formatting of memories in the backend, so you will not see that - incase that makes any difference 
-  tool name is `store_memory` as used for other agents, but VSCode uses `copilot_memory`!