### PR TITLE
Implement pending commit handling for worktree changes in chat sessions

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
@@ -1383,13 +1383,17 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 	}
 
 	private async commitWorktreeChangesIfNeeded(session: ICopilotCLISession, token: vscode.CancellationToken): Promise<void> {
+		if (token.isCancellationRequested) {
+			return;
+		}
+
 		const existingPromise = this.pendingCommitWorktreeChangesBySession.get(session.sessionId);
 		if (existingPromise) {
 			return existingPromise;
 		}
 
 		const commitPromise = (async () => {
-			if (session.status === vscode.ChatSessionStatus.Completed && !token.isCancellationRequested) {
+			if (session.status === vscode.ChatSessionStatus.Completed) {
 				const workingDirectory = getWorkingDirectory(session.workspace);
 				if (isIsolationEnabled(session.workspace)) {
 					// When isolation is enabled and we are using a git worktree, so we commit


### PR DESCRIPTION
Introduce a mechanism to handle pending commits for worktree changes in chat sessions, ensuring that multiple requests do not lead to redundant commits. This enhancement improves the efficiency of commit operations upon session completion.

Fixes https://github.com/microsoft/vscode/issues/301619