### PR TITLE
Improve external ingest handling of multiroot workspace

### DIFF
--- a/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestClient.ts
+++ b/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestClient.ts
@@ -15,13 +15,10 @@ import { CancellationTokenSource } from '../../../../util/vs/base/common/cancell
 import { CancellationError, isCancellationError } from '../../../../util/vs/base/common/errors';
 import { Disposable } from '../../../../util/vs/base/common/lifecycle';
 import { URI } from '../../../../util/vs/base/common/uri';
-import { Range } from '../../../../util/vs/editor/common/core/range';
 import { IAuthenticationService } from '../../../authentication/common/authentication';
-import { FileChunkAndScore } from '../../../chunking/common/chunk';
 import { EmbeddingType } from '../../../embeddings/common/embeddingsComputer';
 import { githubHeaders, IGithubApiFetcherService } from '../../../github/common/githubApiFetcherService';
 import { ILogService } from '../../../log/common/logService';
-import { CodeSearchResult } from '../../../remoteCodeSearch/common/remoteCodeSearch';
 import { ITelemetryService } from '../../../telemetry/common/telemetry';
 
 
@@ -49,7 +46,7 @@ export interface IExternalIngestClient {
 	listFilesets(callTracker: CallTracker, token: CancellationToken): Promise<string[]>;
 	deleteFileset(filesetName: string, callTracker: CallTracker, token: CancellationToken): Promise<void>;
 
-	searchFilesets(filesetName: string, rootUri: URI, prompt: string, limit: number, callTracker: CallTracker, token: CancellationToken): Promise<CodeSearchResult>;
+	searchFilesets(filesetName: string, prompt: string, limit: number, callTracker: CallTracker, token: CancellationToken): Promise<SearchFilesetsResponse | undefined>;
 
 	/**
 	 * Quickly checks if a file can be ingested based on its path and size.
@@ -511,11 +508,11 @@ export class ExternalIngestClient extends Disposable implements IExternalIngestC
 		this.logService.info(`ExternalIngestClient::deleteFilesetByName(): Deleted: ${fileSetName}`);
 	}
 
-	async searchFilesets(filesetName: string, rootUri: URI, prompt: string, limit: number, callTracker: CallTracker, token: CancellationToken): Promise<CodeSearchResult> {
+	async searchFilesets(filesetName: string, prompt: string, limit: number, callTracker: CallTracker, token: CancellationToken): Promise<SearchFilesetsResponse | undefined> {
 		const authToken = await this.getAuthToken();
 		if (!authToken) {
 			this.logService.warn('ExternalIngestClient::searchFilesets(): No auth token available');
-			return { outOfSync: false, chunks: [] };
+			return undefined;
 		}
 
 		this.logService.debug(`ExternalIngestClient::searchFilesets(): Searching fileset '${filesetName}' for prompt: '${prompt}'`);
@@ -527,32 +524,16 @@ export class ExternalIngestClient extends Disposable implements IExternalIngestC
 			limit,
 		}, {}, callTracker.add('ExternalIngestClient::searchFilesets'), token);
 
-		const body = await resp.json() as SearchFilesetsResponse;
-		return {
-			outOfSync: false,
-			chunks: (body.results ?? []).map((r): FileChunkAndScore => ({
-				distance: {
-					embeddingType,
-					value: r.distance,
-				},
-				chunk: {
-					text: r.chunk.text,
-					rawText: undefined,
-					file: URI.joinPath(rootUri, r.location.path),
-					range: new Range(r.chunk.line_range.start, 0, r.chunk.line_range.end, 0),
-				},
-			})),
-		};
-
+		return await resp.json() as SearchFilesetsResponse;
 	}
 }
 
 interface SearchFilesetsResponse {
-	readonly results: SearchResult[] | undefined;
+	readonly results: SearchFilesetsResult[] | undefined;
 	readonly embedding_model: string;
 }
 
-interface SearchResult {
+export interface SearchFilesetsResult {
 	readonly location: SearchLocation;
 	readonly distance: number;
 	readonly chunk: SearchChunk;

--- a/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestIndex.ts
+++ b/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestIndex.ts
@@ -9,19 +9,23 @@ import * as fs from 'node:fs';
 import sql from 'node:sqlite';
 import { Result } from '../../../../util/common/result';
 import { CallTracker } from '../../../../util/common/telemetryCorrelationId';
+import { coalesce } from '../../../../util/vs/base/common/arrays';
 import { CancelablePromise, createCancelablePromise, Limiter, raceCancellationError } from '../../../../util/vs/base/common/async';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
 import { isCancellationError } from '../../../../util/vs/base/common/errors';
 import { Emitter } from '../../../../util/vs/base/common/event';
-import { hashAsync } from '../../../../util/vs/base/common/hash';
-import { Disposable, DisposableStore, MutableDisposable } from '../../../../util/vs/base/common/lifecycle';
-import { ResourceSet } from '../../../../util/vs/base/common/map';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../util/vs/base/common/lifecycle';
+import { ResourceMap, ResourceSet } from '../../../../util/vs/base/common/map';
 import { Schemas } from '../../../../util/vs/base/common/network';
 import { isEqualOrParent, relativePath } from '../../../../util/vs/base/common/resources';
 import { StopWatch } from '../../../../util/vs/base/common/stopwatch';
 import { URI } from '../../../../util/vs/base/common/uri';
+import { generateUuid } from '../../../../util/vs/base/common/uuid';
+import { Range } from '../../../../util/vs/editor/common/core/range';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { FileChunkAndScore } from '../../../chunking/common/chunk';
+import { stripChunkTextMetadata } from '../../../chunking/common/chunkingStringUtils';
+import { EmbeddingType } from '../../../embeddings/common/embeddingsComputer';
 import { IEnvService } from '../../../env/common/envService';
 import { IVSCodeExtensionContext } from '../../../extContext/common/extensionContext';
 import { IFileSystemService } from '../../../filesystem/common/fileSystemService';
@@ -35,10 +39,9 @@ import { StrategySearchSizing, WorkspaceChunkQueryWithEmbeddings } from '../../c
 import { shouldPotentiallyIndexFile } from '../workspaceFileIndex';
 import { CodeSearchRepoStatus, TriggerIndexingError, TriggerRemoteIndexingError } from './codeSearchRepo';
 import { ExternalIngestFile, IExternalIngestClient } from './externalIngestClient';
+import { WorkspaceFolderIdMap } from './workspaceFolderIdMap';
 
 const debug = false;
-
-const maxFileSetNameLength = 256;
 
 const enum ShouldIngestState {
 	/** File is tracked but we haven't yet determined if it should be ingested */
@@ -67,12 +70,17 @@ export interface ExternalIngestStatus {
  */
 export class ExternalIngestIndex extends Disposable {
 
+	private static readonly storageKeys = Object.freeze({
+		Checkpoint: 'externalIngest.checkpoint',
+		FileSetName: 'externalIngest.fileSetName',
+	});
+
 	private readonly _db: sql.DatabaseSync;
 
 	private readonly _readLimiter = this._register(new Limiter<Uint8Array>(20));
-	private readonly _watcher = this._register(new MutableDisposable<DisposableStore>());
+	private readonly _watchers = this._register(new MutableDisposable<IDisposable>());
 
-	private static readonly _checkpointStorageKey = 'externalIngest.checkpoint';
+	private readonly workspaceFolderIdMap: WorkspaceFolderIdMap;
 
 	private _isDisposed = false;
 
@@ -142,6 +150,7 @@ export class ExternalIngestIndex extends Disposable {
 		super();
 
 		this._client = client;
+		this.workspaceFolderIdMap = new WorkspaceFolderIdMap(this._vsExtensionContext.workspaceState);
 
 		let dbPath: string;
 		if (debug || !this._vsExtensionContext.storageUri || this._vsExtensionContext.storageUri.scheme !== Schemas.file) {
@@ -163,21 +172,19 @@ export class ExternalIngestIndex extends Disposable {
 
 		super.dispose();
 
-		this._watcher?.dispose();
-		this._readLimiter.dispose();
 		this._db.close();
 	}
 
 	private getCurrentIndexCheckpoint(): string | undefined {
-		return this._vsExtensionContext.workspaceState.get<string>(ExternalIngestIndex._checkpointStorageKey);
+		return this._vsExtensionContext.workspaceState.get<string>(ExternalIngestIndex.storageKeys.Checkpoint);
 	}
 
 	private setCurrentIndexCheckpoint(checkpoint: string): void {
-		this._vsExtensionContext.workspaceState.update(ExternalIngestIndex._checkpointStorageKey, checkpoint);
+		this._vsExtensionContext.workspaceState.update(ExternalIngestIndex.storageKeys.Checkpoint, checkpoint);
 	}
 
 	private clearCurrentIndexCheckpoint(): void {
-		this._vsExtensionContext.workspaceState.update(ExternalIngestIndex._checkpointStorageKey, undefined);
+		this._vsExtensionContext.workspaceState.update(ExternalIngestIndex.storageKeys.Checkpoint, undefined);
 	}
 
 	/**
@@ -187,13 +194,10 @@ export class ExternalIngestIndex extends Disposable {
 	 * has a cache of file shas.
 	 */
 	public async deleteIndex(callTracker: CallTracker, token: CancellationToken): Promise<void> {
-		const workspaceFolders = this._workspaceService.getWorkspaceFolders();
-		if (!workspaceFolders.length) {
+		const filesetName = this.getFilesetName();
+		if (!filesetName) {
 			return;
 		}
-
-		const primaryRoot = workspaceFolders[0];
-		const filesetName = await this.getFilesetName(primaryRoot);
 		this._logService.info(`ExternalIngestIndex: Deleting index for fileset ${filesetName}`);
 
 		try {
@@ -225,6 +229,7 @@ export class ExternalIngestIndex extends Disposable {
 
 	/**
 	 * Updates the set of roots that are covered by code search.
+	 *
 	 * Files under these roots will be excluded from external ingest indexing.
 	 */
 	public updateCodeSearchRoots(roots: readonly URI[]): void {
@@ -259,14 +264,10 @@ export class ExternalIngestIndex extends Disposable {
 	async doIngest(callTracker: CallTracker, onProgress: (message: string) => void, callerToken: CancellationToken): Promise<Result<true, TriggerIndexingError>> {
 		await raceCancellationError(this.initialize(), callerToken);
 
-		const workspaceFolders = this._workspaceService.getWorkspaceFolders();
-		if (!workspaceFolders.length) {
+		const filesetName = this.getFilesetName();
+		if (!filesetName) {
 			return Result.error(TriggerRemoteIndexingError.noWorkspace);
 		}
-
-		// Use the first workspace folder as the "root" for the fileset
-		const primaryRoot = workspaceFolders[0];
-		const filesetName = await raceCancellationError(this.getFilesetName(primaryRoot), callerToken);
 
 		const currentCheckpoint = this.getCurrentIndexCheckpoint();
 
@@ -367,8 +368,8 @@ export class ExternalIngestIndex extends Disposable {
 	}
 
 	async search(sizing: StrategySearchSizing, query: WorkspaceChunkQueryWithEmbeddings, inCallTracker: CallTracker, token: CancellationToken): Promise<readonly FileChunkAndScore[]> {
-		const workspaceFolders = this._workspaceService.getWorkspaceFolders();
-		if (!workspaceFolders.length) {
+		const filesetName = this.getFilesetName();
+		if (!filesetName) {
 			return [];
 		}
 
@@ -380,15 +381,48 @@ export class ExternalIngestIndex extends Disposable {
 
 			await raceCancellationError(this.doIngest(callTracker, () => { }, token), token);
 
-			// TODO: search changed files too
-			const primaryRoot = workspaceFolders[0];
-			const result = await raceCancellationError(this._client.searchFilesets(
-				await this.getFilesetName(primaryRoot),
-				primaryRoot,
+			const searchResult = await raceCancellationError(this._client.searchFilesets(
+				filesetName,
 				resolvedQuery,
 				sizing.maxResultCountHint,
 				callTracker,
 				token), token);
+
+			if (!searchResult || !searchResult.results) {
+				return [];
+			}
+
+			const embeddingType = EmbeddingType.metis_1024_I16_Binary;
+			const primaryRoot = this._workspaceService.getWorkspaceFolders().at(0);
+
+			const chunks: readonly FileChunkAndScore[] = coalesce(searchResult.results.map((r): FileChunkAndScore | undefined => {
+				let file = this.fromIndexPath(r.location.path);
+				if (!file) {
+					this._logService.warn(`ExternalIngestIndex: Could not resolve file for search result path: ${r.location.path}`);
+
+					// Make a best effort guess
+					if (primaryRoot) {
+						file = URI.joinPath(primaryRoot, r.location.path);
+					}
+				}
+
+				if (!file) {
+					return undefined;
+				}
+
+				return {
+					distance: {
+						embeddingType,
+						value: r.distance,
+					},
+					chunk: {
+						text: stripChunkTextMetadata(r.chunk.text),
+						rawText: undefined,
+						file,
+						range: new Range(r.chunk.line_range.start, 0, r.chunk.line_range.end, 0),
+					},
+				};
+			}));
 
 			/* __GDPR__
 				"externalIngestIndex.search.success" : {
@@ -399,11 +433,11 @@ export class ExternalIngestIndex extends Disposable {
 				}
 			*/
 			this._telemetryService.sendMSFTTelemetryEvent('externalIngestIndex.search.success', undefined, {
-				resultCount: result.chunks.length,
+				resultCount: chunks.length,
 				durationMs: sw.elapsed()
 			});
 
-			return result.chunks;
+			return chunks;
 		} catch (e) {
 			if (isCancellationError(e)) {
 				throw e;
@@ -609,19 +643,36 @@ export class ExternalIngestIndex extends Disposable {
 		};
 	}
 
-	private computeRelativePath(uri: URI): string | undefined {
+	private toIndexPath(uri: URI): string | undefined {
 		const folder = this._workspaceService.getWorkspaceFolder(uri);
 		if (folder) {
 			const rel = relativePath(folder, uri);
 			if (rel) {
-				return rel;
+				const folderId = this.workspaceFolderIdMap.getIdForFolder(folder);
+				return `${folderId}/${rel}`;
 			}
 		}
 		return undefined;
 	}
 
+	private fromIndexPath(indexPath: string): URI | undefined {
+		const [folderId, ...rest] = indexPath.split('/');
+		const folderUri = this.workspaceFolderIdMap.getFolderForId(folderId);
+		if (folderUri) {
+			return URI.joinPath(folderUri, ...rest);
+		}
+
+		// Old style indexes always use the first workspace folder as the root
+		const primaryRoot = this._workspaceService.getWorkspaceFolders().at(0);
+		if (!primaryRoot) {
+			return undefined;
+		}
+
+		return URI.joinPath(primaryRoot, indexPath);
+	}
+
 	private createExternalIngestFile(uri: URI, docSha: Uint8Array): ExternalIngestFile | undefined {
-		const relativePath = this.computeRelativePath(uri);
+		const relativePath = this.toIndexPath(uri);
 		if (!relativePath) {
 			return undefined;
 		}
@@ -763,20 +814,50 @@ export class ExternalIngestIndex extends Disposable {
 	}
 
 	private registerWatcher(): void {
-		if (this._watcher.value) {
+		if (this._watchers.value) {
 			return;
 		}
 
-		const workspaceFolders = this._workspaceService.getWorkspaceFolders();
-		const disposables = new DisposableStore();
+		const addWatchersFolder = (folder: URI): IDisposable => {
+			const disposables = new DisposableStore();
 
-		for (const folder of workspaceFolders) {
 			const watcher = disposables.add(this._fileSystemService.createFileSystemWatcher(new RelativePattern(folder, '**/*')));
 			disposables.add(watcher.onDidCreate(uri => this.onFileAdded(uri)));
 			disposables.add(watcher.onDidChange(uri => this.onFileChanged(uri)));
 			disposables.add(watcher.onDidDelete(uri => this.onFileDeleted(uri)));
+
+			return disposables;
+		};
+
+		const watchersForWorkspaceFolders = new ResourceMap<IDisposable>();
+		for (const folder of this._workspaceService.getWorkspaceFolders()) {
+			watchersForWorkspaceFolders.set(folder, addWatchersFolder(folder));
 		}
-		this._watcher.value = disposables;
+
+		const folderChangeSubscription = this._workspaceService.onDidChangeWorkspaceFolders(e => {
+			for (const removed of e.removed) {
+				const disposable = watchersForWorkspaceFolders.get(removed.uri);
+				if (disposable) {
+					disposable.dispose();
+					watchersForWorkspaceFolders.delete(removed.uri);
+				}
+			}
+
+			for (const added of e.added) {
+				if (!watchersForWorkspaceFolders.has(added.uri)) {
+					watchersForWorkspaceFolders.set(added.uri, addWatchersFolder(added.uri));
+				}
+			}
+		});
+
+		this._watchers.value = toDisposable(() => {
+			folderChangeSubscription.dispose();
+
+			for (const disposable of watchersForWorkspaceFolders.values()) {
+				disposable.dispose();
+			}
+			watchersForWorkspaceFolders.clear();
+		});
 	}
 
 	private async onFileAdded(uri: URI): Promise<void> {
@@ -819,7 +900,7 @@ export class ExternalIngestIndex extends Disposable {
 	}
 
 	private computeIngestDocShaFromContents(uri: URI, data: Uint8Array): Uint8Array | undefined {
-		const relativePath = this.computeRelativePath(uri);
+		const relativePath = this.toIndexPath(uri);
 		if (!relativePath) {
 			return undefined;
 		}
@@ -835,18 +916,22 @@ export class ExternalIngestIndex extends Disposable {
 		}
 	}
 
-	private async getFilesetName(workspaceRoot: URI): Promise<string> {
-		const folderName = workspaceRoot.toString(false);
-
-		const prefix = `vscode.${this._envService.getName()}.`;
-		const fullName = `${prefix}${folderName}`;
-
-		if (fullName.length >= maxFileSetNameLength) {
-			const hash = await hashAsync(folderName);
-			return `${prefix}${hash}`;
+	private getFilesetName(): string | undefined {
+		const stored = this._vsExtensionContext.workspaceState.get<string>(ExternalIngestIndex.storageKeys.FileSetName);
+		if (stored) {
+			return stored;
 		}
 
-		return fullName;
+		// Don't bother building up external ingest sets if there's no workspace as often these are transient and only
+		// have a handful of files.
+		const workspaceFolders = this._workspaceService.getWorkspaceFolders();
+		if (!workspaceFolders.length) {
+			return undefined;
+		}
+
+		const name = `vscode.${this._envService.getName()}.${generateUuid()}`;
+		this._vsExtensionContext.workspaceState.update(ExternalIngestIndex.storageKeys.FileSetName, name);
+		return name;
 	}
 
 	private *iterateDbFiles(): Iterable<URI> {
@@ -856,3 +941,5 @@ export class ExternalIngestIndex extends Disposable {
 		}
 	}
 }
+
+

--- a/src/platform/workspaceChunkSearch/node/codeSearch/workspaceFolderIdMap.ts
+++ b/src/platform/workspaceChunkSearch/node/codeSearch/workspaceFolderIdMap.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { Memento } from 'vscode';
+import { ResourceMap } from '../../../../util/vs/base/common/map';
+import { basenameOrAuthority } from '../../../../util/vs/base/common/resources';
+import { URI } from '../../../../util/vs/base/common/uri';
+
+const maxPrefixLength = 8;
+
+interface StoredIdMap {
+	/** Maps folder URI string -> assigned id */
+	readonly entries: ReadonlyArray<{ readonly uri: string; readonly id: string }>;
+}
+
+/**
+ * Generates short, unique, persistent ids for workspace folder URIs.
+ */
+export class WorkspaceFolderIdMap {
+
+	private static readonly _storageKey = 'workspaceFolderIds';
+
+	private readonly _idByUri = new ResourceMap<string>();
+	private readonly _usedIds = new Set<string>();
+
+	constructor(
+		private readonly _workspaceState: Memento,
+	) {
+		this._loadFromStorage();
+	}
+
+	getIdForFolder(folderRoot: URI): string {
+		const existing = this._idByUri.get(folderRoot);
+		if (existing) {
+			return existing;
+		}
+
+		const id = this._generateUniqueId(folderRoot);
+		this._idByUri.set(folderRoot, id);
+		this._usedIds.add(id);
+		this._saveToStorage();
+		return id;
+	}
+
+	getFolderForId(id: string): URI | undefined {
+		for (const [uri, assignedId] of this._idByUri) {
+			if (assignedId === id) {
+				return uri;
+			}
+		}
+		return undefined;
+	}
+
+	private _generateUniqueId(folderRoot: URI): string {
+		const name = basenameOrAuthority(folderRoot);
+		const sanitized = name.replace(/[^a-zA-Z0-9_-]/g, '').toLowerCase();
+		const base = sanitized.slice(0, maxPrefixLength) || 'ws';
+
+		if (base.length <= maxPrefixLength && !this._usedIds.has(base)) {
+			return base;
+		}
+
+		// Resolve collision by appending a numeric suffix
+		for (let i = 0; ; i++) {
+			const suffix = String(i);
+			const candidate = base.slice(0, maxPrefixLength - suffix.length) + suffix;
+			if (!this._usedIds.has(candidate)) {
+				return candidate;
+			}
+		}
+	}
+
+	private _loadFromStorage(): void {
+		const stored = this._workspaceState.get<StoredIdMap>(WorkspaceFolderIdMap._storageKey);
+		if (!stored?.entries) {
+			return;
+		}
+		for (const { uri, id } of stored.entries) {
+			try {
+				this._idByUri.set(URI.parse(uri), id);
+				this._usedIds.add(id);
+			} catch {
+				// Ignore invalid URIs
+			}
+		}
+	}
+
+	private _saveToStorage(): void {
+		const data: StoredIdMap = {
+			entries: [...this._idByUri].map(([uri, id]) => ({ uri: uri.toString(), id })),
+		};
+		this._workspaceState.update(WorkspaceFolderIdMap._storageKey, data);
+	}
+}

--- a/src/platform/workspaceChunkSearch/test/node/externalIngest.spec.ts
+++ b/src/platform/workspaceChunkSearch/test/node/externalIngest.spec.ts
@@ -16,7 +16,6 @@ import { URI } from '../../../../util/vs/base/common/uri';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { IFileSystemService } from '../../../filesystem/common/fileSystemService';
 import { FileType } from '../../../filesystem/common/fileTypes';
-import { CodeSearchResult } from '../../../remoteCodeSearch/common/remoteCodeSearch';
 import { ISearchService } from '../../../search/common/searchService';
 import { createPlatformServices, TestingServiceCollection } from '../../../test/node/services';
 import { IWorkspaceService, NullWorkspaceService } from '../../../workspace/common/workspaceService';
@@ -53,9 +52,9 @@ function createMockExternalIngestClient(options?: {
 		async deleteFileset(_filesetName: string, _callTracker: CallTracker, _token: CancellationToken): Promise<void> {
 			// no-op
 		},
-		async searchFilesets(filesetName: string, _rootUri: URI, prompt: string, _limit: number, _callTracker: CallTracker, _token: CancellationToken): Promise<CodeSearchResult> {
+		async searchFilesets(filesetName: string, prompt: string, _limit: number, _callTracker: CallTracker, _token: CancellationToken): Promise<undefined> {
 			searchCalls.push({ filesetName, prompt });
-			return { chunks: [], outOfSync: false };
+			return undefined;
 		},
 		canIngestPathAndSize(filePath: string, size: number): boolean {
 			return options?.canIngestPathAndSize?.(filePath, size) ?? true;

--- a/src/platform/workspaceChunkSearch/test/node/workspaceFolderIdMap.spec.ts
+++ b/src/platform/workspaceChunkSearch/test/node/workspaceFolderIdMap.spec.ts
@@ -1,0 +1,186 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test } from 'vitest';
+import type { Memento } from 'vscode';
+import { URI } from '../../../../util/vs/base/common/uri';
+import { WorkspaceFolderIdMap } from '../../node/codeSearch/workspaceFolderIdMap';
+
+class MockMemento implements Memento {
+	private readonly _data = new Map<string, unknown>();
+
+	keys(): readonly string[] {
+		return [...this._data.keys()];
+	}
+
+	get<T>(key: string): T | undefined;
+	get<T>(key: string, defaultValue: T): T;
+	get<T>(key: string, defaultValue?: T): T | undefined {
+		const val = this._data.get(key);
+		return val !== undefined ? val as T : defaultValue;
+	}
+
+	async update(key: string, value: unknown): Promise<void> {
+		this._data.set(key, value);
+	}
+}
+
+suite('WorkspaceFolderIdMap', () => {
+
+	test('returns an id based on folder basename', () => {
+		const store = new MockMemento();
+		const map = new WorkspaceFolderIdMap(store);
+
+		const id = map.getIdForFolder(URI.file('/home/user/my-project'));
+		assert.strictEqual(id, 'my-proje');
+	});
+
+	test('returns the same id on subsequent calls', () => {
+		const store = new MockMemento();
+		const map = new WorkspaceFolderIdMap(store);
+
+		const uri = URI.file('/home/user/my-project');
+		const first = map.getIdForFolder(uri);
+		const second = map.getIdForFolder(uri);
+		assert.strictEqual(first, second);
+	});
+
+	test('returns short name without padding when basename is shorter than 8 chars', () => {
+		const store = new MockMemento();
+		const map = new WorkspaceFolderIdMap(store);
+
+		const id = map.getIdForFolder(URI.file('/home/user/app'));
+		assert.strictEqual(id, 'app');
+	});
+
+	test('handles collision by appending numeric suffix', () => {
+		const store = new MockMemento();
+		const map = new WorkspaceFolderIdMap(store);
+
+		const p1 = map.getIdForFolder(URI.file('/a/my-project'));
+		const p2 = map.getIdForFolder(URI.file('/b/my-project'));
+
+		assert.strictEqual(p1, 'my-proje');
+		assert.strictEqual(p2, 'my-proj0');
+		assert.notStrictEqual(p1, p2);
+	});
+
+	test('handles multiple collisions', () => {
+		const store = new MockMemento();
+		const map = new WorkspaceFolderIdMap(store);
+
+		const p1 = map.getIdForFolder(URI.file('/a/my-project'));
+		const p2 = map.getIdForFolder(URI.file('/b/my-project'));
+		const p3 = map.getIdForFolder(URI.file('/c/my-project'));
+
+		assert.strictEqual(p1, 'my-proje');
+		assert.strictEqual(p2, 'my-proj0');
+		assert.strictEqual(p3, 'my-proj1');
+	});
+
+	test('sanitizes non-alphanumeric characters from basename', () => {
+		const store = new MockMemento();
+		const map = new WorkspaceFolderIdMap(store);
+
+		const id = map.getIdForFolder(URI.file('/home/user/my project (2)'));
+		assert.strictEqual(id, 'myprojec');
+	});
+
+	test('uses fallback for folders with only special characters', () => {
+		const store = new MockMemento();
+		const map = new WorkspaceFolderIdMap(store);
+
+		const id = map.getIdForFolder(URI.file('/home/user/...'));
+		assert.strictEqual(id, 'ws');
+	});
+
+	test('persists and restores from storage', () => {
+		const store = new MockMemento();
+
+		const map1 = new WorkspaceFolderIdMap(store);
+		const uri = URI.file('/home/user/my-project');
+		const original = map1.getIdForFolder(uri);
+
+		// Create a new instance with the same store
+		const map2 = new WorkspaceFolderIdMap(store);
+		const restored = map2.getIdForFolder(uri);
+
+		assert.strictEqual(original, restored);
+	});
+
+	test('restored map avoids collisions with persisted ids', () => {
+		const store = new MockMemento();
+
+		const map1 = new WorkspaceFolderIdMap(store);
+		map1.getIdForFolder(URI.file('/a/my-project'));
+
+		// New instance should know 'my-proje' is taken
+		const map2 = new WorkspaceFolderIdMap(store);
+		const p2 = map2.getIdForFolder(URI.file('/b/my-project'));
+
+		assert.strictEqual(p2, 'my-proj0');
+	});
+
+	test('getFolderForId returns undefined for unknown id', () => {
+		const store = new MockMemento();
+		const map = new WorkspaceFolderIdMap(store);
+
+		assert.strictEqual(map.getFolderForId('unknown'), undefined);
+	});
+
+	test('getFolderForId returns the URI for a known id', () => {
+		const store = new MockMemento();
+		const map = new WorkspaceFolderIdMap(store);
+
+		const uri = URI.file('/home/user/my-project');
+		const id = map.getIdForFolder(uri);
+
+		const result = map.getFolderForId(id);
+		assert.ok(result);
+		assert.strictEqual(result.toString(), uri.toString());
+	});
+
+	test('getFolderForId round-trips with getIdForFolder', () => {
+		const store = new MockMemento();
+		const map = new WorkspaceFolderIdMap(store);
+
+		const uris = [
+			URI.file('/a/project-one'),
+			URI.file('/b/project-two'),
+			URI.file('/c/project-three'),
+		];
+
+		for (const uri of uris) {
+			const id = map.getIdForFolder(uri);
+			const recovered = map.getFolderForId(id);
+			assert.ok(recovered);
+			assert.strictEqual(recovered.toString(), uri.toString());
+		}
+	});
+
+	test('getFolderForId works after restore from storage', () => {
+		const store = new MockMemento();
+
+		const map1 = new WorkspaceFolderIdMap(store);
+		const uri = URI.file('/home/user/my-project');
+		const id = map1.getIdForFolder(uri);
+
+		const map2 = new WorkspaceFolderIdMap(store);
+		const result = map2.getFolderForId(id);
+		assert.ok(result);
+		assert.strictEqual(result.toString(), uri.toString());
+	});
+
+	test('getFolderForId returns undefined after only unrelated ids are registered', () => {
+		const store = new MockMemento();
+		const map = new WorkspaceFolderIdMap(store);
+
+		map.getIdForFolder(URI.file('/home/user/project-a'));
+		map.getIdForFolder(URI.file('/home/user/project-b'));
+
+		assert.strictEqual(map.getFolderForId('notregistered'), undefined);
+	});
+});


### PR DESCRIPTION
- Be smarter about generating fileset ids to avoid collisions if the same folder is in multiple workspaces
- Fix path in results for multi-root workspaces