### PR TITLE
Agent debug: troubleshoot support for claude cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -5928,6 +5928,10 @@
 					{
 						"name": "compact",
 						"description": "Compact the conversation history to save context tokens"
+					},
+					{
+						"name": "troubleshoot",
+						"description": "Investigate unexpected chat behavior using debug logs"
 					}
 				]
 			},

--- a/src/extension/chatSessions/claude/vscode-node/claudeSlashCommandService.ts
+++ b/src/extension/chatSessions/claude/vscode-node/claudeSlashCommandService.ts
@@ -13,6 +13,8 @@ import { getClaudeSlashCommandRegistry, IClaudeSlashCommandHandler } from './sla
 export interface IClaudeSlashCommandRequest {
 	readonly prompt: string;
 	readonly command: string | undefined;
+	/** The Claude session ID for session-aware commands like /troubleshoot */
+	readonly sessionId?: string;
 }
 
 // Import all slash command handlers to trigger self-registration
@@ -21,6 +23,11 @@ import './slashCommands/index';
 export interface IClaudeSlashCommandResult {
 	handled: boolean;
 	result?: vscode.ChatResult;
+	/**
+	 * When set, the original prompt is replaced with this text before
+	 * being sent to the Claude SDK.  Only meaningful when `handled` is false.
+	 */
+	rewrittenPrompt?: string;
 }
 
 export interface IClaudeSlashCommandService {
@@ -71,12 +78,14 @@ export class ClaudeSlashCommandService extends Disposable implements IClaudeSlas
 		stream: vscode.ChatResponseStream,
 		token: CancellationToken
 	): Promise<IClaudeSlashCommandResult> {
+		const handlerContext = { sessionId: request.sessionId };
+
 		// 1. Check request.command (VS Code slash command selected via UI)
 		if (request.command) {
 			const handler = this._getHandler(request.command.toLowerCase());
 			if (handler) {
-				const result = await handler.handle(request.prompt, stream, token);
-				return { handled: true, result: result ?? {} };
+				const result = await handler.handle(request.prompt, stream, token, handlerContext);
+				return this._toResult(result);
 			}
 		}
 
@@ -92,7 +101,14 @@ export class ClaudeSlashCommandService extends Disposable implements IClaudeSlas
 			return { handled: false };
 		}
 
-		const result = await handler.handle(args ?? '', stream, token);
+		const result = await handler.handle(args ?? '', stream, token, handlerContext);
+		return this._toResult(result);
+	}
+
+	private _toResult(result: vscode.ChatResult | { rewrittenPrompt: string } | void): IClaudeSlashCommandResult {
+		if (result && 'rewrittenPrompt' in result) {
+			return { handled: false, rewrittenPrompt: result.rewrittenPrompt };
+		}
 		return { handled: true, result: result ?? {} };
 	}
 

--- a/src/extension/chatSessions/claude/vscode-node/slashCommands/claudeSlashCommandRegistry.ts
+++ b/src/extension/chatSessions/claude/vscode-node/slashCommands/claudeSlashCommandRegistry.ts
@@ -38,13 +38,17 @@ export interface IClaudeSlashCommandHandler {
 	 * @param args - Arguments passed after the command name
 	 * @param stream - Response stream for sending messages to the chat (undefined when invoked from Command Palette)
 	 * @param token - Cancellation token
-	 * @returns Chat result or void
+	 * @param context - Optional context with session information
+	 * @returns Chat result, void, or an object with `rewrittenPrompt` to pass a
+	 *          modified prompt through to the Claude SDK instead of handling the
+	 *          command directly.
 	 */
 	handle(
 		args: string,
 		stream: vscode.ChatResponseStream | undefined,
-		token: CancellationToken
-	): Promise<vscode.ChatResult | void>;
+		token: CancellationToken,
+		context?: { readonly sessionId?: string },
+	): Promise<vscode.ChatResult | { rewrittenPrompt: string } | void>;
 }
 
 /**

--- a/src/extension/chatSessions/claude/vscode-node/slashCommands/index.ts
+++ b/src/extension/chatSessions/claude/vscode-node/slashCommands/index.ts
@@ -13,5 +13,6 @@ import '../../node/slashCommands/index';
 import './agentsCommand';
 import './hooksCommand';
 import './memoryCommand';
+import './troubleshootCommand';
 // TODO: Re-enable after legal review is complete
 // import './terminalCommand';

--- a/src/extension/chatSessions/claude/vscode-node/slashCommands/troubleshootCommand.ts
+++ b/src/extension/chatSessions/claude/vscode-node/slashCommands/troubleshootCommand.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { IChatDebugFileLoggerService } from '../../../../../platform/chat/common/chatDebugFileLoggerService';
+import { IVSCodeExtensionContext } from '../../../../../platform/extContext/common/extensionContext';
+import { ILogService } from '../../../../../platform/log/common/logService';
+import { CancellationToken } from '../../../../../util/vs/base/common/cancellation';
+import { URI } from '../../../../../util/vs/base/common/uri';
+import { IClaudeSlashCommandHandler, registerClaudeSlashCommand } from './claudeSlashCommandRegistry';
+
+const RUNTIME_CONTEXT_PLACEHOLDER = '{{DEBUG_LOG_RUNTIME_CONTEXT}}';
+
+/**
+ * Slash command handler for /troubleshoot in Claude sessions.
+ *
+ * Loads the troubleshoot SKILL.md template, resolves the debug log path placeholders,
+ * and returns a rewritten prompt that includes the skill instructions so Claude can
+ * investigate the session's debug logs.
+ */
+export class TroubleshootSlashCommand implements IClaudeSlashCommandHandler {
+	readonly commandName = 'troubleshoot';
+	readonly description = 'Investigate unexpected chat behavior using debug logs';
+
+	/** Cached skill template (without runtime context — that's resolved per-invocation) */
+	private _cachedTemplate: string | undefined;
+
+	constructor(
+		@ILogService private readonly logService: ILogService,
+		@IChatDebugFileLoggerService private readonly debugFileLogger: IChatDebugFileLoggerService,
+		@IVSCodeExtensionContext private readonly extensionContext: IVSCodeExtensionContext,
+	) { }
+
+	async handle(
+		args: string,
+		_stream: vscode.ChatResponseStream | undefined,
+		_token: CancellationToken,
+		context?: { readonly sessionId?: string },
+	): Promise<{ rewrittenPrompt: string }> {
+		const skillContent = await this._loadSkillContent(context?.sessionId);
+		const userQuestion = args.trim() || 'What went wrong in this session?';
+		return { rewrittenPrompt: `${skillContent}\n\n---\n\nUser question: ${userQuestion}` };
+	}
+
+	private async _loadSkillContent(sessionId: string | undefined): Promise<string> {
+		const template = await this._loadTemplate();
+		return template.replace(RUNTIME_CONTEXT_PLACEHOLDER, this._getRuntimeContext(sessionId));
+	}
+
+	private async _loadTemplate(): Promise<string> {
+		if (this._cachedTemplate) {
+			return this._cachedTemplate;
+		}
+		try {
+			const skillUri = URI.joinPath(
+				this.extensionContext.extensionUri,
+				'assets', 'prompts', 'skills', 'troubleshoot', 'SKILL.md'
+			);
+			const bytes = await vscode.workspace.fs.readFile(skillUri);
+			let content = new TextDecoder().decode(bytes);
+
+			// Strip YAML frontmatter
+			if (content.startsWith('---')) {
+				const endIdx = content.indexOf('\n---', 3);
+				if (endIdx !== -1) {
+					content = content.substring(endIdx + 4).trimStart();
+				}
+			}
+
+			this._cachedTemplate = content;
+			return content;
+		} catch (error) {
+			this.logService.error('[TroubleshootSlashCommand] Failed to load SKILL.md:', error);
+			return 'Troubleshoot skill unavailable. Investigate the debug logs manually.';
+		}
+	}
+
+	private _getRuntimeContext(sessionId: string | undefined): string {
+		const logDir = this.debugFileLogger.debugLogsDir;
+		if (!logDir) {
+			return '## Runtime Log Context\n\n- Debug-logs directory: unavailable in this environment. Abort now and tell the user that troubleshooting is only available if a workspace is open.';
+		}
+
+		if (sessionId) {
+			const sessionLogPath = URI.joinPath(logDir, sessionId).fsPath;
+			return `## Runtime Log Context\n\n- Current session log directory: \`${sessionLogPath}\``;
+		}
+
+		return `## Runtime Log Context\n\n- Debug-logs directory: \`${logDir.fsPath}\`\n- No active session detected. List session directories to find the relevant logs.`;
+	}
+}
+registerClaudeSlashCommand(TroubleshootSlashCommand);

--- a/src/extension/chatSessions/claude/vscode-node/test/claudeSlashCommandService.spec.ts
+++ b/src/extension/chatSessions/claude/vscode-node/test/claudeSlashCommandService.spec.ts
@@ -25,7 +25,7 @@ class TestHooksHandler implements IClaudeSlashCommandHandler {
 	readonly commandName = 'hooks';
 	readonly description = 'Test hooks handler';
 
-	handle(args: string, stream: vscode.ChatResponseStream | undefined, token: CancellationToken): Promise<vscode.ChatResult | void> {
+	handle(args: string, stream: vscode.ChatResponseStream | undefined, token: CancellationToken) {
 		return TestHooksHandler.handleSpy(args, stream, token);
 	}
 }
@@ -35,7 +35,7 @@ class TestMemoryHandler implements IClaudeSlashCommandHandler {
 	readonly commandName = 'memory';
 	readonly description = 'Test memory handler';
 
-	handle(args: string, stream: vscode.ChatResponseStream | undefined, token: CancellationToken): Promise<vscode.ChatResult | void> {
+	handle(args: string, stream: vscode.ChatResponseStream | undefined, token: CancellationToken) {
 		return TestMemoryHandler.handleSpy(args, stream, token);
 	}
 }

--- a/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -246,12 +246,19 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 			}
 
 			// Try to handle as a slash command first
-			const slashResult = await this.slashCommandService.tryHandleCommand(request, stream, token);
+			const effectiveSessionId = ClaudeSessionUri.getSessionId(chatSessionContext.chatSessionItem.resource);
+			const slashResult = await this.slashCommandService.tryHandleCommand({ ...request, sessionId: effectiveSessionId }, stream, token);
 			if (slashResult.handled) {
 				return slashResult.result ?? {};
 			}
 
-			const effectiveSessionId = ClaudeSessionUri.getSessionId(chatSessionContext.chatSessionItem.resource);
+			// If the slash command returned a rewritten prompt, override the prompt
+			// before it reaches the Claude SDK. Clear `command` so the SDK doesn't
+			// try to interpret it as a Claude CLI slash command.
+			const effectiveRequest = slashResult.rewrittenPrompt !== undefined
+				? { ...request, prompt: slashResult.rewrittenPrompt, command: undefined } as vscode.ChatRequest
+				: request;
+
 			const yieldRequested = () => context.yieldRequested;
 
 			// Determine whether this is a new session by checking if a session
@@ -295,7 +302,7 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 
 			const prompt = request.prompt;
 			this._controller.updateItemStatus(effectiveSessionId, vscode.ChatSessionStatus.InProgress, prompt);
-			const result = await this.claudeAgentManager.handleRequest(effectiveSessionId, request, context, stream, token, isNewSession, yieldRequested);
+			const result = await this.claudeAgentManager.handleRequest(effectiveSessionId, effectiveRequest, context, stream, token, isNewSession, yieldRequested);
 			this._controller.updateItemStatus(effectiveSessionId, vscode.ChatSessionStatus.Completed, prompt);
 
 			// Clear usage handler after request completes


### PR DESCRIPTION
The default Copilot participant receives troubleshoot skill content via VS Code core's skill injection pipeline (prompt-tsx rendering). Since Claude sessions use the Claude Agent SDK and bypass prompt-tsx, we implement an equivalent flow:
load the same shared SKILL.md template, resolve the debug log path placeholders, and deliver the content via prompt rewriting — the handler returns a { rewrittenPrompt } that flows through to the Claude SDK as a normal user message instead of being handled directly.