### PR TITLE
Auto mode: per-conversation routing

### DIFF
--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -820,6 +820,7 @@ export namespace ConfigKey {
 		export const InlineEditsJointCompletionsProviderTriggerChangeStrategy = defineTeamInternalSetting<JointCompletionsProviderTriggerChangeStrategy>('chat.advanced.inlineEdits.jointCompletionsProvider.triggerChangeStrategy', ConfigType.ExperimentBased, JointCompletionsProviderTriggerChangeStrategy.NoTriggerOnCompletionsRequestInFlight);
 		export const InstantApplyModelName = defineTeamInternalSetting<string>('chat.advanced.instantApply.modelName', ConfigType.ExperimentBased, CHAT_MODEL.GPT4OPROXY);
 		export const VerifyTextDocumentChanges = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.verifyTextDocumentChanges', ConfigType.ExperimentBased, false);
+		export const UsePerConversationRouting = defineTeamInternalSetting<boolean>('chat.advanced.usePerConversationRouting', ConfigType.ExperimentBased, false);
 		export const UseAutoModeRouting = defineTeamInternalSetting<boolean>('chat.advanced.useAutoModeRouter', ConfigType.ExperimentBased, false);
 
 		/** Inline Completions */

--- a/src/platform/endpoint/node/automodeService.ts
+++ b/src/platform/endpoint/node/automodeService.ts
@@ -36,6 +36,8 @@ interface AutoModelCacheEntry {
 	lastRoutedPrompt?: string;
 	routerFallbackReason?: string;
 	turnCount: number;
+	/** When per-conversation routing is active, the model chosen on the first turn. */
+	conversationRoutedModel?: string;
 }
 
 class AutoModeTokenBank extends Disposable {
@@ -213,6 +215,35 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		const lastRoutedPrompt = routerResult.lastRoutedPrompt;
 		const routerFallbackReason = routerResult.fallbackReason;
 
+		// Telemetry: report model selection with routing mode
+		if (selectedModel) {
+			/* __GDPR__
+				"automode.routerModelSelected" : {
+					"owner": "lramos15",
+					"comment": "Model selection with routing mode context",
+					"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Selected model" },
+					"previousModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Previous turn model" },
+					"routingMode": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "per-turn or per-conversation" },
+					"modelChanged": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether model changed" },
+					"turnNumber": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Turn number" },
+					"discountedCost": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Discounted cost" },
+					"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Chat conversation ID" },
+					"isConversationReuse": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether model was reused from first turn (per-conversation routing)" }
+				}
+			*/
+			this._telemetryService.sendMSFTTelemetryEvent('automode.routerModelSelected', {
+				model: selectedModel.model,
+				previousModel: entry?.endpoint?.model ?? '',
+				routingMode: this._isPerConversationRouting() ? 'per-conversation' : 'per-turn',
+				modelChanged: String(selectedModel.model !== entry?.endpoint?.model),
+				conversationId,
+				isConversationReuse: String(!!routerResult.conversationRoutedModel && !!entry?.conversationRoutedModel),
+			}, {
+				turnNumber: (entry?.turnCount ?? 0) + 1,
+				discountedCost: token.discounted_costs?.[selectedModel.model] ?? 0,
+			});
+		}
+
 		// Default model selection when router was skipped or failed
 		if (!selectedModel) {
 			if (routerFallbackReason) {
@@ -244,7 +275,8 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			lastSessionToken: token.session_token,
 			lastRoutedPrompt,
 			routerFallbackReason,
-			turnCount: (entry?.turnCount ?? 0) + (isNewTurn ? 1 : 0)
+			turnCount: (entry?.turnCount ?? 0) + (isNewTurn ? 1 : 0),
+			conversationRoutedModel: routerResult.conversationRoutedModel ?? entry?.conversationRoutedModel,
 		});
 		return autoEndpoint;
 	}
@@ -266,12 +298,35 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		entry: AutoModelCacheEntry | undefined,
 		token: AutoModeAPIResponse,
 		knownEndpoints: IChatEndpoint[],
-	): Promise<{ selectedModel?: IChatEndpoint; lastRoutedPrompt?: string; fallbackReason?: string }> {
+	): Promise<{ selectedModel?: IChatEndpoint; lastRoutedPrompt?: string; fallbackReason?: string; conversationRoutedModel?: string }> {
 		const prompt = chatRequest?.prompt?.trim();
 		const lastRoutedPrompt = entry?.lastRoutedPrompt ?? prompt;
 
 		if (hasImage(chatRequest)) {
 			return { lastRoutedPrompt, fallbackReason: 'hasImage' };
+		}
+
+		// --- Per-conversation routing: route once on first turn, reuse for subsequent turns ---
+		if (this._isPerConversationRouting()) {
+			if (entry?.conversationRoutedModel) {
+				const cachedModel = entry.conversationRoutedModel;
+				const isModelAllowedForToken = !!token.available_models?.includes(cachedModel);
+
+				if (!isModelAllowedForToken) {
+					this._logService.trace(`[AutomodeService] Per-conversation routing: cached model=${cachedModel} not allowed for current token, clearing`);
+					return { lastRoutedPrompt: prompt ?? lastRoutedPrompt, fallbackReason: 'conversationModelNotAllowed' };
+				}
+
+				const selectedModel = knownEndpoints.find(e => e.model === cachedModel);
+				if (selectedModel) {
+					this._logService.trace(`[AutomodeService] Per-conversation routing: reusing model=${cachedModel} for conversation=${conversationId}`);
+					return { selectedModel, lastRoutedPrompt: prompt ?? lastRoutedPrompt, conversationRoutedModel: cachedModel };
+				} else {
+					this._logService.trace(`[AutomodeService] Per-conversation routing: model=${cachedModel} unavailable, clearing`);
+					return { lastRoutedPrompt: prompt ?? lastRoutedPrompt, fallbackReason: 'conversationModelUnavailable' };
+				}
+			}
+			// First turn: fall through to normal router call below, then store the chosen model
 		}
 
 		if (!this._isRouterEnabled(chatRequest) || conversationId === 'unknown') {
@@ -312,7 +367,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			if (result.sticky_override) {
 				this._logService.trace(`[AutomodeService] Sticky routing override: confidence=${(result.confidence * 100).toFixed(1)}%, label=${result.predicted_label}, router_model=${result.candidate_models[0]}, actual_model=${selectedModel.model}`);
 			}
-			return { selectedModel, lastRoutedPrompt: prompt };
+			return { selectedModel, lastRoutedPrompt: prompt, conversationRoutedModel: this._isPerConversationRouting() ? selectedModel.model : undefined };
 		} catch (e) {
 			this._logService.error(`Failed to get routed model for conversation ${conversationId}:`, (e as Error).message);
 			return { lastRoutedPrompt: prompt, fallbackReason: 'routerError' };
@@ -333,6 +388,14 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 	private _isRouterEnabled(chatRequest: ChatRequest | undefined): boolean {
 		const isPanelChat = !chatRequest?.location || chatRequest?.location === ChatLocation.Panel;
 		return isPanelChat && this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.UseAutoModeRouting, this._expService);
+	}
+
+	/**
+	 * When true, the router is called only on the first turn of a conversation.
+	 * The chosen model is then reused for all subsequent turns.
+	 */
+	private _isPerConversationRouting(): boolean {
+		return this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.UsePerConversationRouting, this._expService);
 	}
 
 	/**

--- a/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -602,6 +602,122 @@ describe('AutomodeService', () => {
 			expect(routerCallCount2).toBe(1);
 		});
 
+		describe('per-conversation routing', () => {
+		function enablePerConversationRouting(): void {
+			enableRouter();
+			(configurationService as InMemoryConfigurationService).setConfig(
+				ConfigKey.TeamInternal.UsePerConversationRouting,
+				true
+			);
+		}
+
+		it('should reuse first turn model on subsequent turns', async () => {
+			enablePerConversationRouting();
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
+			const claudeEndpoint = createEndpoint('claude-sonnet', 'Anthropic');
+
+			mockRouterResponse(
+				['gpt-4o', 'claude-sonnet'],
+				{ chosen_model: 'gpt-4o', candidate_models: ['gpt-4o', 'claude-sonnet'] }
+			);
+
+			automodeService = createService();
+			const chatRequest1: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'first question',
+				sessionId: 'session-per-conv-1'
+			};
+
+			const firstResult = await automodeService.resolveAutoModeEndpoint(chatRequest1 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+			expect(firstResult.model).toBe('gpt-4o');
+
+			const chatRequest2: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'second question completely different',
+				sessionId: 'session-per-conv-1'
+			};
+
+			const secondResult = await automodeService.resolveAutoModeEndpoint(chatRequest2 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+			expect(secondResult.model).toBe('gpt-4o');
+
+			const routerCallCount = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls
+				.filter((call: any[]) => call[1]?.type === RequestType.ModelRouter).length;
+			expect(routerCallCount).toBe(1);
+		});
+
+		it('should still route per-turn when per-conversation routing is disabled', async () => {
+			enableRouter();
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
+			const claudeEndpoint = createEndpoint('claude-sonnet', 'Anthropic');
+
+			mockRouterResponse(
+				['gpt-4o', 'claude-sonnet'],
+				{ chosen_model: 'gpt-4o', candidate_models: ['gpt-4o', 'claude-sonnet'] }
+			);
+
+			automodeService = createService();
+			const chatRequest1: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'first question',
+				sessionId: 'session-per-turn-check'
+			};
+
+			await automodeService.resolveAutoModeEndpoint(chatRequest1 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+
+			const chatRequest2: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'second different question',
+				sessionId: 'session-per-turn-check'
+			};
+
+			await automodeService.resolveAutoModeEndpoint(chatRequest2 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+
+			const routerCallCount = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls
+				.filter((call: any[]) => call[1]?.type === RequestType.ModelRouter).length;
+			expect(routerCallCount).toBe(2);
+		});
+
+		it('should re-route when cached per-conversation model is no longer in available_models', async () => {
+			enablePerConversationRouting();
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
+			const claudeEndpoint = createEndpoint('claude-sonnet', 'Anthropic');
+
+			// First call: both models available, router picks gpt-4o
+			mockRouterResponse(
+				['gpt-4o', 'claude-sonnet'],
+				{ chosen_model: 'gpt-4o', candidate_models: ['gpt-4o', 'claude-sonnet'] }
+			);
+
+			automodeService = createService();
+			const chatRequest1: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'first question',
+				sessionId: 'session-entitlement-change'
+			};
+
+			const firstResult = await automodeService.resolveAutoModeEndpoint(chatRequest1 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+			expect(firstResult.model).toBe('gpt-4o');
+
+			// Second call: entitlement changed, gpt-4o no longer in available_models
+			// The token response now only includes claude-sonnet
+			mockRouterResponse(
+				['claude-sonnet'],
+				{ chosen_model: 'claude-sonnet', candidate_models: ['claude-sonnet'] }
+			);
+
+			const chatRequest2: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'second question after entitlement change',
+				sessionId: 'session-entitlement-change'
+			};
+
+			// The cached model is no longer allowed, should fall through to default selection
+			const secondResult = await automodeService.resolveAutoModeEndpoint(chatRequest2 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+			// Should not be gpt-4o since it's no longer in available_models
+			expect(secondResult.model).toBe('claude-sonnet');
+		});
+		});
+
 		it('should re-evaluate router on new turn after a transient fallback reason', async () => {
 			enableRouter();
 			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI', { supportsVision: true });


### PR DESCRIPTION
Route once on the first turn of a conversation, reuse the same model for all subsequent turns. Controlled by UsePerConversationRouting experiment flag (default: off). When disabled, per-turn routing continues as before.

Changes:
- Add conversationRoutedModel to AutoModelCacheEntry
- Add per-conversation routing logic in _tryRouterSelection: on first turn call the router normally; on subsequent turns reuse the cached model
- Validate cached model against token.available_models before reusing (handles entitlement changes mid-conversation)
- Add _isPerConversationRouting() config check
- Add UsePerConversationRouting experiment-based config key
- Add automode.routerModelSelected telemetry with routingMode field
- Add 2 tests: model reuse + per-turn still works when flag is off