### PR TITLE
Route before summarization + per-conversation routing mode

### DIFF
--- a/src/extension/intents/node/agentIntent.ts
+++ b/src/extension/intents/node/agentIntent.ts
@@ -12,6 +12,7 @@ import { ChatLocation, ChatResponse } from '../../../platform/chat/common/common
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { isAnthropicFamily, isGptFamily, modelCanUseApplyPatchExclusively, modelCanUseReplaceStringExclusively, modelSupportsApplyPatch, modelSupportsMultiReplaceString, modelSupportsReplaceString, modelSupportsSimplifiedApplyPatchInstructions } from '../../../platform/endpoint/common/chatModelCapabilities';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { IAutomodeService } from '../../../platform/endpoint/node/automodeService';
 import { IEnvService } from '../../../platform/env/common/envService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IEditLogService } from '../../../platform/multiFileEdit/common/editLogService';
@@ -353,6 +354,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		@INotebookService notebookService: INotebookService,
 		@ILogService private readonly logService: ILogService,
 		@IExperimentationService private readonly expService: IExperimentationService,
+		@IAutomodeService private readonly automodeService: IAutomodeService,
 	) {
 		super(intent, location, endpoint, request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService);
 	}
@@ -475,12 +477,35 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		}
 
 		// Helper function for synchronous summarization flow with fallbacks
+		// --- Router-before-summarization: callback to resolve next model ---
+		const resolveNextEndpoint = async (): Promise<IChatEndpoint | undefined> => {
+			try {
+				const allEndpoints = await this.endpointProvider.getAllChatEndpoints();
+				const conversationId = promptContext.conversation?.sessionResource?.toString()
+					?? promptContext.conversation?.sessionId ?? 'unknown';
+				const userPrompt = this.request.prompt?.trim() ?? '';
+				const result = await this.automodeService.resolveEndpointForSummarization(
+					conversationId, userPrompt, allEndpoints);
+				if (result) {
+					this.logService.debug(
+						`[Agent] Router-before-summarization: ${result.previousModel} -> ${result.endpoint.model} `
+						+ `(label=${result.routerDecision.predicted_label}, `
+						+ `confidence=${(result.routerDecision.confidence * 100).toFixed(1)}%)`);
+					return result.endpoint;
+				}
+			} catch (e) {
+				this.logService.warn('[Agent] Router-before-summarization failed, using current model', (e as Error).message);
+			}
+			return undefined;
+		};
+
 		const renderWithSummarization = async (reason: string, renderProps: AgentPromptProps = props): Promise<RenderPromptResult> => {
 			this.logService.debug(`[Agent] ${reason}, triggering summarization`);
 			try {
 				const renderer = PromptRenderer.create(this.instantiationService, endpoint, this.prompt, {
 					...renderProps,
 					triggerSummarize: true,
+					resolveNextEndpoint,
 				});
 				return await renderer.render(progress, token);
 			} catch (e) {
@@ -723,6 +748,23 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 			...snapshotProps,
 			triggerSummarize: true,
 			summarizationSource: 'background',
+			resolveNextEndpoint: async () => {
+				try {
+					const allEndpoints = await this.endpointProvider.getAllChatEndpoints();
+					const convId = props.promptContext.conversation?.sessionResource?.toString()
+						?? props.promptContext.conversation?.sessionId ?? 'unknown';
+					const userPrompt = this.request.prompt?.trim() ?? '';
+					const result = await this.automodeService.resolveEndpointForSummarization(
+						convId, userPrompt, allEndpoints);
+					if (result) {
+						this.logService.debug(`[Agent] BG router-before-summarization: ${result.previousModel} -> ${result.endpoint.model}`);
+						return result.endpoint;
+					}
+				} catch (e) {
+					this.logService.warn('[Agent] BG router-before-summarization failed', (e as Error).message);
+				}
+				return undefined;
+			},
 		});
 		const bgProgress: vscode.Progress<vscode.ChatResponseReferencePart | vscode.ChatResponseProgressPart> = { report: () => { } };
 		const bgStartTime = Date.now();

--- a/src/extension/prompts/node/agent/agentPrompt.tsx
+++ b/src/extension/prompts/node/agent/agentPrompt.tsx
@@ -72,6 +72,13 @@ export interface AgentPromptProps extends GenericBasePromptElementProps {
 
 	/** Whether this summarization was triggered as a background or foreground operation. */
 	readonly summarizationSource?: 'background' | 'foreground';
+
+	/**
+	 * Optional callback to resolve the next model endpoint before summarization.
+	 * Called by the summarizer for foreground/background summarization (not /compact)
+	 * to switch models and warm the new model's prompt cache during compaction.
+	 */
+	readonly resolveNextEndpoint?: () => Promise<IChatEndpoint | undefined>;
 }
 
 /** Proportion of the prompt token budget any singular textual tool result is allowed to use. */
@@ -147,6 +154,7 @@ export class AgentPrompt extends PromptElement<AgentPromptProps> {
 					tools={this.props.promptContext.tools?.availableTools}
 					enableCacheBreakpoints={this.props.enableCacheBreakpoints}
 					summarizationSource={this.props.summarizationSource}
+					resolveNextEndpoint={this.props.resolveNextEndpoint}
 					userQueryTagName={userQueryTagName}
 					ReminderInstructionsClass={ReminderInstructionsClass}
 					ToolReferencesHintClass={ToolReferencesHintClass}

--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -409,6 +409,12 @@ export interface SummarizedAgentHistoryProps extends BasePromptElementProps, Age
 	readonly summarizationInstructions?: string;
 	/** Whether this summarization was triggered as a background or foreground operation. Defaults to 'foreground'. */
 	readonly summarizationSource?: 'background' | 'foreground';
+	/**
+	 * Optional callback to resolve the next model endpoint before summarization.
+	 * When provided, the summarizer calls the router to pick the next model
+	 * so the summarization LLM call warms that model's prompt cache.
+	 */
+	readonly resolveNextEndpoint?: () => Promise<IChatEndpoint | undefined>;
 	/** Path to the conversation transcript JSONL file, used to inform the model after summarization */
 	readonly transcriptPath?: string;
 }
@@ -647,11 +653,33 @@ class ConversationHistorySummarizer {
 
 	private async getSummary(mode: SummaryMode, propsInfo: ISummarizedConversationHistoryInfo): Promise<SummarizationResult> {
 		const stopwatch = new StopWatch(false);
+
+		// --- Router-before-summarization: resolve next model if callback provided ---
+		let routerResolvedEndpoint: IChatEndpoint | undefined;
+		if (this.props.resolveNextEndpoint && this.props.summarizationSource) {
+			try {
+				routerResolvedEndpoint = await this.props.resolveNextEndpoint();
+				if (routerResolvedEndpoint) {
+					this.logInfo(
+						`Router selected '${routerResolvedEndpoint.model}' for summarization (was '${this.props.endpoint.model}')`, mode);
+				}
+			} catch (e) {
+				this.logInfo(`Failed to resolve next endpoint via router: ${(e as Error).message}`, mode);
+			}
+		}
+
 		const forceGpt41 = this.configurationService.getExperimentBasedConfig(ConfigKey.Advanced.AgentHistorySummarizationForceGpt41, this.experimentationService);
 		const gpt41Endpoint = await this.endpointProvider.getChatEndpoint('copilot-base');
-		const endpoint = forceGpt41 && (gpt41Endpoint.modelMaxPromptTokens >= this.props.endpoint.modelMaxPromptTokens) ?
-			gpt41Endpoint :
-			this.props.endpoint;
+
+		// Priority: router-resolved endpoint > forceGpt41 experiment > current endpoint
+		let endpoint: IChatEndpoint;
+		if (routerResolvedEndpoint) {
+			endpoint = routerResolvedEndpoint;
+		} else if (forceGpt41 && (gpt41Endpoint.modelMaxPromptTokens >= this.props.endpoint.modelMaxPromptTokens)) {
+			endpoint = gpt41Endpoint;
+		} else {
+			endpoint = this.props.endpoint;
+		}
 
 		let summarizationPrompt: ChatMessage[];
 		const associatedRequestId = this.props.promptContext.conversation?.getLatestTurn().id;

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -815,6 +815,7 @@ export namespace ConfigKey {
 		export const InstantApplyModelName = defineTeamInternalSetting<string>('chat.advanced.instantApply.modelName', ConfigType.ExperimentBased, CHAT_MODEL.GPT4OPROXY);
 		export const VerifyTextDocumentChanges = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.verifyTextDocumentChanges', ConfigType.ExperimentBased, false);
 		export const UseAutoModeRouting = defineTeamInternalSetting<boolean>('chat.advanced.useAutoModeRouter', ConfigType.ExperimentBased, false);
+		export const UsePerConversationRouting = defineTeamInternalSetting<boolean>('chat.advanced.usePerConversationRouting', ConfigType.ExperimentBased, false);
 
 		/** Inline Completions */
 		export const InlineCompletionsDefaultDiagnosticsOptions = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineCompletions.defaultDiagnosticsOptionsString', ConfigType.ExperimentBased, undefined);

--- a/src/platform/endpoint/node/automodeService.ts
+++ b/src/platform/endpoint/node/automodeService.ts
@@ -20,7 +20,7 @@ import { IExperimentationService } from '../../telemetry/common/nullExperimentat
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { ICAPIClientService } from '../common/capiClient';
 import { AutoChatEndpoint } from './autoChatEndpoint';
-import { RouterDecisionFetcher, RoutingContextSignals } from './routerDecisionFetcher';
+import { RouterDecisionFetcher, RouterDecisionResponse, RoutingContextSignals } from './routerDecisionFetcher';
 
 interface AutoModeAPIResponse {
 	available_models: string[];
@@ -141,11 +141,26 @@ export interface IAutomodeService {
 	readonly _serviceBrand: undefined;
 
 	resolveAutoModeEndpoint(chatRequest: ChatRequest | undefined, knownEndpoints: IChatEndpoint[]): Promise<IChatEndpoint>;
+
+	/**
+	 * Called BEFORE summarization to let the router pick the next model.
+	 * The new model performs the summarization, warming its prompt cache.
+	 * After summarization the new model continues the conversation.
+	 *
+	 * Only called for automatic (foreground/background) summarization,
+	 * not for manual /compact.
+	 */
+	resolveEndpointForSummarization(
+		conversationId: string,
+		prompt: string,
+		knownEndpoints: IChatEndpoint[],
+		preCompactionPromptTokens?: number,
+	): Promise<{ endpoint: IChatEndpoint; routerDecision: RouterDecisionResponse; previousModel: string } | undefined>;
 }
 
 export class AutomodeService extends Disposable implements IAutomodeService {
 	readonly _serviceBrand: undefined;
-	private readonly _autoModelCache: Map<string, { endpoint: AutoChatEndpoint; tokenBank: AutoModeTokenBank; lastSessionToken?: string; lastRoutedPrompt?: string; turnCount: number }> = new Map();
+	private readonly _autoModelCache: Map<string, { endpoint: AutoChatEndpoint; tokenBank: AutoModeTokenBank; lastSessionToken?: string; lastRoutedPrompt?: string; turnCount: number; conversationRoutedModel?: string }> = new Map();
 	private _reserveTokens: DisposableMap<ChatLocation, AutoModeTokenBank> = new DisposableMap();
 	private readonly _routerDecisionFetcher: RouterDecisionFetcher;
 
@@ -212,6 +227,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 
 		let selectedModel: IChatEndpoint | undefined;
 		let lastRoutedPrompt = entry?.lastRoutedPrompt;
+		let conversationRoutedModel = entry?.conversationRoutedModel;
 		let routerFallbackReason: string | undefined;
 
 		// Try router-based model selection (skip for vision requests to avoid unnecessary latency)
@@ -219,9 +235,52 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			routerFallbackReason = 'hasImage';
 		} else if (this._isRouterEnabled(chatRequest)) {
 			const prompt = chatRequest?.prompt?.trim();
-			// Only route when the prompt has changed since the last decision, to avoid
-			// redundant calls during tool-calling iterations with the same prompt.
-			if (!prompt?.length) {
+
+			if (this._isPerConversationRouting()) {
+				// ── Per-conversation routing: route once on first turn, reuse for the rest ──
+				if (entry?.conversationRoutedModel) {
+					selectedModel = knownEndpoints.find(e => e.model === entry.conversationRoutedModel);
+					if (selectedModel) {
+						this._logService.trace(`[AutomodeService] Per-conversation routing: reusing model=${entry.conversationRoutedModel} for conversation=${conversationId}`);
+					} else {
+						routerFallbackReason = 'conversationModelUnavailable';
+					}
+				} else if (!prompt?.length) {
+					routerFallbackReason = 'emptyPrompt';
+				} else {
+					// First turn: call the router
+					try {
+						const contextSignals: RoutingContextSignals = {
+							session_id: conversationId !== 'unknown' ? conversationId : undefined,
+							reference_count: chatRequest?.references?.length,
+							prompt_char_count: prompt.length,
+							previous_model: entry?.endpoint?.model,
+							turn_number: (entry?.turnCount ?? 0) + 1,
+						};
+						const result = await this._routerDecisionFetcher.getRouterDecision(prompt, token.session_token, token.available_models, undefined, contextSignals);
+						if (!result.candidate_models.length) {
+							routerFallbackReason = 'emptyCandidateList';
+						} else if (entry?.endpoint) {
+							selectedModel = this._findSameProviderModel(entry.endpoint.modelProvider, result.candidate_models, knownEndpoints);
+						}
+						if (!routerFallbackReason) {
+							selectedModel ??= knownEndpoints.find(e => e.model === result.candidate_models[0]);
+						}
+						if (selectedModel) {
+							lastRoutedPrompt = prompt;
+							conversationRoutedModel = selectedModel.model;
+							this._logService.trace(`[AutomodeService] Per-conversation routing: first turn chose model=${selectedModel.model} for conversation=${conversationId}, label=${result.predicted_label}, confidence=${(result.confidence * 100).toFixed(1)}%`);
+						} else {
+							routerFallbackReason = 'noMatchingEndpoint';
+						}
+					} catch (e) {
+						this._logService.error(`Failed to get routed model for conversation ${conversationId}:`, (e as Error).message);
+						routerFallbackReason = 'routerError';
+					}
+				}
+			} else {
+				// ── Per-turn routing (default): route on every new prompt ──
+				if (!prompt?.length) {
 				routerFallbackReason = 'emptyPrompt';
 			} else if (entry && entry.lastRoutedPrompt === prompt) {
 				// Prompt hasn't changed since the last router decision — skip the
@@ -249,6 +308,27 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 					}
 					if (selectedModel) {
 						lastRoutedPrompt = prompt;
+						/* __GDPR__
+							"automode.routerModelSelected" : {
+								"owner": "lramos15",
+								"comment": "Per-turn model selection with cost context for cost/quality analysis",
+								"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Selected model" },
+								"previousModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Previous turn model" },
+								"routingMode": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "per-turn or per-conversation" },
+								"modelChanged": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Model changed" },
+								"turnNumber": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Turn number" },
+								"discountedCost": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Discounted cost" }
+							}
+						*/
+						this._telemetryService.sendMSFTTelemetryEvent('automode.routerModelSelected', {
+							model: selectedModel.model,
+							previousModel: entry?.endpoint?.model ?? '',
+							routingMode: 'per-turn',
+							modelChanged: String(selectedModel.model !== entry?.endpoint?.model),
+						}, {
+							turnNumber: (entry?.turnCount ?? 0) + 1,
+							discountedCost: token.discounted_costs?.[selectedModel.model] ?? 0,
+						});
 						if (result.sticky_override) {
 							this._logService.trace(`[AutomodeService] Sticky routing override: confidence=${(result.confidence * 100).toFixed(1)}%, label=${result.predicted_label}, router_model=${result.candidate_models[0]}, actual_model=${selectedModel.model}`);
 						}
@@ -297,13 +377,135 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			: this._instantiationService.createInstance(AutoChatEndpoint, selectedModel, token.session_token, token.discounted_costs?.[selectedModel.model] || 0, this._calculateDiscountRange(token.discounted_costs));
 
 		const isNewTurn = !entry || lastRoutedPrompt !== entry.lastRoutedPrompt;
-		this._autoModelCache.set(conversationId, { endpoint: autoEndpoint, tokenBank, lastSessionToken: token.session_token, lastRoutedPrompt, turnCount: (entry?.turnCount ?? 0) + (isNewTurn ? 1 : 0) });
+		this._autoModelCache.set(conversationId, { endpoint: autoEndpoint, tokenBank, lastSessionToken: token.session_token, lastRoutedPrompt, turnCount: (entry?.turnCount ?? 0) + (isNewTurn ? 1 : 0), conversationRoutedModel });
 		return autoEndpoint;
+	}
+
+	/**
+	 * Resolve the next model endpoint BEFORE summarization by calling the router.
+	 * The new model will perform the summarization call, warming its prompt cache
+	 * so the continuation experiences a cache hit instead of a cold start.
+	 */
+	async resolveEndpointForSummarization(
+		conversationId: string,
+		prompt: string,
+		knownEndpoints: IChatEndpoint[],
+		preCompactionPromptTokens?: number,
+	): Promise<{ endpoint: IChatEndpoint; routerDecision: RouterDecisionResponse; previousModel: string } | undefined> {
+		const entry = this._autoModelCache.get(conversationId);
+		if (!entry) {
+			this._logService.trace('[AutomodeService] resolveEndpointForSummarization: no cache entry, skipping');
+			return undefined;
+		}
+
+		const previousModel = entry.endpoint.model;
+		if (!prompt?.trim().length) {
+			return undefined;
+		}
+
+		let token: AutoModeAPIResponse;
+		try {
+			token = await entry.tokenBank.getToken();
+		} catch {
+			this._logService.warn('[AutomodeService] resolveEndpointForSummarization: failed to get token');
+			return undefined;
+		}
+
+		try {
+			const contextSignals: RoutingContextSignals = {
+				session_id: conversationId !== 'unknown' ? conversationId : undefined,
+				previous_model: previousModel,
+				turn_number: (entry.turnCount ?? 0) + 1,
+				prompt_char_count: prompt.length,
+			};
+
+			const result = await this._routerDecisionFetcher.getRouterDecision(
+				prompt, token.session_token, token.available_models, undefined, contextSignals);
+
+			if (!result.candidate_models.length) {
+				this._logService.trace('[AutomodeService] resolveEndpointForSummarization: empty candidates');
+				return undefined;
+			}
+
+			let selectedEndpoint = this._findSameProviderModel(
+				entry.endpoint.modelProvider, result.candidate_models, knownEndpoints);
+			selectedEndpoint ??= knownEndpoints.find(e => e.model === result.candidate_models[0]);
+
+			if (!selectedEndpoint) {
+				this._logService.trace('[AutomodeService] resolveEndpointForSummarization: no matching endpoint');
+				return undefined;
+			}
+
+			const modelChanged = selectedEndpoint.model !== previousModel;
+			this._logService.info(
+				`[AutomodeService] resolveEndpointForSummarization: `
+				+ `${previousModel} -> ${selectedEndpoint.model} (changed=${modelChanged}), `
+				+ `label=${result.predicted_label}, confidence=${(result.confidence * 100).toFixed(1)}%`);
+
+			// Update the automode cache so the continuation uses the new model
+			if (modelChanged) {
+				const newAutoEndpoint = this._instantiationService.createInstance(
+					AutoChatEndpoint, selectedEndpoint, token.session_token,
+					token.discounted_costs?.[selectedEndpoint.model] || 0,
+					this._calculateDiscountRange(token.discounted_costs));
+
+				this._autoModelCache.set(conversationId, {
+					...entry,
+					endpoint: newAutoEndpoint,
+					lastSessionToken: token.session_token,
+				});
+			}
+
+			/* __GDPR__
+				"automode.routerBeforeSummarization" : {
+					"owner": "lramos15",
+					"comment": "Reports routing decision made before summarization to switch models and warm the new model cache",
+					"previousModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Model active before summarization" },
+					"nextModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Model selected by router for summarization" },
+					"predictedLabel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Router classification label" },
+					"modelChanged": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the model actually changed" },
+					"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Chat conversation ID" },
+					"confidence": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Router confidence score" }
+				}
+			*/
+			this._telemetryService.sendMSFTTelemetryEvent('automode.routerBeforeSummarization', {
+				previousModel,
+				nextModel: selectedEndpoint.model,
+				predictedLabel: result.predicted_label,
+				modelChanged: String(modelChanged),
+				conversationId,
+			}, {
+				confidence: result.confidence,
+			});
+
+			return { endpoint: selectedEndpoint, routerDecision: result, previousModel };
+		} catch (e) {
+			this._logService.error('[AutomodeService] resolveEndpointForSummarization failed:', (e as Error).message);
+			/* __GDPR__
+				"automode.routerBeforeSummarizationError" : {
+					"owner": "lramos15",
+					"comment": "Reports when the pre-summarization router call fails",
+					"error": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth", "comment": "Error message" }
+				}
+			*/
+			this._telemetryService.sendMSFTTelemetryEvent('automode.routerBeforeSummarizationError', {
+				error: (e as Error).message,
+			});
+			return undefined;
+		}
 	}
 
 	private _isRouterEnabled(chatRequest: ChatRequest | undefined): boolean {
 		const isPanelChat = !chatRequest?.location || chatRequest?.location === ChatLocation.Panel;
 		return isPanelChat && this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.UseAutoModeRouting, this._expService);
+	}
+
+	/**
+	 * When true, the router is called only on the first turn of a conversation.
+	 * The chosen model is then reused for all subsequent turns.
+	 */
+	private _isPerConversationRouting(): boolean {
+		return this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.UsePerConversationRouting, this._expService);
 	}
 
 	/**

--- a/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -630,7 +630,110 @@ describe('AutomodeService', () => {
 		});
 	});
 
-	describe('vision fallback', () => {
+	describe('per-conversation routing', () => {
+		function enablePerConversationRouting(): void {
+			enableRouter();
+			(configurationService as InMemoryConfigurationService).setConfig(
+				ConfigKey.TeamInternal.UsePerConversationRouting,
+				true
+			);
+		}
+
+		function mockRouterResponse(available_models: string[], routerResult: { chosen_model: string; candidate_models: string[] }, session_token = 'test-token'): void {
+			(mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mockImplementation((_body: any, opts: any) => {
+				if (opts?.type === RequestType.ModelRouter) {
+					return Promise.resolve({
+						ok: true,
+						text: vi.fn().mockResolvedValue(JSON.stringify({
+							predicted_label: 'needs_reasoning',
+							confidence: 0.9,
+							latency_ms: 30,
+							chosen_model: routerResult.chosen_model,
+							candidate_models: routerResult.candidate_models,
+							scores: { needs_reasoning: 0.9, no_reasoning: 0.1 },
+							sticky_override: false
+						}))
+					});
+				}
+				return Promise.resolve({
+					ok: true,
+					json: vi.fn().mockResolvedValue({
+						available_models,
+						expires_at: Math.floor(Date.now() / 1000) + 3600,
+						session_token,
+					})
+				});
+			});
+		}
+
+		it('should reuse first turn model on subsequent turns', async () => {
+			enablePerConversationRouting();
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
+			const claudeEndpoint = createEndpoint('claude-sonnet', 'Anthropic');
+
+			mockRouterResponse(
+				['gpt-4o', 'claude-sonnet'],
+				{ chosen_model: 'gpt-4o', candidate_models: ['gpt-4o', 'claude-sonnet'] }
+			);
+
+			automodeService = createService();
+			const chatRequest1: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'first question',
+				sessionId: 'session-per-conv-1'
+			};
+
+			const firstResult = await automodeService.resolveAutoModeEndpoint(chatRequest1 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+			expect(firstResult.model).toBe('gpt-4o');
+
+			const chatRequest2: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'second question completely different',
+				sessionId: 'session-per-conv-1'
+			};
+
+			const secondResult = await automodeService.resolveAutoModeEndpoint(chatRequest2 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+			expect(secondResult.model).toBe('gpt-4o');
+
+			const routerCallCount = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls
+				.filter((call: any[]) => call[1]?.type === RequestType.ModelRouter).length;
+			expect(routerCallCount).toBe(1);
+		});
+
+		it('should still route per-turn when per-conversation routing is disabled', async () => {
+			enableRouter();
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
+			const claudeEndpoint = createEndpoint('claude-sonnet', 'Anthropic');
+
+			mockRouterResponse(
+				['gpt-4o', 'claude-sonnet'],
+				{ chosen_model: 'gpt-4o', candidate_models: ['gpt-4o', 'claude-sonnet'] }
+			);
+
+			automodeService = createService();
+			const chatRequest1: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'first question',
+				sessionId: 'session-per-turn-check'
+			};
+
+			await automodeService.resolveAutoModeEndpoint(chatRequest1 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+
+			const chatRequest2: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'second different question',
+				sessionId: 'session-per-turn-check'
+			};
+
+			await automodeService.resolveAutoModeEndpoint(chatRequest2 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+
+			const routerCallCount = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls
+				.filter((call: any[]) => call[1]?.type === RequestType.ModelRouter).length;
+			expect(routerCallCount).toBe(2);
+		});
+	});
+
+		describe('vision fallback', () => {
 		it('should fall back to vision-capable model when selected model does not support vision', async () => {
 			const nonVisionEndpoint = createEndpoint('gpt-4o-mini', 'OpenAI', { supportsVision: false });
 			const visionEndpoint = createEndpoint('gpt-4o', 'OpenAI', { supportsVision: true });


### PR DESCRIPTION
Two features for the binary router:

1. Re-route at summarization boundaries (Option A): When foreground or background summarization completes, call the router with the summarized text to pick the optimal model for the next phase. The current model performs summarization (warm KV cache), then the router decides which model continues — minimizing wasted cache tokens.

   Flow: Model A summarizes → summary text → router classifies → picks Model B → Model B starts fresh with small summary context (~1K tokens)

   Hooks: foreground (BudgetExceeded), background (budget-exceeded path), post-render background compaction. Manual /compact excluded.

   Telemetry: automode.summarizationReroute, automode.summarizationRerouteError

2. Per-conversation routing mode (opt-in via experiment): Add UsePerConversationRouting config flag. When enabled, the router is called only on the first turn of a conversation. The chosen model is stored as conversationRoutedModel in the cache and reused for all subsequent turns. Falls back to default if cached model unavailable.

   Both per-turn (default) and per-conversation paths coexist via if/else so we can switch between them easily.

Files modified:
- configurationService.ts: Add UsePerConversationRouting config key
- automodeService.ts: notifySummarizationCompleted(), per-conversation routing path, _isPerConversationRouting(), telemetry events
- agentIntent.ts: Import IAutomodeService, hook 3 summarization paths
- agentPrompt.tsx: Pass automodeService through props
- summarizedConversationHistory.tsx: Accept and forward automodeService
- automodeService.spec.ts: Per-conversation routing tests