### PR TITLE
Lazy-load node:sqlite to prevent SIGSEGV crashes during debugging

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -271,7 +271,8 @@ export default tseslint.config(
 				{
 					test: ['vscode'],
 					'src/**/common/**/*': ['vscode'],
-					'src/**/node/**/*': ['vscode']
+					'src/**/node/**/*': ['vscode', 'node:sqlite'],
+					'src/**/vscode-node/**/*': ['node:sqlite'],
 				}
 			],
 			'local/no-funny-filename': ['error'],

--- a/src/platform/tfidf/node/tfidf.ts
+++ b/src/platform/tfidf/node/tfidf.ts
@@ -4,8 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import fs from 'fs';
-import sql from 'node:sqlite';
+import type sql from 'node:sqlite';
 import path from 'path';
+
+function loadSqlite(): typeof import('node:sqlite') {
+	return require('node:sqlite');
+}
 import { GlobIncludeOptions, shouldInclude } from '../../../util/common/glob';
 import { Limiter } from '../../../util/vs/base/common/async';
 import { Iterable } from '../../../util/vs/base/common/iterator';
@@ -151,6 +155,7 @@ export class PersistentTfIdf {
 	private readonly db!: sql.DatabaseSync;
 
 	constructor(dbPath: URI | ':memory:') {
+		const sqliteModule = loadSqlite();
 		const syncOptions: sql.DatabaseSyncOptions = {
 			open: true,
 			enableForeignKeyConstraints: true
@@ -159,7 +164,7 @@ export class PersistentTfIdf {
 		if (dbPath !== ':memory:' && dbPath.scheme === Schemas.file) {
 			try {
 				fs.mkdirSync(path.dirname(dbPath.fsPath), { recursive: true });
-				this.db = new sql.DatabaseSync(dbPath.fsPath, syncOptions);
+				this.db = new sqliteModule.DatabaseSync(dbPath.fsPath, syncOptions);
 			} catch (e) {
 				console.error('Failed to open SQLite database on disk. Trying memory db', e);
 			}
@@ -167,7 +172,7 @@ export class PersistentTfIdf {
 
 		// Try falling back to an in-memory database
 		if (!this.db) {
-			this.db = new sql.DatabaseSync(':memory:', syncOptions);
+			this.db = new sqliteModule.DatabaseSync(':memory:', syncOptions);
 		}
 
 		this.db.exec(`

--- a/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestIndex.ts
+++ b/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestIndex.ts
@@ -6,9 +6,9 @@
 import ingestUtils = require('@github/blackbird-external-ingest-utils');
 import * as l10n from '@vscode/l10n';
 import * as fs from 'node:fs';
-import sql from 'node:sqlite';
-import { Result } from '../../../../util/common/result';
+import type sql from 'node:sqlite';
 import { toErrorMessage } from '../../../../util/common/errorMessage';
+import { Result } from '../../../../util/common/result';
 import { CallTracker } from '../../../../util/common/telemetryCorrelationId';
 import { coalesce } from '../../../../util/vs/base/common/arrays';
 import { CancelablePromise, createCancelablePromise, Limiter, raceCancellationError, timeout } from '../../../../util/vs/base/common/async';
@@ -41,6 +41,10 @@ import { shouldPotentiallyIndexFile } from '../workspaceFileIndex';
 import { CodeSearchRepoStatus, TriggerIndexingError, TriggerRemoteIndexingError } from './codeSearchRepo';
 import { ExternalIngestFile, ExternalIngestRequestError, IExternalIngestClient } from './externalIngestClient';
 import { WorkspaceFolderIdMap } from './workspaceFolderIdMap';
+
+function loadSqlite(): typeof import('node:sqlite') {
+	return require('node:sqlite');
+}
 
 const debug = false;
 
@@ -480,7 +484,8 @@ export class ExternalIngestIndex extends Disposable {
 		// Try to open existing database and check cache version
 		if (fs.existsSync(dbPath)) {
 			try {
-				const db = new sql.DatabaseSync(dbPath, {
+				const sqliteModule = loadSqlite();
+				const db = new sqliteModule.DatabaseSync(dbPath, {
 					open: true,
 					enableForeignKeyConstraints: true,
 				});
@@ -524,7 +529,8 @@ export class ExternalIngestIndex extends Disposable {
 	private createFreshDatabase(dbPath: string | ':memory:'): sql.DatabaseSync {
 		this._logService.trace(`ExternalIngestIndex: Creating fresh database at path: ${dbPath}`);
 
-		const db = new sql.DatabaseSync(dbPath, {
+		const sqliteModule = loadSqlite();
+		const db = new sqliteModule.DatabaseSync(dbPath, {
 			open: true,
 			enableForeignKeyConstraints: true,
 		});

--- a/src/platform/workspaceChunkSearch/node/workspaceChunkAndEmbeddingCache.ts
+++ b/src/platform/workspaceChunkSearch/node/workspaceChunkAndEmbeddingCache.ts
@@ -4,8 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 import fs from 'fs';
 import { IDisposable } from 'monaco-editor';
-import sql from 'node:sqlite';
+import type sql from 'node:sqlite';
 import path from 'path';
+
+function loadSqlite(): typeof import('node:sqlite') {
+	return require('node:sqlite');
+}
 import { CancelablePromise, createCancelablePromise, raceCancellationError } from '../../../util/vs/base/common/async';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
 import { isCancellationError } from '../../../util/vs/base/common/errors';
@@ -97,6 +101,7 @@ class DbCache implements IWorkspaceChunkAndEmbeddingCache {
 		const instantiationService = accessor.get(IInstantiationService);
 		const logService = accessor.get(ILogService);
 
+		const sqliteModule = loadSqlite();
 		const syncOptions: sql.DatabaseSyncOptions = {
 			open: true,
 			enableForeignKeyConstraints: true
@@ -107,7 +112,7 @@ class DbCache implements IWorkspaceChunkAndEmbeddingCache {
 			const dbPath = URI.joinPath(cacheRoot, `workspace-chunks.db`);
 			try {
 				await raceCancellationError(fs.promises.mkdir(path.dirname(dbPath.fsPath), { recursive: true }), token);
-				db = new sql.DatabaseSync(dbPath.fsPath, syncOptions);
+				db = new sqliteModule.DatabaseSync(dbPath.fsPath, syncOptions);
 				logService.trace(`DbWorkspaceChunkAndEmbeddingCache: Opened SQLite database on disk at ${dbPath.fsPath}`);
 			} catch (e) {
 				if (isCancellationError(e)) {
@@ -118,7 +123,7 @@ class DbCache implements IWorkspaceChunkAndEmbeddingCache {
 		}
 
 		if (!db) {
-			db = new sql.DatabaseSync(':memory:', syncOptions);
+			db = new sqliteModule.DatabaseSync(':memory:', syncOptions);
 			logService.trace(`DbWorkspaceChunkAndEmbeddingCache: Using in memory database`);
 		}
 


### PR DESCRIPTION
@mjbvz I wonder what you think. The PR is AI-generated, but I thought it's small enough that maybe you could share your opinion on if you think it's ok. The initial issue this PR came to be from is investigating constant segfaults when launching debugee vscode window from Chat repo -- [see](https://vscodeteam.slack.com/archives/C03ERNTC03X/p1773741532785349).

## Problem

When launching the extension in debug mode (F5), the debugee VS Code instance crashes repeatedly with **SIGSEGV (exit code 11)**. The extension host process segfaults during early activation, enters a crash-restart loop (~8 cycles), and eventually gives up — making local debugging impossible.

### Root cause

The `node:sqlite` module (experimental Node.js builtin) is imported eagerly via top-level `import sql from 'node:sqlite'` in 3 files. When esbuild bundles the extension, this becomes a synchronous `require('node:sqlite')` at the top of `dist/extension.js`, which executes immediately when the extension host loads the bundle.

In debug mode, the V8 inspector is active. A race condition between SQLite's native module initialization/teardown and the V8 inspector's message dispatch causes a **NULL pointer dereference in `v8::Context::Enter()`** — a V8/Electron bug, not a bug in our TypeScript code.

### Evidence from crash reports

- **Crash location**: `v8::Context::Enter()` + 28 — NULL deref at address `0x0` 
- **Native stack includes**: `node::sqlite::UserDefinedFunction::xDestroy()` + `node::inspector::MainThreadInterface::DispatchMessages()`
- **Pattern**: First ext host becomes unresponsive → killed (SIGTERM) → every subsequent restart crashes with SIGSEGV within 1-2 seconds, before finishing extension activation
- **Symptom**: `ExperimentalWarning: SQLite is an experimental feature` appears in every crashing process right before the segfault

## Solution

Defer the `require('node:sqlite')` call until SQLite is actually needed, rather than loading it at bundle initialization time. This is done by:

1. Replacing `import sql from 'node:sqlite'` with `import type sql from 'node:sqlite'` (type-only import, erased at runtime)
2. Adding a `loadSqlite()` function that calls `require('node:sqlite')` on first use
3. Updating all `new sql.DatabaseSync(...)` call sites to use the lazy loader

### Files changed

- `src/platform/tfidf/node/tfidf.ts` — TF-IDF indexing
- `src/platform/workspaceChunkSearch/node/codeSearch/externalIngestIndex.ts` — External ingest indexing
- `src/platform/workspaceChunkSearch/node/workspaceChunkAndEmbeddingCache.ts` — Chunk/embedding cache

### What this achieves

- `node:sqlite` native module is no longer initialized at bundle load time
- The `ExperimentalWarning: SQLite` message no longer appears during early extension host startup
- SQLite is loaded only when workspace chunk search, embedding cache, or TF-IDF features are first used
- Eliminates the window for the V8 inspector + SQLite native teardown race condition

### Potential consequences

- **No functional change**: SQLite is still loaded synchronously when needed — the only difference is *when* it loads (on first database access, not at bundle init)
- **Slight first-use latency**: The very first workspace search/indexing operation will incur a one-time `require()` overhead (~ms), which is negligible compared to the search operation itself
- **Type safety preserved**: `import type sql from 'node:sqlite'` keeps all type annotations (`sql.DatabaseSync`, `sql.DatabaseSyncOptions`) working at compile time with zero runtime cost
- **Does not fix the underlying V8 bug**: This is a workaround. The V8/Electron bug in `node:sqlite` + inspector interaction still exists — we just avoid triggering it by not loading the module during the vulnerable window