### PR TITLE
Send context signals in routing predict request

### DIFF
--- a/src/platform/endpoint/node/automodeService.ts
+++ b/src/platform/endpoint/node/automodeService.ts
@@ -20,7 +20,7 @@ import { IExperimentationService } from '../../telemetry/common/nullExperimentat
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { ICAPIClientService } from '../common/capiClient';
 import { AutoChatEndpoint } from './autoChatEndpoint';
-import { RouterDecisionFetcher } from './routerDecisionFetcher';
+import { RouterDecisionFetcher, RoutingContextSignals } from './routerDecisionFetcher';
 
 interface AutoModeAPIResponse {
 	available_models: string[];
@@ -230,7 +230,16 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 				// Router fallback reason isn't set here because we don't want telemetry for this case
 			} else {
 				try {
-					const result = await this._routerDecisionFetcher.getRouterDecision(prompt, token.session_token, token.available_models);
+					const contextSignals: RoutingContextSignals = {
+						chat_location: chatRequestLocationToString(chatRequest?.location),
+						session_id: conversationId !== 'unknown' ? conversationId : undefined,
+						has_image: hasImage(chatRequest),
+						reference_count: chatRequest?.references?.length,
+						prompt_char_count: prompt.length,
+						previous_model: entry?.endpoint?.model,
+						turn_number: entry ? 2 : 1,
+					};
+					const result = await this._routerDecisionFetcher.getRouterDecision(prompt, token.session_token, token.available_models, undefined, contextSignals);
 					if (!result.candidate_models.length) {
 						routerFallbackReason = 'emptyCandidateList';
 					} else if (entry?.endpoint) {
@@ -362,6 +371,15 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			}
 		}
 		return hasValues ? { low, high } : { low: 0, high: 0 };
+	}
+}
+
+function chatRequestLocationToString(location: ChatLocation | undefined): string | undefined {
+	switch (location) {
+		case ChatLocation.Panel: return 'panel';
+		case ChatLocation.Editor: return 'editor';
+		case ChatLocation.Terminal: return 'terminal';
+		default: return location !== undefined ? String(location) : undefined;
 	}
 }
 

--- a/src/platform/endpoint/node/routerDecisionFetcher.ts
+++ b/src/platform/endpoint/node/routerDecisionFetcher.ts
@@ -24,6 +24,15 @@ export interface RouterDecisionResponse {
 	sticky_override?: boolean;
 }
 
+export interface RoutingContextSignals {
+	has_image?: boolean;
+	chat_location?: string;
+	turn_number?: number;
+	session_id?: string;
+	previous_model?: string;
+	reference_count?: number;
+	prompt_char_count?: number;
+}
 
 /**
  * Fetches routing decisions from a classification API to determine which model should handle a query.
@@ -41,9 +50,9 @@ export class RouterDecisionFetcher {
 	) {
 	}
 
-	async getRouterDecision(query: string, autoModeToken: string, availableModels: string[], stickyThreshold?: number): Promise<RouterDecisionResponse> {
+	async getRouterDecision(query: string, autoModeToken: string, availableModels: string[], stickyThreshold?: number, contextSignals?: RoutingContextSignals): Promise<RouterDecisionResponse> {
 		const startTime = Date.now();
-		const requestBody: Record<string, unknown> = { prompt: query, available_models: availableModels };
+		const requestBody: Record<string, unknown> = { prompt: query, available_models: availableModels, ...contextSignals };
 		if (stickyThreshold !== undefined) {
 			requestBody.sticky_threshold = stickyThreshold;
 		}


### PR DESCRIPTION
Forward optional context fields from the client to the routing service to enable richer routing decisions in future model versions.

Signals sent:
- chat_location (panel/editor/terminal)
- session_id (conversation identifier)
- has_image (image attachment present)
- reference_count (number of #file / @workspace references)
- prompt_char_count (character length of the current prompt)
- previous_model (model used on the prior turn)
- turn_number (position in conversation)

All fields are optional and the server silently ignores unknown fields. Current models do not use these signals.