### PR TITLE
feat: show 'Copied!' status bar feedback on copy action

### DIFF
--- a/src/extension/conversation/vscode-node/userActions.ts
+++ b/src/extension/conversation/vscode-node/userActions.ts
@@ -87,6 +87,7 @@ export class UserFeedbackService implements IUserFeedbackService {
 					characterCount: e.action.copiedCharacters,
 					lineCount: e.action.copiedText.split('\n').length,
 				});
+				vscode.window.setStatusBarMessage(vscode.l10n.t('Copied!'), 2000);
 				break;
 			case 'insert':
 				/* __GDPR__


### PR DESCRIPTION
## Summary                            
  - Adds a brief 'Copied!' status bar message (2 seconds) when clicking copy in chat response action bar
  - Uses vscode.l10n.t for localization support                                                                   
                                                                                                                  
  ## Test plan                                                                                                    
  - [ ] Launch Extension Development Host, trigger a chat response                                                
  - [ ] Click the copy icon, confirm 'Copied!' appears in the status bar for ~2 seconds