### PR TITLE
Integrate custom session title generation in CopilotCLIChatSessionParticipant

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
@@ -1068,6 +1068,7 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ICopilotCLISDK private readonly copilotCLISDK: ICopilotCLISDK,
 		@IChatSessionMetadataStore private readonly chatSessionMetadataStore: IChatSessionMetadataStore,
+		@ICustomSessionTitleService private readonly customSessionTitleService: ICustomSessionTitleService,
 	) {
 		super();
 		this.useController = configurationService.getConfig(ConfigKey.Advanced.CLISessionController);
@@ -1311,6 +1312,7 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 			// If user has selected a repo, then update with repo information (right icons, etc).
 			if (isUntitled) {
 				void this.lockRepoOptionForSession(context, token);
+				this.customSessionTitleService.generateSessionTitle(session.object.sessionId, request, token).catch(ex => this.logService.error(ex, 'Failed to generate custom session title'));
 			}
 			if (isUntitled && this.useController) {
 				// The session has been created and initialized with workspace information,

--- a/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
+++ b/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
@@ -418,6 +418,7 @@ describe('CopilotCLIChatSessionParticipant.handleRequest', () => {
 			configurationService,
 			sdk,
 			new MockChatSessionMetadataStore(),
+			customSessionTitleService,
 		);
 	});
 
@@ -765,6 +766,7 @@ describe('CopilotCLIChatSessionParticipant.handleRequest', () => {
 			configurationService,
 			sdk,
 			new MockChatSessionMetadataStore(),
+			customSessionTitleService,
 		);
 		const sessionResource = vscode.Uri.from({ scheme: 'copilotcli', path: `/${sessionId}` });
 		const contentToken = disposables.add(new CancellationTokenSource()).token;


### PR DESCRIPTION
Implement custom session title generation to enhance session management in the Copilot CLI. This change integrates a new service for generating session titles based on user requests.