### PR TITLE
adopt prompt/instructions variable id rename

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCLIPromptReferences.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLIPromptReferences.ts
@@ -16,6 +16,7 @@ import { URI } from '../../../util/vs/base/common/uri';
 import { Range as InternalRange } from '../../../util/vs/editor/common/core/range';
 import { SymbolKind } from '../../../util/vs/workbench/api/common/extHostTypes/symbolInformation';
 import { ChatReferenceDiagnostic, Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, Range, Uri } from '../../../vscodeTypes';
+import { PromptFileIdPrefix } from '../../prompt/common/chatVariablesCollection';
 
 /**
  * Converts a ChatPromptReference into a PromptVariable entry that is used in VS code.
@@ -51,7 +52,7 @@ export function convertReferenceToVariable(ref: ChatPromptReference, attachments
 	}
 
 	if (URI.isUri(value) && ref.name.startsWith(`prompt:`) &&
-		ref.id.startsWith(PromptFileVariableKind.PromptFile) &&
+		ref.id.startsWith(PromptFileIdPrefix) &&
 		ref.id.endsWith(value.toString())) {
 		return {
 			id: ref.id,
@@ -82,11 +83,6 @@ function toInternalRange(range: Range): InternalRange {
 	return new InternalRange(range.start.line + 1, range.start.character + 1, range.end.line + 1, range.end.character + 1);
 }
 
-enum PromptFileVariableKind {
-	Instruction = 'vscode.prompt.instructions.root',
-	InstructionReference = `vscode.prompt.instructions`,
-	PromptFile = 'vscode.prompt.file'
-}
 
 namespace DiagnosticTagConverter {
 

--- a/src/extension/intents/node/editCodeIntent.ts
+++ b/src/extension/intents/node/editCodeIntent.ts
@@ -35,7 +35,7 @@ import { CodeBlockInfo, CodeBlockProcessor, isCodeBlockWithResource } from '../.
 import { ICommandService } from '../../commands/node/commandService';
 import { Intent } from '../../common/constants';
 import { GenericInlineIntentInvocation } from '../../context/node/resolvers/genericInlineIntentInvocation';
-import { ChatVariablesCollection, isPromptInstruction } from '../../prompt/common/chatVariablesCollection';
+import { ChatVariablesCollection, InstructionFileIdPrefix, isPromptInstruction } from '../../prompt/common/chatVariablesCollection';
 import { CodeBlock, Conversation, Turn } from '../../prompt/common/conversation';
 import { IBuildPromptContext, InternalToolReference, IWorkingSet, IWorkingSetEntry, WorkingSetEntryState } from '../../prompt/common/intents';
 import { ChatTelemetryBuilder } from '../../prompt/node/chatParticipantTelemetry';
@@ -467,7 +467,7 @@ export class EditCodeIntentInvocation implements IIntentInvocation {
 			// TODO@joyceerhl if this reference is subsequently modified and joins the working set, should we suppress it again in the UI?
 			return true;
 		}
-		const PROMPT_INSTRUCTION_PREFIX = 'vscode.prompt.instructions';
+		const PROMPT_INSTRUCTION_PREFIX = InstructionFileIdPrefix;
 		const PROMPT_INSTRUCTION_ROOT_PREFIX = `${PROMPT_INSTRUCTION_PREFIX}.root`;
 		const promptInstruction = chatVariables.find((variable) => isPromptInstruction(variable) && URI.isUri(variable.value) && isEqual(variable.value, uri));
 		if (promptInstruction) {

--- a/src/extension/prompt/common/chatVariablesCollection.ts
+++ b/src/extension/prompt/common/chatVariablesCollection.ts
@@ -106,14 +106,14 @@ export class ChatVariablesCollection {
  * Check if provided variable is a "prompt instruction".
  */
 export function isPromptInstruction(variable: PromptVariable): boolean {
-	return variable.reference.id.startsWith('vscode.prompt.instructions');
+	return variable.reference.id.startsWith(InstructionFileIdPrefix);
 }
 
 /**
  * Check if provided variable is a "prompt instruction text" (index file).
  */
 export function isPromptInstructionText(variable: PromptVariable): variable is PromptVariable & { value: string } {
-	return variable.reference.id === 'vscode.prompt.instructions.text';
+	return variable.reference.id === CustomizationsIndexId;
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/301493

https://github.com/microsoft/vscode/pull/300185 renamed the id for instruction and prompt variable names.
https://github.com/microsoft/vscode-copilot-chat/pull/4298 was the corresponding change, but that PR did not get merged due to a merge conflict/ci problem.

https://github.com/microsoft/vscode-copilot-chat/pull/4298 is now in main.
The current PR fixes the release branch with minimal changes