### PR TITLE
More repo info telemetry check to support windows repo perf issues

### DIFF
--- a/src/extension/prompt/node/repoInfoTelemetry.ts
+++ b/src/extension/prompt/node/repoInfoTelemetry.ts
@@ -231,11 +231,14 @@ export class RepoInfoTelemetry {
 
 		// VFS and sparse checkout enlistments are unlikely to have all blobs available locally,
 		// making diff operations expensive or impossible. Skip early if either is configured.
+		// core.virtualfilesystem is a path to a hook script, any non-empty value means VFS is active.
+		// core.sparsecheckout is a git boolean: true/yes/on/1 are truthy per git-config spec.
 		// If we can't determine the config, skip to be safe.
 		try {
 			const virtualFileSystem = await repository.getConfig('core.virtualfilesystem');
 			const sparseCheckout = await repository.getConfig('core.sparsecheckout');
-			if (virtualFileSystem === 'true' || sparseCheckout === 'true') {
+			const GIT_TRUE_VALUES = new Set(['true', 'yes', 'on', '1']);
+			if (virtualFileSystem || GIT_TRUE_VALUES.has(sparseCheckout.toLowerCase())) {
 				return skipDiffResult('virtualFileSystem');
 			}
 		} catch {

--- a/src/extension/prompt/node/test/repoInfoTelemetry.spec.ts
+++ b/src/extension/prompt/node/test/repoInfoTelemetry.spec.ts
@@ -840,12 +840,12 @@ suite('RepoInfoTelemetry', () => {
 		mockGitServiceWithRepository();
 		mockGitExtensionWithUpstream('abc123');
 
-		// Override getConfig to return a value for core.virtualfilesystem
+		// Override getConfig to return a hook path for core.virtualfilesystem (any non-empty string means VFS is active)
 		const mockApi = gitExtensionService.getExtensionApi();
 		const mockRepo = mockApi!.getRepository(URI.file('/test/repo'))!;
 		vi.spyOn(mockRepo, 'getConfig').mockImplementation(async key => {
 			if (key === 'core.virtualfilesystem') {
-				return 'true';
+				return '/path/to/vfs-hook';
 			}
 			return '';
 		});
@@ -874,7 +874,7 @@ suite('RepoInfoTelemetry', () => {
 		assert.strictEqual((gitService.diffWith as any).mock.calls.length, 0);
 	});
 
-	test('should skip with virtualFileSystem result when core.sparsecheckout is set', async () => {
+	test('should skip with virtualFileSystem result when core.sparsecheckout is true', async () => {
 		setupInternalUser();
 		mockGitServiceWithRepository();
 		mockGitExtensionWithUpstream('abc123');
@@ -906,7 +906,6 @@ suite('RepoInfoTelemetry', () => {
 		assert.strictEqual((telemetryService.sendInternalMSFTTelemetryEvent as any).mock.calls.length, 1);
 		const call = (telemetryService.sendInternalMSFTTelemetryEvent as any).mock.calls[0];
 		assert.strictEqual(call[1].result, 'virtualFileSystem');
-		assert.strictEqual(call[1].diffsJSON, undefined);
 		assert.strictEqual((gitService.diffWith as any).mock.calls.length, 0);
 	});
 


### PR DESCRIPTION
More follow up to: https://github.com/microsoft/vscode-copilot-chat/pull/3774

The configuration of certain windows repos is still having perf issues after the change above. With help from a windows dev the most probably issues were seen as:

1. The configuration of virtualfilesystem and sparsecheckout causing issues with calculating diffs:
https://github.com/microsoft/vscode-copilot-chat/pull/4308

2. Enough extensive local commits created (especially with renames) that just calculating the number of diffs in the change slows down vscode with expensive git processes
https://github.com/microsoft/vscode-copilot-chat/pull/4309

For this date our usual thing is to prioritize avoiding nasty perf issues at the expense of possibly dropping some data, so I'm implementing both changes here. I also do believe that in most cases of the commit count check we'd be pushing on too big a diff to log in telemetry in any case possibly. As with the other change we are logging why we don't check telemetry so if we start to not even enough events through we can re-examine.

Unit tests also updated.

For my local testing I did the following tests with a local build:

- [x] Events fired for a standard scenario
- [x] Too old event fires for >30day old diff
- [x] Does not collect and logs 'virtualfilesystem' with core.virtualfilesystem or core.sparsecheckout specified
<img width="823" height="304" alt="image" src="https://github.com/user-attachments/assets/1c47fc1b-6dd2-4616-a7e5-83e78fbf301d" />

- [x] Does collect after those settings are turned off in the repo
- [x] Collects after 25 local commits from upstream are added
- [x] Does not collect after 10 more local commits are added and logs 'tooManyCommit'
<img width="823" height="301" alt="image" src="https://github.com/user-attachments/assets/ce82d0a8-b643-4bee-8b68-1370a22c5af1" />

