### PR TITLE
Add prompt instructions for dynamic MCP tool discovery

### DIFF
--- a/src/extension/prompts/node/agent/anthropicPrompts.tsx
+++ b/src/extension/prompts/node/agent/anthropicPrompts.tsx
@@ -86,7 +86,11 @@ class ToolSearchToolPrompt extends PromptElement<ToolSearchToolPromptProps> {
 				NEVER do these:<br />
 				- Calling a deferred tool directly without loading it first with {searchToolName}<br />
 				- Calling {searchToolName} again for a tool that was already returned by a previous search<br />
-				- Retrying {searchToolName} repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do NOT retry with different patterns — inform the user that the tool or MCP server is unavailable and stop.<br />
+				- Retrying {searchToolName} repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.<br />
+			</Tag>
+			<br />
+			<Tag name='dynamicToolDiscovery'>
+				MCP servers may add or remove tools dynamically during a conversation via tools/list_changed notifications. If you called a tool that may have enabled new tools on an MCP server, search for the new tools — they may now be discoverable even if not listed in the availableDeferredTools list above.<br />
 			</Tag>
 			<br />
 			<Tag name='availableDeferredTools'>

--- a/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.5/all_non_edit_tools.spec.snap
+++ b/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.5/all_non_edit_tools.spec.snap
@@ -69,9 +69,14 @@ The pattern is matched case-insensitively against tool names, descriptions, argu
 NEVER do these:
 - Calling a deferred tool directly without loading it first with tool_search_tool_regex
 - Calling tool_search_tool_regex again for a tool that was already returned by a previous search
-- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do NOT retry with different patterns — inform the user that the tool or MCP server is unavailable and stop.
+- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.
 
 </incorrectUsagePatterns>
+
+<dynamicToolDiscovery>
+MCP servers may add or remove tools dynamically during a conversation via tools/list_changed notifications. If you called a tool that may have enabled new tools on an MCP server, search for the new tools — they may now be discoverable even if not listed in the availableDeferredTools list above.
+
+</dynamicToolDiscovery>
 
 <availableDeferredTools>
 Available deferred tools (must be loaded with tool_search_tool_regex before use):

--- a/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.5/all_tools.spec.snap
+++ b/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.5/all_tools.spec.snap
@@ -68,9 +68,14 @@ The pattern is matched case-insensitively against tool names, descriptions, argu
 NEVER do these:
 - Calling a deferred tool directly without loading it first with tool_search_tool_regex
 - Calling tool_search_tool_regex again for a tool that was already returned by a previous search
-- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do NOT retry with different patterns — inform the user that the tool or MCP server is unavailable and stop.
+- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.
 
 </incorrectUsagePatterns>
+
+<dynamicToolDiscovery>
+MCP servers may add or remove tools dynamically during a conversation via tools/list_changed notifications. If you called a tool that may have enabled new tools on an MCP server, search for the new tools — they may now be discoverable even if not listed in the availableDeferredTools list above.
+
+</dynamicToolDiscovery>
 
 <availableDeferredTools>
 Available deferred tools (must be loaded with tool_search_tool_regex before use):

--- a/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6-fast/all_non_edit_tools.spec.snap
+++ b/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6-fast/all_non_edit_tools.spec.snap
@@ -101,9 +101,14 @@ The pattern is matched case-insensitively against tool names, descriptions, argu
 NEVER do these:
 - Calling a deferred tool directly without loading it first with tool_search_tool_regex
 - Calling tool_search_tool_regex again for a tool that was already returned by a previous search
-- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do NOT retry with different patterns — inform the user that the tool or MCP server is unavailable and stop.
+- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.
 
 </incorrectUsagePatterns>
+
+<dynamicToolDiscovery>
+MCP servers may add or remove tools dynamically during a conversation via tools/list_changed notifications. If you called a tool that may have enabled new tools on an MCP server, search for the new tools — they may now be discoverable even if not listed in the availableDeferredTools list above.
+
+</dynamicToolDiscovery>
 
 <availableDeferredTools>
 Available deferred tools (must be loaded with tool_search_tool_regex before use):

--- a/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6-fast/all_tools.spec.snap
+++ b/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6-fast/all_tools.spec.snap
@@ -100,9 +100,14 @@ The pattern is matched case-insensitively against tool names, descriptions, argu
 NEVER do these:
 - Calling a deferred tool directly without loading it first with tool_search_tool_regex
 - Calling tool_search_tool_regex again for a tool that was already returned by a previous search
-- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do NOT retry with different patterns — inform the user that the tool or MCP server is unavailable and stop.
+- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.
 
 </incorrectUsagePatterns>
+
+<dynamicToolDiscovery>
+MCP servers may add or remove tools dynamically during a conversation via tools/list_changed notifications. If you called a tool that may have enabled new tools on an MCP server, search for the new tools — they may now be discoverable even if not listed in the availableDeferredTools list above.
+
+</dynamicToolDiscovery>
 
 <availableDeferredTools>
 Available deferred tools (must be loaded with tool_search_tool_regex before use):

--- a/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6/all_non_edit_tools.spec.snap
+++ b/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6/all_non_edit_tools.spec.snap
@@ -101,9 +101,14 @@ The pattern is matched case-insensitively against tool names, descriptions, argu
 NEVER do these:
 - Calling a deferred tool directly without loading it first with tool_search_tool_regex
 - Calling tool_search_tool_regex again for a tool that was already returned by a previous search
-- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do NOT retry with different patterns — inform the user that the tool or MCP server is unavailable and stop.
+- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.
 
 </incorrectUsagePatterns>
+
+<dynamicToolDiscovery>
+MCP servers may add or remove tools dynamically during a conversation via tools/list_changed notifications. If you called a tool that may have enabled new tools on an MCP server, search for the new tools — they may now be discoverable even if not listed in the availableDeferredTools list above.
+
+</dynamicToolDiscovery>
 
 <availableDeferredTools>
 Available deferred tools (must be loaded with tool_search_tool_regex before use):

--- a/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6/all_tools.spec.snap
+++ b/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6/all_tools.spec.snap
@@ -100,9 +100,14 @@ The pattern is matched case-insensitively against tool names, descriptions, argu
 NEVER do these:
 - Calling a deferred tool directly without loading it first with tool_search_tool_regex
 - Calling tool_search_tool_regex again for a tool that was already returned by a previous search
-- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do NOT retry with different patterns — inform the user that the tool or MCP server is unavailable and stop.
+- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.
 
 </incorrectUsagePatterns>
+
+<dynamicToolDiscovery>
+MCP servers may add or remove tools dynamically during a conversation via tools/list_changed notifications. If you called a tool that may have enabled new tools on an MCP server, search for the new tools — they may now be discoverable even if not listed in the availableDeferredTools list above.
+
+</dynamicToolDiscovery>
 
 <availableDeferredTools>
 Available deferred tools (must be loaded with tool_search_tool_regex before use):

--- a/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.5/all_non_edit_tools.spec.snap
+++ b/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.5/all_non_edit_tools.spec.snap
@@ -69,9 +69,14 @@ The pattern is matched case-insensitively against tool names, descriptions, argu
 NEVER do these:
 - Calling a deferred tool directly without loading it first with tool_search_tool_regex
 - Calling tool_search_tool_regex again for a tool that was already returned by a previous search
-- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do NOT retry with different patterns — inform the user that the tool or MCP server is unavailable and stop.
+- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.
 
 </incorrectUsagePatterns>
+
+<dynamicToolDiscovery>
+MCP servers may add or remove tools dynamically during a conversation via tools/list_changed notifications. If you called a tool that may have enabled new tools on an MCP server, search for the new tools — they may now be discoverable even if not listed in the availableDeferredTools list above.
+
+</dynamicToolDiscovery>
 
 <availableDeferredTools>
 Available deferred tools (must be loaded with tool_search_tool_regex before use):

--- a/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.5/all_tools.spec.snap
+++ b/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.5/all_tools.spec.snap
@@ -68,9 +68,14 @@ The pattern is matched case-insensitively against tool names, descriptions, argu
 NEVER do these:
 - Calling a deferred tool directly without loading it first with tool_search_tool_regex
 - Calling tool_search_tool_regex again for a tool that was already returned by a previous search
-- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do NOT retry with different patterns — inform the user that the tool or MCP server is unavailable and stop.
+- Retrying tool_search_tool_regex repeatedly if it fails or returns no results. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.
 
 </incorrectUsagePatterns>
+
+<dynamicToolDiscovery>
+MCP servers may add or remove tools dynamically during a conversation via tools/list_changed notifications. If you called a tool that may have enabled new tools on an MCP server, search for the new tools — they may now be discoverable even if not listed in the availableDeferredTools list above.
+
+</dynamicToolDiscovery>
 
 <availableDeferredTools>
 Available deferred tools (must be loaded with tool_search_tool_regex before use):


### PR DESCRIPTION
## Summary

Improves discoverability of dynamically added MCP tools by updating the Anthropic tool search prompt instructions.

Helps with https://github.com/microsoft/vscode/issues/303012

This was a bigger issue with the server side tool search tool but client side mitigates it since the newly discovered tools are surfaced by the toolService correctly