### PR TITLE
Add OTel log event for conversation summarization

### DIFF
--- a/package.json
+++ b/package.json
@@ -4331,16 +4331,6 @@
 							"onExp"
 						]
 					},
-					"github.copilot.chat.agentHistorySummarizationForceGpt41": {
-						"type": "boolean",
-						"default": false,
-						"markdownDescription": "%github.copilot.config.agentHistorySummarizationForceGpt41%",
-						"tags": [
-							"advanced",
-							"experimental",
-							"onExp"
-						]
-					},
 					"github.copilot.chat.useResponsesApiTruncation": {
 						"type": "boolean",
 						"default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -393,7 +393,6 @@
 	"github.copilot.config.agentHistorySummarizationMode": "Mode for agent history summarization.",
 	"github.copilot.config.backgroundCompaction": "Enable background compaction of conversation history.",
 	"github.copilot.config.agentHistorySummarizationWithPromptCache": "Use prompt caching for agent history summarization.",
-	"github.copilot.config.agentHistorySummarizationForceGpt41": "Force GPT-4.1 for agent history summarization.",
 	"github.copilot.config.useResponsesApiTruncation": "Use Responses API for truncation.",
 	"github.copilot.config.enableReadFileV2": "Enable version 2 of the read file tool.",
 	"github.copilot.config.enableAskAgent": "Enable the Ask agent for answering questions.",

--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -655,6 +655,7 @@ class ConversationHistorySummarizer {
 		const endpoint = forceGpt41 && (gpt41Endpoint.modelMaxPromptTokens >= this.props.endpoint.modelMaxPromptTokens) ?
 			gpt41Endpoint :
 			this.props.endpoint;
+		const resolvedModel = endpoint.model;
 
 		let summarizationPrompt: ChatMessage[];
 		const associatedRequestId = this.props.promptContext.conversation?.getLatestTurn().id;
@@ -675,11 +676,10 @@ class ConversationHistorySummarizer {
 			const budgetExceeded = e instanceof BudgetExceededError;
 			const outcome = budgetExceeded ? 'budget_exceeded' : 'renderError';
 			this.logInfo(`Error rendering summarization prompt in mode: ${mode}. ${e.stack}`, mode);
-			this.sendSummarizationTelemetry(outcome, '', this.props.endpoint.model, mode, stopwatch.elapsed(), undefined);
+			this.sendSummarizationTelemetry(outcome, '', resolvedModel, mode, stopwatch.elapsed(), undefined);
 			throw e;
 		}
 
-		const resolvedModel = endpoint.model;
 		let summaryResponse: ChatResponse;
 		try {
 			const toolOpts = mode === SummaryMode.Full ? {

--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -19,7 +19,7 @@ import { IChatEndpoint } from '../../../../platform/networking/common/networking
 import { APIUsage } from '../../../../platform/networking/common/openai';
 import { IPromptPathRepresentationService } from '../../../../platform/prompts/common/promptPathRepresentationService';
 import { IOTelService } from '../../../../platform/otel/common/otelService';
-import { emitSummarizationEvent } from '../../../../platform/otel/common/genAiEvents';
+import { emitSummarizationEvent } from '../../../../platform/otel/common/index';
 import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry';
 import { ThinkingData } from '../../../../platform/thinking/common/thinking';

--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -18,6 +18,8 @@ import { ILogService } from '../../../../platform/log/common/logService';
 import { IChatEndpoint } from '../../../../platform/networking/common/networking';
 import { APIUsage } from '../../../../platform/networking/common/openai';
 import { IPromptPathRepresentationService } from '../../../../platform/prompts/common/promptPathRepresentationService';
+import { IOTelService } from '../../../../platform/otel/common/otelService';
+import { emitSummarizationEvent } from '../../../../platform/otel/common/genAiEvents';
 import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry';
 import { ThinkingData } from '../../../../platform/thinking/common/thinking';
@@ -564,6 +566,7 @@ class ConversationHistorySummarizer {
 		@IExperimentationService private readonly experimentationService: IExperimentationService,
 		@IEndpointProvider private readonly endpointProvider: IEndpointProvider,
 		@IChatHookService private readonly chatHookService: IChatHookService,
+		@IOTelService private readonly otelService: IOTelService,
 	) { }
 
 	async summarizeHistory(): Promise<{ summary: string; toolCallRoundId: string; thinking?: ThinkingData; usage?: APIUsage; promptTokenDetails?: readonly ChatResultPromptTokenDetail[]; model?: string; summarizationMode?: string; numRounds?: number; numRoundsSinceLastSummarization?: number; durationMs?: number }> {
@@ -676,6 +679,7 @@ class ConversationHistorySummarizer {
 			throw e;
 		}
 
+		const resolvedModel = endpoint.model;
 		let summaryResponse: ChatResponse;
 		try {
 			const toolOpts = mode === SummaryMode.Full ? {
@@ -717,7 +721,7 @@ class ConversationHistorySummarizer {
 			}, this.token ?? CancellationToken.None);
 		} catch (e) {
 			this.logInfo(`Error from summarization request. ${e.message}`, mode);
-			this.sendSummarizationTelemetry('requestThrow', '', this.props.endpoint.model, mode, stopwatch.elapsed(), undefined);
+			this.sendSummarizationTelemetry('requestThrow', '', resolvedModel, mode, stopwatch.elapsed(), undefined);
 			throw e;
 		}
 
@@ -731,18 +735,18 @@ class ConversationHistorySummarizer {
 
 		const durationMs = stopwatch.elapsed();
 		return {
-			result: await this.handleSummarizationResponse(summaryResponse, mode, durationMs),
+			result: await this.handleSummarizationResponse(summaryResponse, resolvedModel, mode, durationMs),
 			promptTokenDetails,
-			model: endpoint.model,
+			model: resolvedModel,
 			summarizationMode: mode,
 			durationMs,
 		};
 	}
 
-	private async handleSummarizationResponse(response: ChatResponse, mode: SummaryMode, elapsedTime: number): Promise<FetchSuccess<string>> {
+	private async handleSummarizationResponse(response: ChatResponse, model: string, mode: SummaryMode, elapsedTime: number): Promise<FetchSuccess<string>> {
 		if (response.type !== ChatFetchResponseType.Success) {
 			const outcome = response.type;
-			this.sendSummarizationTelemetry(outcome, response.requestId, this.props.endpoint.model, mode, elapsedTime, undefined, response.reason);
+			this.sendSummarizationTelemetry(outcome, response.requestId, model, mode, elapsedTime, undefined, response.reason);
 			this.logInfo(`Summarization request failed. ${response.type} ${response.reason}`, mode);
 			if (response.type === ChatFetchResponseType.Canceled) {
 				throw new CancellationError();
@@ -757,12 +761,12 @@ class ConversationHistorySummarizer {
 				? Math.min(this.sizing.tokenBudget, this.props.maxSummaryTokens)
 				: this.sizing.tokenBudget;
 		if (summarySize > effectiveBudget) {
-			this.sendSummarizationTelemetry('too_large', response.requestId, this.props.endpoint.model, mode, elapsedTime, response.usage);
+			this.sendSummarizationTelemetry('too_large', response.requestId, model, mode, elapsedTime, response.usage);
 			this.logInfo(`Summary too large: ${summarySize} tokens (effective budget ${effectiveBudget})`, mode);
 			throw new Error('Summary too large');
 		}
 
-		this.sendSummarizationTelemetry('success', response.requestId, this.props.endpoint.model, mode, elapsedTime, response.usage);
+		this.sendSummarizationTelemetry('success', response.requestId, model, mode, elapsedTime, response.usage);
 		return response;
 	}
 
@@ -840,6 +844,21 @@ class ConversationHistorySummarizer {
 				"source": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the summarization was triggered as a background or foreground operation." }
 			}
 		*/
+		emitSummarizationEvent(this.otelService, {
+			outcome,
+			model,
+			source: this.props.summarizationSource ?? 'foreground',
+			summarizationMode: mode,
+			durationMs: elapsedTime,
+			numRounds,
+			numRoundsSinceLastSummarization,
+			contextLengthBefore: undefined,
+			promptTokens: usage?.prompt_tokens,
+			completionTokens: usage?.completion_tokens,
+			cachedTokens: usage?.prompt_tokens_details?.cached_tokens,
+			detailedOutcome,
+		});
+
 		this.telemetryService.sendMSFTTelemetryEvent('summarizedConversationHistory', {
 			summarizationId: this.summarizationId,
 			outcome,

--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -13,7 +13,6 @@ import { ChatFetchResponseType, ChatLocation, ChatResponse, FetchSuccess } from 
 import { IHistoricalTurn, ISessionTranscriptService } from '../../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
 import { isAnthropicFamily } from '../../../../platform/endpoint/common/chatModelCapabilities';
-import { IEndpointProvider } from '../../../../platform/endpoint/common/endpointProvider';
 import { ILogService } from '../../../../platform/log/common/logService';
 import { IChatEndpoint } from '../../../../platform/networking/common/networking';
 import { APIUsage } from '../../../../platform/networking/common/openai';
@@ -564,7 +563,6 @@ class ConversationHistorySummarizer {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IExperimentationService private readonly experimentationService: IExperimentationService,
-		@IEndpointProvider private readonly endpointProvider: IEndpointProvider,
 		@IChatHookService private readonly chatHookService: IChatHookService,
 		@IOTelService private readonly otelService: IOTelService,
 	) { }
@@ -650,11 +648,7 @@ class ConversationHistorySummarizer {
 
 	private async getSummary(mode: SummaryMode, propsInfo: ISummarizedConversationHistoryInfo): Promise<SummarizationResult> {
 		const stopwatch = new StopWatch(false);
-		const forceGpt41 = this.configurationService.getExperimentBasedConfig(ConfigKey.Advanced.AgentHistorySummarizationForceGpt41, this.experimentationService);
-		const gpt41Endpoint = await this.endpointProvider.getChatEndpoint('copilot-base');
-		const endpoint = forceGpt41 && (gpt41Endpoint.modelMaxPromptTokens >= this.props.endpoint.modelMaxPromptTokens) ?
-			gpt41Endpoint :
-			this.props.endpoint;
+		const endpoint = this.props.endpoint;
 		const resolvedModel = endpoint.model;
 
 		let summarizationPrompt: ChatMessage[];

--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -16,7 +16,7 @@ import { isAnthropicFamily } from '../../../../platform/endpoint/common/chatMode
 import { ILogService } from '../../../../platform/log/common/logService';
 import { IChatEndpoint } from '../../../../platform/networking/common/networking';
 import { APIUsage } from '../../../../platform/networking/common/openai';
-import { emitSummarizationEvent } from '../../../../platform/otel/common/index';
+import { emitSummarizationEvent, GenAiAttr, GenAiMetrics, SpanKind, SpanStatusCode, type ISpanHandle } from '../../../../platform/otel/common/index';
 import { IOTelService } from '../../../../platform/otel/common/otelService';
 import { IPromptPathRepresentationService } from '../../../../platform/prompts/common/promptPathRepresentationService';
 import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
@@ -651,6 +651,27 @@ class ConversationHistorySummarizer {
 		const endpoint = this.props.endpoint;
 		const resolvedModel = endpoint.model;
 
+		const span = this.otelService.startSpan(`summarize_conversation ${mode}`, {
+			kind: SpanKind.INTERNAL,
+			attributes: {
+				'event.name': 'copilot_chat.summarization',
+				[GenAiAttr.REQUEST_MODEL]: resolvedModel,
+				'summarization_mode': mode,
+				'source': this.props.summarizationSource ?? 'foreground',
+			},
+		});
+
+		try {
+			return await this._getSummaryInner(mode, propsInfo, stopwatch, endpoint, resolvedModel, span);
+		} catch (e) {
+			span.setStatus(SpanStatusCode.ERROR, e instanceof Error ? e.message : String(e));
+			throw e;
+		} finally {
+			span.end();
+		}
+	}
+
+	private async _getSummaryInner(mode: SummaryMode, propsInfo: ISummarizedConversationHistoryInfo, stopwatch: StopWatch, endpoint: IChatEndpoint, resolvedModel: string, span: ISpanHandle): Promise<SummarizationResult> {
 		let summarizationPrompt: ChatMessage[];
 		const associatedRequestId = this.props.promptContext.conversation?.getLatestTurn().id;
 		const promptCacheMode = this.configurationService.getExperimentBasedConfig(ConfigKey.Advanced.AgentHistorySummarizationWithPromptCache, this.experimentationService);
@@ -728,6 +749,17 @@ class ConversationHistorySummarizer {
 		});
 
 		const durationMs = stopwatch.elapsed();
+
+		span.setStatus(SpanStatusCode.OK);
+		span.setAttributes({
+			'outcome': 'success',
+			'duration_ms': durationMs,
+			...(summaryResponse.type === ChatFetchResponseType.Success ? {
+				[GenAiAttr.USAGE_INPUT_TOKENS]: summaryResponse.usage?.prompt_tokens ?? 0,
+				[GenAiAttr.USAGE_OUTPUT_TOKENS]: summaryResponse.usage?.completion_tokens ?? 0,
+			} : {}),
+		});
+
 		return {
 			result: await this.handleSummarizationResponse(summaryResponse, resolvedModel, mode, durationMs),
 			promptTokenDetails,
@@ -851,6 +883,10 @@ class ConversationHistorySummarizer {
 			cachedTokens: usage?.prompt_tokens_details?.cached_tokens,
 			detailedOutcome,
 		});
+
+		const metricAttrs = { model, mode, outcome };
+		GenAiMetrics.recordSummarizationCount(this.otelService, metricAttrs);
+		GenAiMetrics.recordSummarizationDuration(this.otelService, elapsedTime / 1000, metricAttrs);
 
 		this.telemetryService.sendMSFTTelemetryEvent('summarizedConversationHistory', {
 			summarizationId: this.summarizationId,

--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -16,9 +16,9 @@ import { isAnthropicFamily } from '../../../../platform/endpoint/common/chatMode
 import { ILogService } from '../../../../platform/log/common/logService';
 import { IChatEndpoint } from '../../../../platform/networking/common/networking';
 import { APIUsage } from '../../../../platform/networking/common/openai';
-import { IPromptPathRepresentationService } from '../../../../platform/prompts/common/promptPathRepresentationService';
-import { IOTelService } from '../../../../platform/otel/common/otelService';
 import { emitSummarizationEvent } from '../../../../platform/otel/common/index';
+import { IOTelService } from '../../../../platform/otel/common/otelService';
+import { IPromptPathRepresentationService } from '../../../../platform/prompts/common/promptPathRepresentationService';
 import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry';
 import { ThinkingData } from '../../../../platform/thinking/common/thinking';
@@ -846,7 +846,6 @@ class ConversationHistorySummarizer {
 			durationMs: elapsedTime,
 			numRounds,
 			numRoundsSinceLastSummarization,
-			contextLengthBefore: undefined,
 			promptTokens: usage?.prompt_tokens,
 			completionTokens: usage?.completion_tokens,
 			cachedTokens: usage?.prompt_tokens_details?.cached_tokens,

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -638,7 +638,6 @@ export namespace ConfigKey {
 		export const InstantApplyShortModelName = defineAndMigrateExpSetting<string>('chat.advanced.instantApply.shortContextModelName', 'chat.instantApply.shortContextModelName', CHAT_MODEL.SHORT_INSTANT_APPLY);
 		export const InstantApplyShortContextLimit = defineAndMigrateExpSetting<number>('chat.advanced.instantApply.shortContextLimit', 'chat.instantApply.shortContextLimit', 8000);
 		export const AgentHistorySummarizationWithPromptCache = defineAndMigrateExpSetting<boolean | undefined>('chat.advanced.agentHistorySummarizationWithPromptCache', 'chat.agentHistorySummarizationWithPromptCache', false);
-		export const AgentHistorySummarizationForceGpt41 = defineAndMigrateExpSetting<boolean | undefined>('chat.advanced.agentHistorySummarizationForceGpt41', 'chat.agentHistorySummarizationForceGpt41', false);
 		export const PromptFileContext = defineAndMigrateExpSetting<boolean>('chat.advanced.promptFileContextProvider.enabled', 'chat.promptFileContextProvider.enabled', true);
 		export const DefaultToolsGrouped = defineAndMigrateExpSetting<boolean>('chat.advanced.tools.defaultToolsGrouped', 'chat.tools.defaultToolsGrouped', false);
 		export const Gpt5AlternativePatch = defineAndMigrateExpSetting<boolean>('chat.advanced.gpt5AlternativePatch', 'chat.gpt5AlternativePatch', false);

--- a/src/platform/otel/common/genAiEvents.ts
+++ b/src/platform/otel/common/genAiEvents.ts
@@ -145,6 +145,6 @@ export function emitSummarizationEvent(
 		...(params.promptTokens !== undefined ? { [GenAiAttr.USAGE_INPUT_TOKENS]: params.promptTokens } : {}),
 		...(params.completionTokens !== undefined ? { [GenAiAttr.USAGE_OUTPUT_TOKENS]: params.completionTokens } : {}),
 		...(params.cachedTokens !== undefined ? { [GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: params.cachedTokens } : {}),
-		...(params.detailedOutcome ? { 'detailed_outcome': params.detailedOutcome } : {}),
+		...(params.detailedOutcome !== undefined ? { 'detailed_outcome': params.detailedOutcome } : {}),
 	});
 }

--- a/src/platform/otel/common/genAiEvents.ts
+++ b/src/platform/otel/common/genAiEvents.ts
@@ -114,3 +114,37 @@ export function emitAgentTurnEvent(
 		'tool_call_count': toolCallCount,
 	});
 }
+
+export function emitSummarizationEvent(
+	otel: IOTelService,
+	params: {
+		outcome: string;
+		model: string;
+		source: string;
+		summarizationMode: string;
+		durationMs: number;
+		numRounds?: number;
+		numRoundsSinceLastSummarization?: number;
+		contextLengthBefore?: number;
+		promptTokens?: number;
+		completionTokens?: number;
+		cachedTokens?: number;
+		detailedOutcome?: string;
+	},
+): void {
+	otel.emitLogRecord(`copilot_chat.summarization: ${params.outcome}`, {
+		'event.name': 'copilot_chat.summarization',
+		'outcome': params.outcome,
+		[GenAiAttr.REQUEST_MODEL]: params.model,
+		'source': params.source,
+		'summarization_mode': params.summarizationMode,
+		'duration_ms': params.durationMs,
+		...(params.numRounds !== undefined ? { 'num_rounds': params.numRounds } : {}),
+		...(params.numRoundsSinceLastSummarization !== undefined ? { 'num_rounds_since_last_summarization': params.numRoundsSinceLastSummarization } : {}),
+		...(params.contextLengthBefore !== undefined ? { 'context_length_before': params.contextLengthBefore } : {}),
+		...(params.promptTokens !== undefined ? { [GenAiAttr.USAGE_INPUT_TOKENS]: params.promptTokens } : {}),
+		...(params.completionTokens !== undefined ? { [GenAiAttr.USAGE_OUTPUT_TOKENS]: params.completionTokens } : {}),
+		...(params.cachedTokens !== undefined ? { [GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: params.cachedTokens } : {}),
+		...(params.detailedOutcome ? { 'detailed_outcome': params.detailedOutcome } : {}),
+	});
+}

--- a/src/platform/otel/common/genAiMetrics.ts
+++ b/src/platform/otel/common/genAiMetrics.ts
@@ -96,4 +96,27 @@ export class GenAiMetrics {
 	static incrementSessionCount(otel: IOTelService): void {
 		otel.incrementCounter('copilot_chat.session.count');
 	}
+
+	static recordSummarizationDuration(
+		otel: IOTelService,
+		durationSec: number,
+		attrs: { model: string; mode: string; outcome: string },
+	): void {
+		otel.recordMetric('copilot_chat.summarization.duration', durationSec, {
+			[GenAiAttr.REQUEST_MODEL]: attrs.model,
+			'summarization_mode': attrs.mode,
+			'outcome': attrs.outcome,
+		});
+	}
+
+	static recordSummarizationCount(
+		otel: IOTelService,
+		attrs: { model: string; mode: string; outcome: string },
+	): void {
+		otel.incrementCounter('copilot_chat.summarization.count', 1, {
+			[GenAiAttr.REQUEST_MODEL]: attrs.model,
+			'summarization_mode': attrs.mode,
+			'outcome': attrs.outcome,
+		});
+	}
 }

--- a/src/platform/otel/common/index.ts
+++ b/src/platform/otel/common/index.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 export { CopilotChatAttr, GenAiAttr, GenAiOperationName, GenAiProviderName, GenAiTokenType, GenAiToolType, StdAttr } from './genAiAttributes';
-export { emitAgentTurnEvent, emitInferenceDetailsEvent, emitSessionStartEvent, emitToolCallEvent } from './genAiEvents';
+export { emitAgentTurnEvent, emitInferenceDetailsEvent, emitSessionStartEvent, emitSummarizationEvent, emitToolCallEvent } from './genAiEvents';
 export { GenAiMetrics } from './genAiMetrics';
 export { toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from './messageFormatters';
 export { NoopOTelService } from './noopOtelService';

--- a/src/platform/otel/common/test/genAiEvents.spec.ts
+++ b/src/platform/otel/common/test/genAiEvents.spec.ts
@@ -197,4 +197,25 @@ describe('emitSummarizationEvent', () => {
 		expect(attrs[GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]).toBe(400);
 		expect(attrs['detailed_outcome']).toBe('none');
 	});
+
+	it('omits optional attributes when not provided', () => {
+		const otel = createMockOTel();
+		emitSummarizationEvent(otel, {
+			outcome: 'too_large',
+			model: 'gpt-4.1',
+			source: 'background',
+			summarizationMode: 'simple',
+			durationMs: 100,
+		});
+
+		const attrs = otel.emitLogRecord.mock.calls[0][1];
+		expect(attrs['outcome']).toBe('too_large');
+		expect(attrs).not.toHaveProperty('num_rounds');
+		expect(attrs).not.toHaveProperty('num_rounds_since_last_summarization');
+		expect(attrs).not.toHaveProperty('context_length_before');
+		expect(attrs).not.toHaveProperty(GenAiAttr.USAGE_INPUT_TOKENS);
+		expect(attrs).not.toHaveProperty(GenAiAttr.USAGE_OUTPUT_TOKENS);
+		expect(attrs).not.toHaveProperty(GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS);
+		expect(attrs).not.toHaveProperty('detailed_outcome');
+	});
 });

--- a/src/platform/otel/common/test/genAiEvents.spec.ts
+++ b/src/platform/otel/common/test/genAiEvents.spec.ts
@@ -6,7 +6,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Event } from '../../../../util/vs/base/common/event';
 import { GenAiAttr, GenAiOperationName, StdAttr } from '../genAiAttributes';
-import { emitAgentTurnEvent, emitInferenceDetailsEvent, emitSessionStartEvent, emitToolCallEvent } from '../genAiEvents';
+import { emitAgentTurnEvent, emitInferenceDetailsEvent, emitSessionStartEvent, emitSummarizationEvent, emitToolCallEvent } from '../genAiEvents';
 import { resolveOTelConfig } from '../otelConfig';
 import type { IOTelService } from '../otelService';
 
@@ -159,5 +159,42 @@ describe('emitAgentTurnEvent', () => {
 		expect(attrs[GenAiAttr.USAGE_INPUT_TOKENS]).toBe(500);
 		expect(attrs[GenAiAttr.USAGE_OUTPUT_TOKENS]).toBe(200);
 		expect(attrs['tool_call_count']).toBe(2);
+	});
+});
+
+describe('emitSummarizationEvent', () => {
+	it('emits summarization event with optional telemetry attributes', () => {
+		const otel = createMockOTel();
+		emitSummarizationEvent(otel, {
+			outcome: 'success',
+			model: 'gpt-4.1',
+			source: 'foreground',
+			summarizationMode: 'full',
+			durationMs: 321,
+			numRounds: 5,
+			numRoundsSinceLastSummarization: 2,
+			contextLengthBefore: 10000,
+			promptTokens: 1200,
+			completionTokens: 250,
+			cachedTokens: 400,
+			detailedOutcome: 'none',
+		});
+
+		expect(otel.emitLogRecord).toHaveBeenCalledOnce();
+		const [body, attrs] = otel.emitLogRecord.mock.calls[0];
+		expect(body).toContain('success');
+		expect(attrs['event.name']).toBe('copilot_chat.summarization');
+		expect(attrs['outcome']).toBe('success');
+		expect(attrs[GenAiAttr.REQUEST_MODEL]).toBe('gpt-4.1');
+		expect(attrs['source']).toBe('foreground');
+		expect(attrs['summarization_mode']).toBe('full');
+		expect(attrs['duration_ms']).toBe(321);
+		expect(attrs['num_rounds']).toBe(5);
+		expect(attrs['num_rounds_since_last_summarization']).toBe(2);
+		expect(attrs['context_length_before']).toBe(10000);
+		expect(attrs[GenAiAttr.USAGE_INPUT_TOKENS]).toBe(1200);
+		expect(attrs[GenAiAttr.USAGE_OUTPUT_TOKENS]).toBe(250);
+		expect(attrs[GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]).toBe(400);
+		expect(attrs['detailed_outcome']).toBe('none');
 	});
 });

--- a/src/platform/otel/common/test/genAiMetrics.spec.ts
+++ b/src/platform/otel/common/test/genAiMetrics.spec.ts
@@ -124,4 +124,28 @@ describe('GenAiMetrics', () => {
 		expect(attrs).not.toHaveProperty(StdAttr.SERVER_ADDRESS);
 		expect(attrs).not.toHaveProperty(StdAttr.ERROR_TYPE);
 	});
+
+	it('recordSummarizationDuration records histogram with correct attributes', () => {
+		const otel = createMockOTelService();
+
+		GenAiMetrics.recordSummarizationDuration(otel, 1.2, { model: 'gpt-4.1', mode: 'full', outcome: 'success' });
+
+		expect(otel.recordMetric).toHaveBeenCalledWith('copilot_chat.summarization.duration', 1.2, {
+			[GenAiAttr.REQUEST_MODEL]: 'gpt-4.1',
+			'summarization_mode': 'full',
+			'outcome': 'success',
+		});
+	});
+
+	it('recordSummarizationCount increments counter with correct attributes', () => {
+		const otel = createMockOTelService();
+
+		GenAiMetrics.recordSummarizationCount(otel, { model: 'gpt-4.1', mode: 'simple', outcome: 'too_large' });
+
+		expect(otel.incrementCounter).toHaveBeenCalledWith('copilot_chat.summarization.count', 1, {
+			[GenAiAttr.REQUEST_MODEL]: 'gpt-4.1',
+			'summarization_mode': 'simple',
+			'outcome': 'too_large',
+		});
+	});
 });


### PR DESCRIPTION
- Emit `copilot_chat.summarization` OTel log record alongside existing MSFT telemetry for every summarization attempt (foreground & background)
- Fix model attribution: use resolved endpoint model instead of props model so the correct model is reported in telemetry
- Use canonical `gen_ai.usage.cache_read.input_tokens` attribute for cached prompt tokens
- Remove `AgentHistorySummarizationForceGpt41` experiment setting and associated `IEndpointProvider` plumbing — the force-GPT-4.1 override for summarization is no longer needed
- Add unit test coverage for the new `emitSummarizationEvent` helper