### PR TITLE
Publish VSIX as GitHub release asset

### DIFF
--- a/build/pre-release.yml
+++ b/build/pre-release.yml
@@ -256,3 +256,4 @@ extends:
     generateNotice: ${{ parameters.generateNotice }}
 
     publishExtension: ${{ parameters.publishExtension }}
+    ghReleasePublishVSIX: true

--- a/build/release.yml
+++ b/build/release.yml
@@ -242,3 +242,4 @@ extends:
     generateNotice: ${{ parameters.generateNotice }}
 
     publishExtension: ${{ parameters.publishExtension }}
+    ghReleasePublishVSIX: true


### PR DESCRIPTION
Adopts [microsoft/vscode-engineering#2009](https://github.com/microsoft/vscode-engineering/pull/2009) to attach signed VSIX files as GitHub release assets when publishing.

Sets `ghReleasePublishVSIX: true` in both `build/release.yml` and `build/pre-release.yml`.