### PR TITLE
nes: support multi-file cursor jump

### DIFF
--- a/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -371,7 +371,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 				logContext.markAsNoSuggestions();
 			} else {
 				telemetryBuilder.setStatus('emptyEditsButHasNextCursorPosition');
-				return new NextEditResult(logContext.requestId, req, { jumpToPosition: error.nextCursorPosition, documentBeforeEdits: documentAtInvocationTime, isFromCursorJump: false, isSubsequentEdit: false });
+				return new NextEditResult(logContext.requestId, req, { jumpToPosition: error.nextCursorPosition, targetDocumentId: error.nextCursorDocumentId, documentBeforeEdits: documentAtInvocationTime, isFromCursorJump: false, isSubsequentEdit: false });
 			}
 		}
 

--- a/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
+++ b/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as l10n from '@vscode/l10n';
-import { CancellationToken, Command, EndOfLine, InlineCompletionContext, InlineCompletionDisplayLocation, InlineCompletionDisplayLocationKind, InlineCompletionEndOfLifeReason, InlineCompletionEndOfLifeReasonKind, InlineCompletionItem, InlineCompletionItemProvider, InlineCompletionList, InlineCompletionModelInfo, InlineCompletionProviderOption, InlineCompletionsDisposeReason, InlineCompletionsDisposeReasonKind, NotebookCell, NotebookCellKind, Position, Range, TextDocument, TextDocumentShowOptions, window, workspace } from 'vscode';
+import { CancellationToken, Command, EndOfLine, InlineCompletionContext, InlineCompletionDisplayLocation, InlineCompletionDisplayLocationKind, InlineCompletionEndOfLifeReason, InlineCompletionEndOfLifeReasonKind, InlineCompletionItem, InlineCompletionItemProvider, InlineCompletionList, InlineCompletionModelInfo, InlineCompletionProviderOption, InlineCompletionsDisposeReason, InlineCompletionsDisposeReasonKind, NotebookCell, NotebookCellKind, Position, Range, TextDocument, TextDocumentShowOptions, Uri, window, workspace } from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IDiffService } from '../../../platform/diff/common/diffService';
 import { stringEditFromDiff } from '../../../platform/editing/common/edit';
@@ -352,12 +352,14 @@ export class InlineCompletionProviderImpl extends Disposable implements InlineCo
 				this.telemetrySender.scheduleSendingEnhancedTelemetry(suggestionInfo.suggestion, telemetryBuilder);
 				const positionToJumpOneBased = suggestionInfo.suggestion.result.jumpToPosition;
 				const jumpToPosition = new Position(positionToJumpOneBased.lineNumber - 1, positionToJumpOneBased.column - 1);
+				const targetDocumentId = suggestionInfo.suggestion.result.targetDocumentId;
 				const jumpToPositionCompletionItem: NesCompletionItem = {
 					insertText: undefined as unknown as string,
 					info: suggestionInfo,
 					wasShown: false,
 					telemetryBuilder,
 					jumpToPosition,
+					...(targetDocumentId ? { uri: Uri.parse(targetDocumentId.uri) } : {}),
 					correlationId
 				};
 				return new NesCompletionList(context.requestUuid, jumpToPositionCompletionItem, [], telemetryBuilder);

--- a/src/extension/xtab/node/xtabNextCursorPredictor.ts
+++ b/src/extension/xtab/node/xtabNextCursorPredictor.ts
@@ -21,10 +21,15 @@ import { Result } from '../../../util/common/result';
 import { TokenizerType } from '../../../util/common/tokenizer';
 import { assertNever } from '../../../util/vs/base/common/assert';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
+import { OffsetRange } from '../../../util/vs/editor/common/core/ranges/offsetRange';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { LintErrors } from '../common/lintErrors';
 import { constructTaggedFile, getUserPrompt, PromptPieces } from '../common/promptCrafting';
 import { constructMessages } from './xtabUtils';
+
+export type CursorJumpPrediction =
+	| { readonly kind: 'sameFile'; readonly lineNumber: number }
+	| { readonly kind: 'differentFile'; readonly filePath: string; readonly lineNumber: number };
 
 export class XtabNextCursorPredictor {
 
@@ -67,11 +72,11 @@ export class XtabNextCursorPredictor {
 	}
 
 
-	public async predictNextCursorPosition(promptPieces: PromptPieces, parentTracer: ILogger, telemetryBuilder: StatelessNextEditTelemetryBuilder | undefined, cancellationToken: CancellationToken): Promise<Result</* zero-based line number */ number, Error>> {
+	public async predictNextCursorPosition(promptPieces: PromptPieces, parentTracer: ILogger, telemetryBuilder: StatelessNextEditTelemetryBuilder | undefined, cancellationToken: CancellationToken): Promise<Result<CursorJumpPrediction, Error>> {
 
 		const tracer = parentTracer.createSubLogger('predictNextCursorPosition');
 
-		const systemMessage = `Your task is to predict the next line number in the current file where the developer is most likely to make their next edit, using the provided context. If you don't think anywhere is a good next line jump target, just output the current line number of the cursor. Make sure to just output the line number and nothing else (no explanation, reasoning, etc.).`;
+		const systemMessage = `Your task is to predict the line number where the developer is most likely to make their next edit. If you jump in the current file, just output the line number. If you want to jump to another file, output the filepath (relative to workspace root), colon, then line number. If you don't think anywhere is a good next line jump target, just output the current line number of the cursor. Make sure to output no explanation, reasoning, extra spaces, etc.`;
 
 		const maxTokens = this.configService.getExperimentBasedConfig(ConfigKey.Advanced.InlineEditsNextCursorPredictionCurrentFileMaxTokens, this.expService);
 
@@ -216,18 +221,7 @@ export class XtabNextCursorPredictor {
 		try {
 			telemetryBuilder?.setCursorJumpResponse(response.value);
 			const trimmed = response.value.trim();
-			const lineNumber = parseInt(trimmed, 10);
-			if (isNaN(lineNumber)) {
-				return Result.fromString(`gotNaN`);
-			}
-			if (lineNumber < 0) {
-				return Result.fromString(`negativeLineNumber`);
-			}
-			if (lineNumber < clippedTaggedCurrentDoc.keptRange.start || clippedTaggedCurrentDoc.keptRange.endExclusive <= lineNumber) {
-				return Result.fromString(`modelNotSeenLineNumber`);
-			}
-
-			return Result.ok(lineNumber);
+			return this.parseResponse(trimmed, clippedTaggedCurrentDoc.keptRange);
 		} catch (err: unknown) {
 			tracer.trace(`Failed to parse predicted line number from response '${response.value}': ${err}`);
 			return Result.fromString(`failedToParseLine:"${response.value}". Error ${ErrorUtils.fromUnknown(err).message}`);
@@ -246,6 +240,44 @@ export class XtabNextCursorPredictor {
 		}
 
 		return parseLintOptionString(expLintOptions);
+	}
+
+	public parseResponse(trimmed: string, keptRange: OffsetRange): Result<CursorJumpPrediction, Error> {
+		// Try parsing as a plain line number (same-file jump)
+		const lineNumber = parseInt(trimmed, 10);
+		if (!isNaN(lineNumber) && String(lineNumber) === trimmed) {
+			return this.parseSameFileLineNumber(lineNumber, keptRange);
+		}
+
+		// Try parsing as filepath:lineNumber (cross-file jump)
+		const lastColonIdx = trimmed.lastIndexOf(':');
+		if (lastColonIdx <= 0) {
+			return Result.fromString(`gotNaN`);
+		}
+
+		const filePath = trimmed.substring(0, lastColonIdx);
+		const lineNumberStr = trimmed.substring(lastColonIdx + 1);
+		const crossFileLineNumber = parseInt(lineNumberStr, 10);
+
+		if (isNaN(crossFileLineNumber) || crossFileLineNumber < 0) {
+			return Result.fromString(`crossFileInvalidLineNumber`);
+		}
+
+		if (filePath.trim().length === 0) {
+			return Result.fromString(`crossFileEmptyFilePath`);
+		}
+
+		return Result.ok({ kind: 'differentFile', filePath: filePath.trim(), lineNumber: crossFileLineNumber });
+	}
+
+	private parseSameFileLineNumber(lineNumber: number, keptRange: OffsetRange): Result<CursorJumpPrediction, Error> {
+		if (lineNumber < 0) {
+			return Result.fromString(`negativeLineNumber`);
+		}
+		if (lineNumber < keptRange.start || keptRange.endExclusive <= lineNumber) {
+			return Result.fromString(`modelNotSeenLineNumber`);
+		}
+		return Result.ok({ kind: 'sameFile', lineNumber });
 	}
 }
 

--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -12,6 +12,7 @@ import { ChatEndpoint } from '../../../platform/endpoint/node/chatEndpoint';
 import { createProxyXtabEndpoint } from '../../../platform/endpoint/node/proxyXtabEndpoint';
 import { IIgnoreService } from '../../../platform/ignore/common/ignoreService';
 import { Copilot } from '../../../platform/inlineCompletions/common/api';
+import { DocumentId } from '../../../platform/inlineEdits/common/dataTypes/documentId';
 import { LanguageContextEntry, LanguageContextResponse } from '../../../platform/inlineEdits/common/dataTypes/languageContext';
 import { LanguageId } from '../../../platform/inlineEdits/common/dataTypes/languageId';
 import { NextCursorLinePrediction } from '../../../platform/inlineEdits/common/dataTypes/nextCursorLinePrediction';
@@ -38,7 +39,9 @@ import { Result } from '../../../util/common/result';
 import { assertNever } from '../../../util/vs/base/common/assert';
 import { DeferredPromise, raceCancellation, raceTimeout, timeout } from '../../../util/vs/base/common/async';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
+import { isAbsolute } from '../../../util/vs/base/common/path';
 import { StopWatch } from '../../../util/vs/base/common/stopwatch';
+import { URI } from '../../../util/vs/base/common/uri';
 import { LineEdit, LineReplacement } from '../../../util/vs/editor/common/core/edits/lineEdit';
 import { Position } from '../../../util/vs/editor/common/core/position';
 import { Range } from '../../../util/vs/editor/common/core/range';
@@ -61,7 +64,7 @@ import { TerminalMonitor } from '../common/terminalOutput';
 import { CurrentDocument } from '../common/xtabCurrentDocument';
 import { XtabCustomDiffPatchResponseHandler } from './xtabCustomDiffPatchResponseHandler';
 import { XtabEndpoint } from './xtabEndpoint';
-import { XtabNextCursorPredictor } from './xtabNextCursorPredictor';
+import { CursorJumpPrediction, XtabNextCursorPredictor } from './xtabNextCursorPredictor';
 import { charCount, constructMessages, linesWithBackticksRemoved } from './xtabUtils';
 
 /**
@@ -1026,10 +1029,17 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			return noSuggestions;
 		}
 
-		const nextCursorLineZeroBased = nextCursorLineR.val;
+		const prediction: CursorJumpPrediction = nextCursorLineR.val;
+
+		if (prediction.kind === 'differentFile') {
+			return this.handleCrossFilePrediction(prediction, request, editWindow, promptPieces, tracer, telemetryBuilder);
+		}
+
+		const nextCursorLineZeroBased = prediction.lineNumber;
 
 		const lineDistanceFromCursorLine = nextCursorLineZeroBased - promptPieces.currentDocument.cursorLineOffset;
 		telemetryBuilder.setNextCursorLineDistance(lineDistanceFromCursorLine);
+		telemetryBuilder.setNextCursorIsCrossFile(false);
 
 		tracer.trace(`Predicted next cursor line: ${nextCursorLineZeroBased}`);
 
@@ -1072,6 +1082,34 @@ export class XtabProvider implements IStatelessNextEditProvider {
 				assertNever(nextCursorLinePrediction);
 			}
 		}
+	}
+
+	private handleCrossFilePrediction(
+		prediction: Extract<CursorJumpPrediction, { kind: 'differentFile' }>,
+		request: StatelessNextEditRequest,
+		editWindow: OffsetRange,
+		promptPieces: PromptPieces,
+		tracer: ILogger,
+		telemetryBuilder: StatelessNextEditTelemetryBuilder,
+	): NoNextEditReason.NoSuggestions {
+		const workspaceRoot = promptPieces.activeDoc.workspaceRoot;
+		if (!workspaceRoot && !isAbsolute(prediction.filePath)) {
+			tracer.trace('Predicted cross-file cursor jump error: noWorkspaceRoot');
+			telemetryBuilder.setNextCursorLineError('crossFile:noWorkspaceRoot');
+			return new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, editWindow);
+		}
+
+		const targetUri = isAbsolute(prediction.filePath)
+			? URI.file(prediction.filePath)
+			: URI.joinPath(workspaceRoot!, prediction.filePath);
+		const targetDocumentId = DocumentId.create(targetUri.toString());
+		const nextCursorLineOneBased = prediction.lineNumber + 1;
+		const nextCursorPosition = new Position(nextCursorLineOneBased, 1);
+
+		telemetryBuilder.setNextCursorIsCrossFile(true);
+		tracer.trace(`Predicted cross-file cursor jump: ${prediction.filePath}:${prediction.lineNumber}`);
+
+		return new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, editWindow, nextCursorPosition, targetDocumentId);
 	}
 
 	private computeEditWindowLinesRange(currentDocument: CurrentDocument, request: StatelessNextEditRequest, tracer: ILogger, telemetry: StatelessNextEditTelemetryBuilder): OffsetRange {

--- a/src/extension/xtab/test/node/xtabNextCursorPredictor.spec.ts
+++ b/src/extension/xtab/test/node/xtabNextCursorPredictor.spec.ts
@@ -221,11 +221,122 @@ describe('XtabNextCursorPredictor', () => {
 
 			expect(result.isOk()).toBe(true);
 			if (result.isOk()) {
-				expect(result.val).toBe(0);
+				expect(result.val).toEqual({ kind: 'sameFile', lineNumber: 0 });
 			}
 
 			// Predictor should still be enabled
 			expect(predictor.determineEnablement()).toBe(NextCursorLinePrediction.OnlyWithEdit);
+		});
+
+		it('should return cross-file result when prediction contains filepath:line', async () => {
+			const predictor = instaService.createInstance(XtabNextCursorPredictor, computeTokens);
+			const tracer = createTestLogger();
+			const promptPieces = createTestPromptPieces();
+
+			mockChatMLFetcher.setNextResponse({
+				type: ChatFetchResponseType.Success,
+				requestId: 'test-request-id',
+				serverRequestId: 'test-server-request-id',
+				usage: { prompt_tokens: 100, completion_tokens: 10, total_tokens: 110, prompt_tokens_details: { cached_tokens: 0 } },
+				value: 'src/utils/helpers.ts:42',
+				resolvedModel: 'test-model'
+			});
+
+			const result = await predictor.predictNextCursorPosition(promptPieces, tracer, undefined, CancellationToken.None);
+
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.val).toEqual({ kind: 'differentFile', filePath: 'src/utils/helpers.ts', lineNumber: 42 });
+			}
+		});
+	});
+
+	describe('parseResponse', () => {
+		let predictor: XtabNextCursorPredictor;
+		const keptRange = new OffsetRange(0, 100);
+
+		beforeEach(() => {
+			predictor = instaService.createInstance(XtabNextCursorPredictor, computeTokens);
+		});
+
+		it('should parse a plain line number as sameFile', () => {
+			const result = predictor.parseResponse('42', keptRange);
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.val).toEqual({ kind: 'sameFile', lineNumber: 42 });
+			}
+		});
+
+		it('should parse zero as sameFile', () => {
+			const result = predictor.parseResponse('0', keptRange);
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.val).toEqual({ kind: 'sameFile', lineNumber: 0 });
+			}
+		});
+
+		it('should parse filepath:lineNumber as differentFile', () => {
+			const result = predictor.parseResponse('src/utils/helpers.ts:42', keptRange);
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.val).toEqual({ kind: 'differentFile', filePath: 'src/utils/helpers.ts', lineNumber: 42 });
+			}
+		});
+
+		it('should handle file paths with colons by splitting on last colon', () => {
+			const result = predictor.parseResponse('src/file:with:colons.ts:10', keptRange);
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.val).toEqual({ kind: 'differentFile', filePath: 'src/file:with:colons.ts', lineNumber: 10 });
+			}
+		});
+
+		it('should reject negative line numbers for sameFile', () => {
+			const result = predictor.parseResponse('-5', keptRange);
+			expect(result.isError()).toBe(true);
+			if (result.isError()) {
+				expect(result.err.message).toContain('negativeLineNumber');
+			}
+		});
+
+		it('should reject line numbers outside keptRange for sameFile', () => {
+			const result = predictor.parseResponse('150', keptRange);
+			expect(result.isError()).toBe(true);
+			if (result.isError()) {
+				expect(result.err.message).toContain('modelNotSeenLineNumber');
+			}
+		});
+
+		it('should reject crossFileInvalidLineNumber for non-numeric line in filepath:line format', () => {
+			const result = predictor.parseResponse('src/file.ts:abc', keptRange);
+			expect(result.isError()).toBe(true);
+			if (result.isError()) {
+				expect(result.err.message).toContain('crossFileInvalidLineNumber');
+			}
+		});
+
+		it('should reject gotNaN for non-numeric non-path string', () => {
+			const result = predictor.parseResponse('abc', keptRange);
+			expect(result.isError()).toBe(true);
+			if (result.isError()) {
+				expect(result.err.message).toContain('gotNaN');
+			}
+		});
+
+		it('should reject negative line numbers for cross-file', () => {
+			const result = predictor.parseResponse('src/file.ts:-5', keptRange);
+			expect(result.isError()).toBe(true);
+			if (result.isError()) {
+				expect(result.err.message).toContain('crossFileInvalidLineNumber');
+			}
+		});
+
+		it('should handle line number 0 for cross-file', () => {
+			const result = predictor.parseResponse('src/file.ts:0', keptRange);
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.val).toEqual({ kind: 'differentFile', filePath: 'src/file.ts', lineNumber: 0 });
+			}
 		});
 	});
 });

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -766,7 +766,7 @@ export namespace ConfigKey {
 		export const InlineEditsProviderId = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineEdits.providerId', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsUnification = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.unification', ConfigType.ExperimentBased, false);
 		export const InlineEditsNextCursorPredictionModelName = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineEdits.nextCursorPrediction.modelName', ConfigType.ExperimentBased, 'copilot-suggestions-himalia-001');
-		export const InlineEditsNextCursorPredictionMaxResponseTokens = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.nextCursorPrediction.maxResponseTokens', ConfigType.ExperimentBased, 4);
+		export const InlineEditsNextCursorPredictionMaxResponseTokens = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.nextCursorPrediction.maxResponseTokens', ConfigType.ExperimentBased, 40);
 		export const InlineEditsNextCursorPredictionLintOptionsString = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineEdits.nextCursorPrediction.lintOptionsString', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsXtabProviderModelConfigurationString = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineEdits.xtabProvider.modelConfigurationString', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsXtabProviderDefaultModelConfigurationString = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineEdits.xtabProvider.defaultModelConfigurationString', ConfigType.ExperimentBased, undefined);

--- a/src/platform/inlineEdits/common/statelessNextEditProvider.ts
+++ b/src/platform/inlineEdits/common/statelessNextEditProvider.ts
@@ -222,6 +222,7 @@ export namespace NoNextEditReason {
 			public readonly documentBeforeEdits: StringText,
 			public readonly window: OffsetRange | undefined,
 			public readonly nextCursorPosition?: Position | undefined,
+			public readonly nextCursorDocumentId?: DocumentId | undefined,
 		) {
 			super();
 		}
@@ -368,6 +369,7 @@ export interface IStatelessNextEditTelemetry {
 		nextCursorLineError: string | undefined;
 		/** nextCursorLineNumber - currentCursorLineNumber */
 		nextCursorLineDistance: number | undefined;
+		isCrossFile: boolean | undefined;
 	};
 
 	/* xtab aggressiveness telemetry (only set when promptingStrategy is aggressiveness-based) */
@@ -615,7 +617,8 @@ export class StatelessNextEditTelemetryBuilder {
 
 	private _nextCursorPrediction: IStatelessNextEditTelemetry['nextCursorPrediction'] = {
 		nextCursorLineError: undefined,
-		nextCursorLineDistance: undefined
+		nextCursorLineDistance: undefined,
+		isCrossFile: undefined
 	};
 
 	public setNextCursorLineError(error: string): this {
@@ -628,6 +631,11 @@ export class StatelessNextEditTelemetryBuilder {
 	 */
 	public setNextCursorLineDistance(distance: number): this {
 		this._nextCursorPrediction.nextCursorLineDistance = distance;
+		return this;
+	}
+
+	public setNextCursorIsCrossFile(isCrossFile: boolean): this {
+		this._nextCursorPrediction.isCrossFile = isCrossFile;
 		return this;
 	}
 


### PR DESCRIPTION
closes https://github.com/microsoft/vscode-internalbacklog/issues/6951

currently, UI would only suggest to jump to the model-suggested file and location but not verify if Xtab has an edit there which's the case for cursor jump in the current file. This support is in the works.