### PR TITLE
Skip reasoning effort picker for Auto model endpoint

### DIFF
--- a/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -54,6 +54,11 @@ function buildConfigurationSchema(endpoint: IChatEndpoint): { configurationSchem
 		return {};
 	}
 
+	// Auto model delegates to different backends, so don't expose effort picker
+	if (endpoint instanceof AutoChatEndpoint) {
+		return {};
+	}
+
 	// Only enable effort picker for Claude and GPT models
 	const family = endpoint.family.toLowerCase();
 	if (!family.startsWith('claude') && !family.startsWith('gpt-')) {


### PR DESCRIPTION
Auto delegates to different backends, so exposing a fixed effort level in the model picker doesn't make sense. This skips the `buildConfigurationSchema` effort picker for `AutoChatEndpoint` instances.