### PR TITLE
Fix 'Hide Ghost Requests' not filtering ghost prompt groups

### DIFF
--- a/src/extension/log/vscode-node/requestLogTree.ts
+++ b/src/extension/log/vscode-node/requestLogTree.ts
@@ -862,6 +862,9 @@ class LogTreeFilters extends Disposable {
 			if (this.isNesRequest(item)) {
 				return this._nesRequestsShown;
 			}
+			if (this.isGhostRequest(item)) {
+				return this._ghostRequestsShown;
+			}
 			return true; // Always show chat prompt items
 		} else if (item instanceof ChatElementItem) {
 			return this._elementsShown;
@@ -881,8 +884,14 @@ class LogTreeFilters extends Disposable {
 		return true;
 	}
 
-	private isGhostRequest(item: ChatRequestItem): boolean {
-		const debugName = item.info.entry.debugName.toLowerCase();
+	private isGhostRequest(item: ChatPromptItem | ChatRequestItem): boolean {
+		let debugName: string;
+		if (item instanceof ChatPromptItem) {
+			assert(typeof item.label === 'string', 'ChatPromptItem label must be a string');
+			debugName = item.label.toLowerCase();
+		} else {
+			debugName = item.info.entry.debugName.toLowerCase();
+		}
 		return debugName === 'ghost' || debugName.startsWith('ghost |');
 	}
 


### PR DESCRIPTION
The ghost request filter in the Chat Debug Log only checked \`ChatRequestItem\` instances but not \`ChatPromptItem\` (parent grouping nodes). This meant ghost prompt groups labeled "Ghost" or "Ghost | ..." remained visible even with the filter active.

Extends \`isGhostRequest\` to also handle \`ChatPromptItem\`, matching the pattern already used for NES request filtering.

Fixes https://github.com/microsoft/vscode/issues/297566