### PR TITLE
nes: smarter rebase when user types in agreement with suggestion

### DIFF
--- a/src/extension/inlineEdits/common/editRebase.ts
+++ b/src/extension/inlineEdits/common/editRebase.ts
@@ -15,6 +15,14 @@ import { ILinesDiffComputerOptions } from '../../../util/vs/editor/common/diff/l
 const TROUBLESHOOT_EDIT_CONSISTENCY = false;
 
 export interface NesRebaseConfigs {
+	/**
+	 * When enabled, if the user's typed text can be aligned as a subsequence of the
+	 * suggestion's insert text, the rebase absorbs it instead of failing.
+	 * For example, "()" aligns with "(n: number): number" because "(" and ")"
+	 * appear in that order; "(n: )" aligns similarly. Text like "abc" that cannot
+	 * be matched as a subsequence is not absorbed.
+	 */
+	readonly absorbSubsequenceTyping?: boolean;
 }
 
 export class EditDataWithIndex implements IEditData<EditDataWithIndex> {
@@ -231,7 +239,21 @@ function tryRebaseEdits<T extends IEditData<T>>(content: string, ours: Annotated
 export const maxAgreementOffset = 10; // If the user's typing is more than this into the suggestion we consider it a miss.
 export const maxImperfectAgreementLength = 5; // If the user's typing is longer than this and the suggestion is not a perfect match we consider it a miss.
 
+/** Returns true if every character of `typed` appears in `suggestion` in order (subsequence match). */
+function isSubsequenceOf(typed: string, suggestion: string): boolean {
+	let si = 0;
+	for (let ti = 0; ti < typed.length; ti++) {
+		const idx = suggestion.indexOf(typed[ti], si);
+		if (idx === -1) {
+			return false;
+		}
+		si = idx + 1;
+	}
+	return true;
+}
+
 function agreementIndexOf<T extends IEditData<T>>(content: string, ourE: AnnotatedStringReplacement<T>, baseE: StringReplacement, previousBaseE: StringReplacement | undefined, ourNewTextOffset: number, resolution: 'strict' | 'lenient', nesConfigs: NesRebaseConfigs) {
+	const originalBaseNewText = baseE.newText;
 	const minStart = previousBaseE ? previousBaseE.replaceRange.endExclusive : ourE.replaceRange.start;
 	if (minStart < baseE.replaceRange.start) {
 		baseE = new StringReplacement(
@@ -240,13 +262,20 @@ function agreementIndexOf<T extends IEditData<T>>(content: string, ourE: Annotat
 		);
 	}
 	const j = ourE.newText.indexOf(baseE.newText, ourNewTextOffset);
-	if (resolution === 'strict' && j > maxAgreementOffset) {
-		return -1;
+	const strictRejected = j !== -1 && resolution === 'strict' && (
+		j > maxAgreementOffset ||
+		(j > 0 && baseE.newText.length > maxImperfectAgreementLength)
+	);
+	if (j !== -1 && !strictRejected) {
+		return j + baseE.newText.length;
 	}
-	if (resolution === 'strict' && j > 0 && baseE.newText.length > maxImperfectAgreementLength) {
-		return -1;
+	// User typed text not found in suggestion (or rejected by strict limits) — absorb if it aligns as a subsequence.
+	// Guard: only attempt for short typed text to avoid expensive matching on long pastes
+	// and to stay consistent with the existing strict safeguards.
+	if (nesConfigs.absorbSubsequenceTyping && originalBaseNewText.length <= maxImperfectAgreementLength && isSubsequenceOf(originalBaseNewText, ourE.newText.substring(ourNewTextOffset))) {
+		return ourNewTextOffset;
 	}
-	return j !== -1 ? j + baseE.newText.length : -1;
+	return -1;
 }
 
 function computeDiff(original: string, modified: string, offset: number, editData: EditDataWithIndex, options: ILinesDiffComputerOptions): AnnotatedStringReplacement<EditDataWithIndex>[] | undefined {

--- a/src/extension/inlineEdits/node/nextEditCache.ts
+++ b/src/extension/inlineEdits/node/nextEditCache.ts
@@ -15,7 +15,7 @@ import { mapObservableArrayCached } from '../../../util/vs/base/common/observabl
 import { AnnotatedStringReplacement, StringEdit, StringReplacement } from '../../../util/vs/editor/common/core/edits/stringEdit';
 import { OffsetRange } from '../../../util/vs/editor/common/core/ranges/offsetRange';
 import { StringText } from '../../../util/vs/editor/common/core/text/abstractText';
-import { checkEditConsistency, EditDataWithIndex, tryRebase } from '../common/editRebase';
+import { checkEditConsistency, EditDataWithIndex, NesRebaseConfigs, tryRebase } from '../common/editRebase';
 import { NextEditFetchRequest } from './nextEditProvider';
 
 export interface CachedEditOpts {
@@ -62,8 +62,8 @@ export class NextEditCache extends Disposable {
 	constructor(
 		public readonly workspace: ObservableWorkspace,
 		private readonly _logService: ILogService,
-		configService: IConfigurationService,
-		expService: IExperimentationService,
+		private readonly _configService: IConfigurationService,
+		private readonly _expService: IExperimentationService,
 	) {
 		super();
 
@@ -81,7 +81,7 @@ export class NextEditCache extends Disposable {
 				}
 				// if editor-change triggering is allowed,
 				// 	it means an edit in file A can result in a cached edit for file B to be less relevant than with the edits in file A included
-				if (configService.getExperimentBasedConfig(ConfigKey.Advanced.InlineEditsTriggerOnEditorChangeAfterSeconds, expService) !== undefined) {
+				if (this._configService.getExperimentBasedConfig(ConfigKey.Advanced.InlineEditsTriggerOnEditorChangeAfterSeconds, this._expService) !== undefined) {
 					for (const [k, v] of this._sharedCache.entries()) {
 						if (v.docId !== doc.id) {
 							this._sharedCache.deleteKey(k);
@@ -112,12 +112,18 @@ export class NextEditCache extends Disposable {
 		docCache.setNoNextEdit(documentContents, editWindow, source);
 	}
 
+	private _getNesRebaseConfigs(): NesRebaseConfigs {
+		return {
+			absorbSubsequenceTyping: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsAbsorbSubsequenceTyping, this._expService),
+		};
+	}
+
 	public lookupNextEdit(docId: DocumentId, currentDocumentContents: StringText, currentSelection: readonly OffsetRange[]): CachedOrRebasedEdit | undefined {
 		const docCache = this._documentCaches.get(docId);
 		if (!docCache) {
 			return undefined;
 		}
-		return docCache.lookupNextEdit(currentDocumentContents, currentSelection);
+		return docCache.lookupNextEdit(currentDocumentContents, currentSelection, this._getNesRebaseConfigs());
 	}
 
 	public tryRebaseCacheEntry(cachedEdit: CachedEdit, currentDocumentContents: StringText, currentSelection: readonly OffsetRange[]): CachedOrRebasedEdit | undefined {
@@ -125,7 +131,7 @@ export class NextEditCache extends Disposable {
 		if (!docCache) {
 			return undefined;
 		}
-		return docCache.tryRebaseCacheEntry(cachedEdit, currentDocumentContents, currentSelection);
+		return docCache.tryRebaseCacheEntry(cachedEdit, currentDocumentContents, currentSelection, this._getNesRebaseConfigs());
 	}
 
 	public rejectedNextEdit(requestId: string): void {
@@ -228,7 +234,7 @@ class DocumentEditCache {
 		}
 	}
 
-	public lookupNextEdit(currentDocumentContents: StringText, currentSelection: readonly OffsetRange[]): CachedOrRebasedEdit | undefined {
+	public lookupNextEdit(currentDocumentContents: StringText, currentSelection: readonly OffsetRange[], nesRebaseConfigs: NesRebaseConfigs): CachedOrRebasedEdit | undefined {
 		// TODO@chrmarti: Update entries i > 1 with user edits and edit window and start tracking.
 		const key = this._getKey(currentDocumentContents.value);
 		const cachedEdit = this._sharedCache.get(key);
@@ -246,7 +252,7 @@ class DocumentEditCache {
 			return cachedEdit;
 		}
 		for (const cachedEdit of this._trackedCachedEdits) {
-			const rebased = this.tryRebaseCacheEntry(cachedEdit, currentDocumentContents, currentSelection);
+			const rebased = this.tryRebaseCacheEntry(cachedEdit, currentDocumentContents, currentSelection, nesRebaseConfigs);
 			if (rebased) {
 				return rebased;
 			}
@@ -254,7 +260,7 @@ class DocumentEditCache {
 		return undefined;
 	}
 
-	public tryRebaseCacheEntry(cachedEdit: CachedEdit, currentDocumentContents: StringText, currentSelection: readonly OffsetRange[]): CachedEdit | undefined {
+	public tryRebaseCacheEntry(cachedEdit: CachedEdit, currentDocumentContents: StringText, currentSelection: readonly OffsetRange[], nesRebaseConfigs: NesRebaseConfigs): CachedEdit | undefined {
 		const logger = this._logger.createSubLogger('tryRebaseCacheEntry');
 		if (cachedEdit.userEditSince && !cachedEdit.rebaseFailed) {
 			const originalEdits = cachedEdit.edits || (cachedEdit.edit ? [cachedEdit.edit] : []);
@@ -267,7 +273,7 @@ class DocumentEditCache {
 				: [cachedEdit.editWindow];
 
 			for (const window of windowsToTry) {
-				const res = tryRebase(cachedEdit.documentBeforeEdit.value, window, originalEdits, cachedEdit.detailedEdits, cachedEdit.userEditSince, currentDocumentContents.value, currentSelection, 'strict', logger);
+				const res = tryRebase(cachedEdit.documentBeforeEdit.value, window, originalEdits, cachedEdit.detailedEdits, cachedEdit.userEditSince, currentDocumentContents.value, currentSelection, 'strict', logger, nesRebaseConfigs);
 				if (res === 'rebaseFailed') {
 					cachedEdit.rebaseFailed = true;
 					return undefined;

--- a/src/extension/inlineEdits/test/common/editRebase.spec.ts
+++ b/src/extension/inlineEdits/test/common/editRebase.spec.ts
@@ -232,6 +232,322 @@ int main()
 			expect(result[0].rebasedEdit.removeCommonSuffixAndPrefix(currentDocument).toString()).toMatchInlineSnapshot(`"[87, 164) -> "esult42.empty())\\n        return result42.size();\\n    result42.clear();\\n    return result42""`);
 		}
 	});
+
+	test('tryRebase fails when user types characters absent from the suggestion', () => {
+		// Document state when suggestion was cached:
+		//   "function fib\n"
+		//                ^ cursor at offset 12
+		//
+		// Suggestion (two edits):
+		//   edit 0: replace [0,12) "function fib" → "function fib(n: number): number {"
+		//   edit 1: insert at 34                  → "    if (n <= 1) return n;\n    return fib(n - 1) + fib(n - 2);\n}\n"
+		//
+		// User then types "()" at offset 12, producing:
+		//   "function fib()\n"
+		//
+		// Rebase fails because the diff of edit 0 inserts "(n: number): number {" at offset 12,
+		// but the user typed "()" — and "()" is not a substring of "(n: number): number {",
+		// so agreementIndexOf returns -1 and the rebase cannot reconcile the two.
+		const originalDocument = 'function fib\n';
+		const originalEdits = [
+			StringReplacement.replace(new OffsetRange(0, 12), 'function fib(n: number): number {'),
+			StringReplacement.replace(new OffsetRange(34, 34), '    if (n <= 1) return n;\n    return fib(n - 1) + fib(n - 2);\n}\n'),
+		];
+		const userEditSince = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(12, 12), '()'),
+		]);
+		const currentDocumentContent = 'function fib()\n';
+		const editWindow = new OffsetRange(0, 13);
+		const currentSelection = [new OffsetRange(13, 13)];
+
+		const logger = new TestLogService();
+		expect(tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'strict', logger)).toBe('rebaseFailed');
+		expect(tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'lenient', logger)).toBe('rebaseFailed');
+	});
+
+	test('absorbSubsequenceTyping: parentheses typed by user are absorbed', () => {
+		// The "()" the user typed is a subsequence of the suggestion's "(n: number): number {",
+		// so the rebased edit replaces it with the suggestion's text.
+		const originalDocument = 'function fib\n';
+		const originalEdits = [
+			StringReplacement.replace(new OffsetRange(0, 12), 'function fib(n: number): number {'),
+			StringReplacement.replace(new OffsetRange(34, 34), '    if (n <= 1) return n;\n    return fib(n - 1) + fib(n - 2);\n}\n'),
+		];
+		const userEditSince = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(12, 12), '()'),
+		]);
+		const currentDocumentContent = 'function fib()\n';
+		const editWindow = new OffsetRange(0, 13);
+		const currentSelection = [new OffsetRange(13, 13)];
+		const nesConfigs = { absorbSubsequenceTyping: true };
+		const logger = new TestLogService();
+
+		const final = 'function fib(n: number): number {\n    if (n <= 1) return n;\n    return fib(n - 1) + fib(n - 2);\n}\n';
+
+		{
+			const res = tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'strict', logger, nesConfigs);
+			expect(res).toBeTypeOf('object');
+			const result = res as Exclude<typeof res, string>;
+			expect(StringEdit.create(result.map(r => r.rebasedEdit)).apply(currentDocumentContent)).toBe(final);
+		}
+		{
+			const res = tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'lenient', logger, nesConfigs);
+			expect(res).toBeTypeOf('object');
+			const result = res as Exclude<typeof res, string>;
+			expect(StringEdit.create(result.map(r => r.rebasedEdit)).apply(currentDocumentContent)).toBe(final);
+		}
+	});
+
+	test('absorbSubsequenceTyping: user types partial params "(n: )" absorbed', () => {
+		// User types "(n: )" in "function fib" → "function fib(n: )\n"
+		// "(n: )" is a subsequence of "(n: number): number {" because each character
+		// ( → 0, n → 1, : → 2, ' ' → 3, ) → 10 aligns in order.
+		const originalDocument = 'function fib\n';
+		const originalEdits = [
+			StringReplacement.replace(new OffsetRange(0, 12), 'function fib(n: number): number {'),
+			StringReplacement.replace(new OffsetRange(34, 34), '    if (n <= 1) return n;\n    return fib(n - 1) + fib(n - 2);\n}\n'),
+		];
+		const userEditSince = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(12, 12), '(n: )'),
+		]);
+		const currentDocumentContent = 'function fib(n: )\n';
+		const editWindow = new OffsetRange(0, 13);
+		const currentSelection = [new OffsetRange(16, 16)];
+		const nesConfigs = { absorbSubsequenceTyping: true };
+		const logger = new TestLogService();
+
+		const final = 'function fib(n: number): number {\n    if (n <= 1) return n;\n    return fib(n - 1) + fib(n - 2);\n}\n';
+
+		{
+			const res = tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'strict', logger, nesConfigs);
+			expect(res).toBeTypeOf('object');
+			const result = res as Exclude<typeof res, string>;
+			expect(StringEdit.create(result.map(r => r.rebasedEdit)).apply(currentDocumentContent)).toBe(final);
+		}
+		{
+			const res = tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'lenient', logger, nesConfigs);
+			expect(res).toBeTypeOf('object');
+			const result = res as Exclude<typeof res, string>;
+			expect(StringEdit.create(result.map(r => r.rebasedEdit)).apply(currentDocumentContent)).toBe(final);
+		}
+	});
+
+	test('absorbSubsequenceTyping: semicolon NOT absorbed when it cannot align with suggestion', () => {
+		// User types ";" but suggestion wants to insert ": string = \"hello\""
+		// ";" is not a subsequence of ": string = \"hello\"", so absorption fails
+		const originalDocument = 'const x\n';
+		const originalEdits = [
+			StringReplacement.replace(new OffsetRange(0, 7), 'const x: string = "hello"'),
+		];
+		const userEditSince = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(7, 7), ';'),
+		]);
+		const currentDocumentContent = 'const x;\n';
+		const editWindow = new OffsetRange(0, 8);
+		const currentSelection = [new OffsetRange(8, 8)];
+		const nesConfigs = { absorbSubsequenceTyping: true };
+		const logger = new TestLogService();
+
+		expect(tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'strict', logger, nesConfigs)).toBe('rebaseFailed');
+		expect(tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'lenient', logger, nesConfigs)).toBe('rebaseFailed');
+	});
+
+	test('absorbSubsequenceTyping: semicolon absorbed when suggestion contains semicolon', () => {
+		// User types ";" and suggestion inserts ": string = \"hello\";"
+		// ";" IS a subsequence of ": string = \"hello\";", so absorption succeeds
+		const originalDocument = 'const x\n';
+		const originalEdits = [
+			StringReplacement.replace(new OffsetRange(0, 7), 'const x: string = "hello";'),
+		];
+		const userEditSince = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(7, 7), ';'),
+		]);
+		const currentDocumentContent = 'const x;\n';
+		const editWindow = new OffsetRange(0, 8);
+		const currentSelection = [new OffsetRange(8, 8)];
+		const nesConfigs = { absorbSubsequenceTyping: true };
+		const logger = new TestLogService();
+
+		const final = 'const x: string = "hello";\n';
+
+		{
+			const res = tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'strict', logger, nesConfigs);
+			expect(res).toBeTypeOf('object');
+			const result = res as Exclude<typeof res, string>;
+			expect(StringEdit.create(result.map(r => r.rebasedEdit)).apply(currentDocumentContent)).toBe(final);
+		}
+	});
+
+	test('absorbSubsequenceTyping: text NOT a subsequence of suggestion is NOT absorbed', () => {
+		// User types "abc" — not a subsequence of "(n: number): number {", so not absorbed
+		const originalDocument = 'function fib\n';
+		const originalEdits = [
+			StringReplacement.replace(new OffsetRange(0, 12), 'function fib(n: number): number {'),
+			StringReplacement.replace(new OffsetRange(34, 34), '    if (n <= 1) return n;\n    return fib(n - 1) + fib(n - 2);\n}\n'),
+		];
+		const userEditSince = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(12, 12), 'abc'),
+		]);
+		const currentDocumentContent = 'function fibabc\n';
+		const editWindow = new OffsetRange(0, 13);
+		const currentSelection = [new OffsetRange(15, 15)];
+		const nesConfigs = { absorbSubsequenceTyping: true };
+		const logger = new TestLogService();
+
+		expect(tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'strict', logger, nesConfigs)).toBe('rebaseFailed');
+		expect(tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'lenient', logger, nesConfigs)).toBe('rebaseFailed');
+	});
+
+	test('absorbSubsequenceTyping: text NOT a subsequence of suggestion is NOT absorbed (2)', () => {
+		// User types "(a" — "a" is not found in "(n: number): number {", so not absorbed
+		const originalDocument = 'function fib\n';
+		const originalEdits = [
+			StringReplacement.replace(new OffsetRange(0, 12), 'function fib(n: number): number {'),
+			StringReplacement.replace(new OffsetRange(34, 34), '    if (n <= 1) return n;\n    return fib(n - 1) + fib(n - 2);\n}\n'),
+		];
+		const userEditSince = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(12, 12), '(a'),
+		]);
+		const currentDocumentContent = 'function fib(a\n';
+		const editWindow = new OffsetRange(0, 13);
+		const currentSelection = [new OffsetRange(14, 14)];
+		const nesConfigs = { absorbSubsequenceTyping: true };
+		const logger = new TestLogService();
+
+		expect(tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'strict', logger, nesConfigs)).toBe('rebaseFailed');
+		expect(tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'lenient', logger, nesConfigs)).toBe('rebaseFailed');
+	});
+
+	test('absorbSubsequenceTyping: config disabled means punctuation is NOT absorbed', () => {
+		// Same fib scenario with "()" but config is explicitly false
+		const originalDocument = 'function fib\n';
+		const originalEdits = [
+			StringReplacement.replace(new OffsetRange(0, 12), 'function fib(n: number): number {'),
+			StringReplacement.replace(new OffsetRange(34, 34), '    if (n <= 1) return n;\n    return fib(n - 1) + fib(n - 2);\n}\n'),
+		];
+		const userEditSince = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(12, 12), '()'),
+		]);
+		const currentDocumentContent = 'function fib()\n';
+		const editWindow = new OffsetRange(0, 13);
+		const currentSelection = [new OffsetRange(13, 13)];
+		const logger = new TestLogService();
+
+		// Explicitly disabled
+		expect(tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'strict', logger, { absorbSubsequenceTyping: false })).toBe('rebaseFailed');
+		// Default (no config)
+		expect(tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'strict', logger)).toBe('rebaseFailed');
+	});
+
+	test('absorbSubsequenceTyping: normal agreement still works when user types text present in suggestion', () => {
+		// User types "(n" which IS a prefix found in the suggestion "(n: number): number {"
+		// Normal agreement should handle this regardless of the config
+		const originalDocument = 'function fib\n';
+		const suggestedEdit = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(0, 12), 'function fib(n: number): number {'),
+		]);
+		const userEdit = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(12, 12), '(n'),
+		]);
+		const currentDocument = userEdit.apply(originalDocument);
+		expect(currentDocument).toBe('function fib(n\n');
+
+		const nesConfigs = { absorbSubsequenceTyping: true };
+		const res = tryRebaseStringEdits(originalDocument, suggestedEdit, userEdit, 'strict', nesConfigs);
+		expect(res).toBeDefined();
+		expect(res!.apply(currentDocument)).toBe(suggestedEdit.apply(originalDocument));
+	});
+
+	test('absorbSubsequenceTyping via tryRebaseStringEdits: curly brace absorbed', () => {
+		const text = 'if (true)\n';
+		const suggestion = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(0, 9), 'if (true) {\n    console.log("yes");\n}'),
+		]);
+		const userEdit = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(9, 9), '{'),
+		]);
+		const current = userEdit.apply(text);
+		expect(current).toBe('if (true){\n');
+
+		const final = suggestion.apply(text);
+		expect(final).toBe('if (true) {\n    console.log("yes");\n}\n');
+
+		// Without config: fails
+		expect(tryRebaseStringEdits(text, suggestion, userEdit, 'strict')).toBeUndefined();
+
+		// With config: succeeds because "{" aligns with "{" in the suggestion
+		const result = tryRebaseStringEdits(text, suggestion, userEdit, 'strict', { absorbSubsequenceTyping: true });
+		expect(result).toBeDefined();
+		expect(result!.apply(current)).toBe(final);
+	});
+
+	test('absorbSubsequenceTyping: "{}" NOT absorbed when suggestion only has opening brace', () => {
+		// User types "{}" but suggestion only inserts " {" (no closing brace in suggestion text)
+		// "}" is not found after "{" in " {", so subsequence check fails
+		const text = 'if (true)\n';
+		const suggestion = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(0, 9), 'if (true) {\n    console.log("yes");'),
+		]);
+		const userEdit = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(9, 9), '{}'),
+		]);
+		const current = userEdit.apply(text);
+		expect(current).toBe('if (true){}\n');
+
+		expect(tryRebaseStringEdits(text, suggestion, userEdit, 'strict', { absorbSubsequenceTyping: true })).toBeUndefined();
+	});
+
+	test('absorbSubsequenceTyping: "{}" absorbed when suggestion has both braces', () => {
+		const text = 'if (true)\n';
+		const suggestion = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(0, 9), 'if (true) {\n    console.log("yes");\n}'),
+		]);
+		const userEdit = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(9, 9), '{}'),
+		]);
+		const current = userEdit.apply(text);
+		expect(current).toBe('if (true){}\n');
+
+		const final = suggestion.apply(text);
+		expect(final).toBe('if (true) {\n    console.log("yes");\n}\n');
+
+		const result = tryRebaseStringEdits(text, suggestion, userEdit, 'strict', { absorbSubsequenceTyping: true });
+		expect(result).toBeDefined();
+		expect(result!.apply(current)).toBe(final);
+	});
+
+	test('absorbSubsequenceTyping: "{}" typed after function signature, suggestion fills body', () => {
+		// User types "{}" after "function fib(n: number) " → "function fib(n: number) {}\n"
+		// Suggestion wants to replace with a full function body including { ... }
+		// "{}" is a subsequence of "{\n    if ...\n}" so absorption succeeds
+		const originalDocument = 'function fib(n: number) \n';
+		const originalEdits = [
+			StringReplacement.replace(new OffsetRange(0, 24), 'function fib(n: number) {\n    if (n <= 1) return 1;\n    return n * factorial(n - 1);\n}'),
+		];
+		const userEditSince = StringEdit.create([
+			StringReplacement.replace(new OffsetRange(24, 24), '{}'),
+		]);
+		const currentDocumentContent = 'function fib(n: number) {}\n';
+		const editWindow = new OffsetRange(0, 25);
+		const currentSelection = [new OffsetRange(26, 26)];
+		const nesConfigs = { absorbSubsequenceTyping: true };
+		const logger = new TestLogService();
+
+		const final = 'function fib(n: number) {\n    if (n <= 1) return 1;\n    return n * factorial(n - 1);\n}\n';
+
+		{
+			const res = tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'strict', logger, nesConfigs);
+			expect(res).toBeTypeOf('object');
+			const result = res as Exclude<typeof res, string>;
+			expect(StringEdit.create(result.map(r => r.rebasedEdit)).apply(currentDocumentContent)).toBe(final);
+		}
+		{
+			const res = tryRebase(originalDocument, editWindow, originalEdits, [], userEditSince, currentDocumentContent, currentSelection, 'lenient', logger, nesConfigs);
+			expect(res).toBeTypeOf('object');
+			const result = res as Exclude<typeof res, string>;
+			expect(StringEdit.create(result.map(r => r.rebasedEdit)).apply(currentDocumentContent)).toBe(final);
+		}
+	});
 });
 
 suite('NextEditCache.tryRebaseStringEdits', () => {

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -815,6 +815,7 @@ export namespace ConfigKey {
 		export const InlineEditsSubsequentCacheDelay = defineTeamInternalSetting<number | undefined>('chat.advanced.inlineEdits.subsequentCacheDelay', ConfigType.ExperimentBased, 0);
 		export const InlineEditsSpeculativeRequestDelay = defineTeamInternalSetting<number | undefined>('chat.advanced.inlineEdits.speculativeRequestDelay', ConfigType.ExperimentBased, 0);
 		export const InlineEditsRebasedCacheDelay = defineTeamInternalSetting<number | undefined>('chat.advanced.inlineEdits.rebasedCacheDelay', ConfigType.ExperimentBased, 0);
+		export const InlineEditsAbsorbSubsequenceTyping = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.absorbSubsequenceTyping', ConfigType.ExperimentBased, false);
 		export const InlineEditsBackoffDebounceEnabled = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.backoffDebounceEnabled', ConfigType.ExperimentBased, true);
 		export const InlineEditsExtraDebounceEndOfLine = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.extraDebounceEndOfLine', ConfigType.ExperimentBased, 2000);
 		export const InlineEditsSpeculativeRequests = defineTeamInternalSetting<SpeculativeRequestsEnablement>('chat.advanced.inlineEdits.speculativeRequests', ConfigType.ExperimentBased, SpeculativeRequestsEnablement.Off, SpeculativeRequestsEnablement.VALIDATOR);


### PR DESCRIPTION
* test: add tryRebase test showing rebase failure when user types divergent text

Add a test case for tryRebase where:
- Document is "function fib\n", suggestion replaces it with a full fib function
- User types "()" at the cursor, producing "function fib()\n"
- Rebase fails because "()" is not a substring of the suggestion's
  insert text "(n: number): number {", so agreementIndexOf cannot
  reconcile the user's typing with the suggested edit

* nes: smarter rebase when user types in agreement with suggestion

but is actually a subsequence of the insertion

* address copilot review: read config at call sites, add length guard for subsequence absorption