### PR TITLE
Fix duplicate semantic search results from git worktrees

### DIFF
--- a/src/platform/workspaceChunkSearch/node/codeSearch/codeSearchChunkSearch.ts
+++ b/src/platform/workspaceChunkSearch/node/codeSearch/codeSearchChunkSearch.ts
@@ -783,6 +783,24 @@ export class CodeSearchChunkSearch extends Disposable implements IWorkspaceChunk
 			return;
 		}
 
+		// Skip repos that aren't relevant to the workspace (e.g. worktrees at external paths)
+		const workspaceFolders = this._workspaceService.getWorkspaceFolders();
+		const isRelevantToWorkspace = workspaceFolders.some(folder =>
+			isEqualOrParent(repo.rootUri, folder) || isEqualOrParent(folder, repo.rootUri));
+		if (!isRelevantToWorkspace) {
+			this._logService.trace(`CodeSearchChunkSearch.openGitRepo(${repo.rootUri}): skipping, not relevant to workspace`);
+			return;
+		}
+
+		// Skip if another repo already covers this remote (e.g. git worktrees sharing the same remote)
+		const remoteKey = remoteInfo.repoId.toString();
+		for (const entry of this._codeSearchRepos.values()) {
+			if (entry.repo.remoteInfo?.repoId.toString() === remoteKey) {
+				this._logService.trace(`CodeSearchChunkSearch.openGitRepo(${repo.rootUri}): skipping, remote already covered by ${entry.repo.repoInfo.rootUri}`);
+				return;
+			}
+		}
+
 		if (remoteInfo.repoId.type === 'github') {
 			this.updateRepoEntry(repo, this._instantiationService.createInstance(GithubCodeSearchRepo, repo, remoteInfo.repoId, remoteInfo));
 			// Update external ingest roots since this repo is now covered by code search


### PR DESCRIPTION
Fixes microsoft/vscode#295628

When a repo has git worktrees, the `semantic_search` tool returns the same file multiple times - once from the main repo and once from each worktree. This pollutes the context of the LLM, reducing the agent's ability to find relevant code and degrading accuracy.

This happens because the Git extension exposes each worktree as a separate repository, and `CodeSearchChunkSearch` creates a `CodeSearchRepo` for each one.

### Fix

Two filters in `CodeSearchChunkSearch.openGitRepo()`:

1. Skip repos that aren't related to the workspace (filters worktrees at external paths like `*.worktrees/` or `~/.cursor/worktrees/`)

2. Skip repos whose remote is already covered by an existing repo (handles worktrees physically inside the workspace like `.claude/worktrees/`)