### PR TITLE
nes: fix: don't error if server response contained no choices

### DIFF
--- a/src/extension/prompt/node/chatMLFetcher.ts
+++ b/src/extension/prompt/node/chatMLFetcher.ts
@@ -10,7 +10,7 @@ import { IAuthenticationService } from '../../../platform/authentication/common/
 import { CopilotToken } from '../../../platform/authentication/common/copilotToken';
 import { FetchStreamRecorder, IChatMLFetcher, IFetchMLOptions, Source } from '../../../platform/chat/common/chatMLFetcher';
 import { IChatQuotaService } from '../../../platform/chat/common/chatQuotaService';
-import { ChatFetchError, ChatFetchResponseType, ChatFetchRetriableError, ChatLocation, ChatResponse, ChatResponses } from '../../../platform/chat/common/commonTypes';
+import { ChatFetchError, ChatFetchResponseType, ChatFetchRetriableError, ChatLocation, ChatResponse, ChatResponses, RESPONSE_CONTAINED_NO_CHOICES } from '../../../platform/chat/common/commonTypes';
 import { IConversationOptions } from '../../../platform/chat/common/conversationOptions';
 import { getTextPart, toTextParts } from '../../../platform/chat/common/globalStringUtils';
 import { IInteractionService } from '../../../platform/chat/common/interactionService';
@@ -1663,7 +1663,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 		}
 		return {
 			type: ChatFetchResponseType.Unknown,
-			reason: 'Response contained no choices.',
+			reason: RESPONSE_CONTAINED_NO_CHOICES,
 			requestId: requestId,
 			serverRequestId: result?.requestId.headerRequestId,
 		};

--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -5,7 +5,7 @@
 
 import { Raw } from '@vscode/prompt-tsx';
 import { FetchStreamSource } from '../../../platform/chat/common/chatMLFetcher';
-import { ChatFetchError, ChatFetchResponseType, ChatLocation } from '../../../platform/chat/common/commonTypes';
+import { ChatFetchError, ChatFetchResponseType, ChatLocation, RESPONSE_CONTAINED_NO_CHOICES } from '../../../platform/chat/common/commonTypes';
 import { ConfigKey, IConfigurationService, XTabProviderId } from '../../../platform/configuration/common/configurationService';
 import { IDiffService } from '../../../platform/diff/common/diffService';
 import { ChatEndpoint } from '../../../platform/endpoint/node/chatEndpoint';
@@ -737,6 +737,10 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			) {
 				this.forceUseDefaultModel = true;
 				return yield* this.doGetNextEdit(request, delaySession, tracer, logContext, cancellationToken, telemetryBuilder, opts.retryState); // use the same retry state
+			}
+			// diff-patch based model returns no choices if it has no edits to suggest
+			if (fetchRes.type === ChatFetchResponseType.Unknown && fetchRes.reason === RESPONSE_CONTAINED_NO_CHOICES) {
+				return new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, editWindow);
 			}
 			return mapChatFetcherErrorToNoNextEditReason(fetchRes);
 		}

--- a/src/extension/xtab/test/node/xtabProvider.spec.ts
+++ b/src/extension/xtab/test/node/xtabProvider.spec.ts
@@ -6,7 +6,7 @@
 import { Raw } from '@vscode/prompt-tsx';
 import { afterEach, beforeEach, describe, expect, it, suite, test, vi } from 'vitest';
 import { IChatMLFetcher } from '../../../../platform/chat/common/chatMLFetcher';
-import { ChatFetchResponseType } from '../../../../platform/chat/common/commonTypes';
+import { ChatFetchResponseType, RESPONSE_CONTAINED_NO_CHOICES } from '../../../../platform/chat/common/commonTypes';
 import { StreamingMockChatMLFetcher } from '../../../../platform/chat/test/common/streamingMockChatMLFetcher';
 import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
 import { InMemoryConfigurationService } from '../../../../platform/configuration/test/common/inMemoryConfigurationService';
@@ -1313,6 +1313,44 @@ describe('XtabProvider integration', () => {
 			expect(finalValue.v).toBeInstanceOf(NoNextEditReason.FetchFailure);
 			// Exactly 2 calls: initial + one retry with default model
 			expect(streamingFetcher.callCount).toBe(2);
+		});
+
+		it('returns NoSuggestions when response contains no choices', async () => {
+			const provider = createProvider();
+
+			const lines = ['const x = 1;'];
+			const request = createRequestWithEdit(lines, { insertionOffset: 3, insertedText: 'a' });
+
+			streamingFetcher.enqueueResponse({
+				type: ChatFetchResponseType.Unknown,
+				reason: RESPONSE_CONTAINED_NO_CHOICES,
+				requestId: 'req-1',
+				serverRequestId: undefined,
+			});
+
+			const gen = provider.provideNextEdit(request, createMockLogger(), createLogContext(), CancellationToken.None);
+			const finalValue = await AsyncIterUtils.drainUntilReturn(gen);
+
+			expect(finalValue.v).toBeInstanceOf(NoNextEditReason.NoSuggestions);
+		});
+
+		it('returns FetchFailure for Unknown response with a different reason', async () => {
+			const provider = createProvider();
+
+			const lines = ['const x = 1;'];
+			const request = createRequestWithEdit(lines, { insertionOffset: 3, insertedText: 'a' });
+
+			streamingFetcher.enqueueResponse({
+				type: ChatFetchResponseType.Unknown,
+				reason: 'some other error',
+				requestId: 'req-1',
+				serverRequestId: undefined,
+			});
+
+			const gen = provider.provideNextEdit(request, createMockLogger(), createLogContext(), CancellationToken.None);
+			const finalValue = await AsyncIterUtils.drainUntilReturn(gen);
+
+			expect(finalValue.v).toBeInstanceOf(NoNextEditReason.FetchFailure);
 		});
 	});
 

--- a/src/platform/chat/common/commonTypes.ts
+++ b/src/platform/chat/common/commonTypes.ts
@@ -113,6 +113,8 @@ export enum ChatFetchResponseType {
 	Success = 'success'
 }
 
+export const RESPONSE_CONTAINED_NO_CHOICES = 'Response contained no choices.';
+
 export type ChatFetchError =
 	/**
 	 * We requested conversation, but the message was deemed off topic by the intent classifier.


### PR DESCRIPTION
diff-patch models return no choices if they have no edits