### PR TITLE
fix: use per-session created_at for cloud agent timing

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -1047,8 +1047,6 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 				} catch { }
 			};
 
-			const createdAt = sessions.length > 0 ? validateISOTimestamp(sessions[0].created_at) : undefined;
-
 			// Create session items from latest sessions
 			const sessionItems = await Promise.all(Array.from(latestSessionsMap.values()).map(async sessionItem => {
 				const pr = prMap.get(sessionItem.resource_global_id);
@@ -1071,6 +1069,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 					pullRequestUrl: pr.url,
 				} satisfies { readonly [key: string]: unknown };
 
+				const createdAt = validateISOTimestamp(sessionItem.created_at);
 				const session = {
 					resource: vscode.Uri.from({ scheme: CopilotCloudSessionsProvider.TYPE, path: '/' + pr.number }),
 					label: pr.title,


### PR DESCRIPTION
`provideChatSessionItems` was using `sessions[0].created_ the creation time of whichever session happened to be first in the API  as the `timing.created` for **every** session item. This meant all cloud agent sessions displayed the same creation timestamp rather than their own.response at` 

The fix moves `createdAt` computation inside the per-session mapping so each session item uses its own `sessionItem.created_at` from the GitHub API, correctly reflecting when that individual session was created.

fixes https://github.com/microsoft/vscode/issues/302942