### PR TITLE
init prompt: inventory docs and link instead of duplicating content

### DIFF
--- a/assets/prompts/init.prompt.md
+++ b/assets/prompts/init.prompt.md
@@ -21,9 +21,12 @@ Bootstrap workspace instructions (`.github/copilot-instructions.md` or `AGENTS.m
    - Potential pitfalls or common development environment issues
    - Key files/directories that exemplify patterns
 
+   Also inventory existing documentation (`docs/**/*.md`, `CONTRIBUTING.md`, `ARCHITECTURE.md`, etc.) to identify topics that should be linked, not duplicated.
+
 3. **Generate or merge**
    - New file: Use template from workspace-instructions.md, include only relevant sections
    - Existing file: Preserve valuable content, update outdated sections, remove duplication
+   - Follow the **Link, don't embed** principle from workspace-instructions.md
 
 4. **Iterate**
    - Ask for feedback on unclear or incomplete sections

--- a/assets/prompts/skills/agent-customization/references/workspace-instructions.md
+++ b/assets/prompts/skills/agent-customization/references/workspace-instructions.md
@@ -55,7 +55,7 @@ For large repos, link to detailed docs instead of embedding: `See docs/TESTING.m
 
 1. **Minimal by default**: Only what's relevant to *every* task
 2. **Concise and actionable**: Every line should guide behavior
-3. **Link, don't embed**: Reference docs instead of copying
+3. **Link, don't embed**: Reference docs instead of copying content. Search for existing docs (`docs/**/*.md`, `CONTRIBUTING.md`, etc.) and catalog what they cover—only inline agent-critical gotchas not documented elsewhere
 4. **Keep current**: Update when practices change
 
 ## Anti-patterns


### PR DESCRIPTION
When `/init` explores a codebase, it reads `docs/*.md` files but then duplicates their content into the generated workspace instructions. This adds explicit guidance to inventory existing documentation and link to it instead.

**Changes:**
- **workspace-instructions.md**: Expanded 'Link, don't embed' principle with actionable steps (search for docs, catalog, decide what to inline)
- **init.prompt.md**: Added doc-inventory step during exploration; references the shared principle instead of restating it