### PR TITLE
Add OTel instrumentation for hook executions in Claude CLI sessions

### DIFF
--- a/src/extension/chatSessions/claude/common/claudeHookRegistry.ts
+++ b/src/extension/chatSessions/claude/common/claudeHookRegistry.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { HookCallbackMatcher, HookEvent } from '@anthropic-ai/claude-agent-sdk';
-import { CopilotChatAttr, GenAiAttr, GenAiOperationName, IOTelService, SpanKind, SpanStatusCode, truncateForOTel } from '../../../../platform/otel/common/index';
+import { CopilotChatAttr, GenAiAttr, GenAiOperationName, IOTelService, ISpanHandle, SpanKind, SpanStatusCode, truncateForOTel } from '../../../../platform/otel/common/index';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 
 /**
@@ -61,23 +61,26 @@ export function buildHooksFromRegistry(
 }
 
 /**
- * Emits an OTel span for a hook execution in the debug panel.
+ * Wraps a hook callback with an OTel span that captures real execution duration and exceptions.
+ * The span starts before the callback runs and ends after it completes (or throws).
+ * The span handle is passed to the callback so it can set additional attributes (e.g. hook_output).
  *
  * @param otelService The OTel service to emit spans
  * @param hookType The hook event type (e.g. 'PreToolUse', 'SessionStart')
  * @param hookCommand Display label for the command (e.g. 'PreToolUse:Glob')
  * @param sessionId The Claude session ID
  * @param input Hook-specific input data to serialize
- * @param options Optional: output data and error info
+ * @param callback The async hook logic to execute within the span; receives the span handle
+ * @returns The result of the callback
  */
-export function emitHookOTelSpan(
+export async function withHookOTelSpan<T>(
 	otelService: IOTelService,
 	hookType: string,
 	hookCommand: string,
 	sessionId: string,
 	input: Record<string, unknown>,
-	options?: { output?: string; error?: string }
-): void {
+	callback: (span: ISpanHandle) => Promise<T>
+): Promise<T> {
 	const span = otelService.startSpan(`execute_hook ${hookType}`, {
 		kind: SpanKind.INTERNAL,
 		attributes: {
@@ -90,17 +93,18 @@ export function emitHookOTelSpan(
 	try {
 		span.setAttribute('copilot_chat.hook_input', truncateForOTel(JSON.stringify(input)));
 	} catch { /* swallow serialization errors */ }
-	if (options?.output) {
-		try {
-			span.setAttribute('copilot_chat.hook_output', truncateForOTel(options.output));
-		} catch { /* swallow */ }
-	}
-	if (options?.error) {
-		span.setAttribute('copilot_chat.hook_result_kind', 'error');
-		span.setStatus(SpanStatusCode.ERROR, options.error);
-	} else {
+
+	try {
+		const result = await callback(span);
 		span.setAttribute('copilot_chat.hook_result_kind', 'success');
 		span.setStatus(SpanStatusCode.OK);
+		return result;
+	} catch (err) {
+		const errMsg = err instanceof Error ? err.message : 'unknown error';
+		span.setAttribute('copilot_chat.hook_result_kind', 'error');
+		span.setStatus(SpanStatusCode.ERROR, errMsg);
+		throw err;
+	} finally {
+		span.end();
 	}
-	span.end();
 }

--- a/src/extension/chatSessions/claude/node/hooks/loggingHooks.ts
+++ b/src/extension/chatSessions/claude/node/hooks/loggingHooks.ts
@@ -15,7 +15,7 @@ import {
 } from '@anthropic-ai/claude-agent-sdk';
 import { ILogService } from '../../../../../platform/log/common/logService';
 import { IOTelService } from '../../../../../platform/otel/common/index';
-import { emitHookOTelSpan, registerClaudeHook } from '../../common/claudeHookRegistry';
+import { registerClaudeHook, withHookOTelSpan } from '../../common/claudeHookRegistry';
 
 /**
  * Logging hook for Notification events.
@@ -32,12 +32,11 @@ export class NotificationLoggingHook implements HookCallbackMatcher {
 
 	private async _handle(input: HookInput): Promise<HookJSONOutput> {
 		const hookInput = input as NotificationHookInput;
-		this.logService.trace(`[ClaudeCodeSession] Notification Hook: title=${hookInput.title}, message=${hookInput.message}`);
-
-		emitHookOTelSpan(this.otelService, 'Notification', 'Notification', hookInput.session_id,
-			{ title: hookInput.title, message: hookInput.message });
-
-		return { continue: true };
+		return withHookOTelSpan(this.otelService, 'Notification', 'Notification', hookInput.session_id,
+			{ title: hookInput.title, message: hookInput.message }, async () => {
+				this.logService.trace(`[ClaudeCodeSession] Notification Hook: title=${hookInput.title}, message=${hookInput.message}`);
+				return { continue: true };
+			});
 	}
 }
 registerClaudeHook('Notification', NotificationLoggingHook);
@@ -57,12 +56,11 @@ export class UserPromptSubmitLoggingHook implements HookCallbackMatcher {
 
 	private async _handle(input: HookInput): Promise<HookJSONOutput> {
 		const hookInput = input as { prompt?: string; session_id: string };
-		this.logService.trace(`[ClaudeCodeSession] UserPromptSubmit Hook: prompt=${hookInput.prompt}`);
-
-		emitHookOTelSpan(this.otelService, 'UserPromptSubmit', 'UserPromptSubmit', hookInput.session_id,
-			{ prompt: hookInput.prompt });
-
-		return { continue: true };
+		return withHookOTelSpan(this.otelService, 'UserPromptSubmit', 'UserPromptSubmit', hookInput.session_id,
+			{ prompt: hookInput.prompt }, async () => {
+				this.logService.trace(`[ClaudeCodeSession] UserPromptSubmit Hook: prompt=${hookInput.prompt}`);
+				return { continue: true };
+			});
 	}
 }
 registerClaudeHook('UserPromptSubmit', UserPromptSubmitLoggingHook);
@@ -82,12 +80,11 @@ export class StopLoggingHook implements HookCallbackMatcher {
 
 	private async _handle(input: HookInput): Promise<HookJSONOutput> {
 		const hookInput = input as StopHookInput;
-		this.logService.trace(`[ClaudeCodeSession] Stop Hook: stopHookActive=${hookInput.stop_hook_active}`);
-
-		emitHookOTelSpan(this.otelService, 'Stop', 'Stop', hookInput.session_id,
-			{ stop_hook_active: hookInput.stop_hook_active });
-
-		return { continue: true };
+		return withHookOTelSpan(this.otelService, 'Stop', 'Stop', hookInput.session_id,
+			{ stop_hook_active: hookInput.stop_hook_active }, async () => {
+				this.logService.trace(`[ClaudeCodeSession] Stop Hook: stopHookActive=${hookInput.stop_hook_active}`);
+				return { continue: true };
+			});
 	}
 }
 registerClaudeHook('Stop', StopLoggingHook);
@@ -107,12 +104,11 @@ export class PreCompactLoggingHook implements HookCallbackMatcher {
 
 	private async _handle(input: HookInput): Promise<HookJSONOutput> {
 		const hookInput = input as PreCompactHookInput;
-		this.logService.trace(`[ClaudeCodeSession] PreCompact Hook: trigger=${hookInput.trigger}, customInstructions=${hookInput.custom_instructions}`);
-
-		emitHookOTelSpan(this.otelService, 'PreCompact', 'PreCompact', hookInput.session_id,
-			{ trigger: hookInput.trigger });
-
-		return { continue: true };
+		return withHookOTelSpan(this.otelService, 'PreCompact', 'PreCompact', hookInput.session_id,
+			{ trigger: hookInput.trigger }, async () => {
+				this.logService.trace(`[ClaudeCodeSession] PreCompact Hook: trigger=${hookInput.trigger}, customInstructions=${hookInput.custom_instructions}`);
+				return { continue: true };
+			});
 	}
 }
 registerClaudeHook('PreCompact', PreCompactLoggingHook);
@@ -132,12 +128,11 @@ export class PermissionRequestLoggingHook implements HookCallbackMatcher {
 
 	private async _handle(input: HookInput): Promise<HookJSONOutput> {
 		const hookInput = input as PermissionRequestHookInput;
-		this.logService.trace(`[ClaudeCodeSession] PermissionRequest Hook: tool=${hookInput.tool_name}, input=${JSON.stringify(hookInput.tool_input)}`);
-
-		emitHookOTelSpan(this.otelService, 'PermissionRequest', `PermissionRequest:${hookInput.tool_name}`, hookInput.session_id,
-			{ tool_name: hookInput.tool_name, tool_input: hookInput.tool_input });
-
-		return { continue: true };
+		return withHookOTelSpan(this.otelService, 'PermissionRequest', `PermissionRequest:${hookInput.tool_name}`, hookInput.session_id,
+			{ tool_name: hookInput.tool_name, tool_input: hookInput.tool_input }, async () => {
+				this.logService.trace(`[ClaudeCodeSession] PermissionRequest Hook: tool=${hookInput.tool_name}, input=${JSON.stringify(hookInput.tool_input)}`);
+				return { continue: true };
+			});
 	}
 }
 registerClaudeHook('PermissionRequest', PermissionRequestLoggingHook);

--- a/src/extension/chatSessions/claude/node/hooks/sessionHooks.ts
+++ b/src/extension/chatSessions/claude/node/hooks/sessionHooks.ts
@@ -13,7 +13,7 @@ import {
 } from '@anthropic-ai/claude-agent-sdk';
 import { ILogService } from '../../../../../platform/log/common/logService';
 import { IOTelService } from '../../../../../platform/otel/common/index';
-import { emitHookOTelSpan, registerClaudeHook } from '../../common/claudeHookRegistry';
+import { registerClaudeHook, withHookOTelSpan } from '../../common/claudeHookRegistry';
 
 /**
  * Logging hook for SessionStart events.
@@ -30,12 +30,11 @@ export class SessionStartLoggingHook implements HookCallbackMatcher {
 
 	private async _handle(input: HookInput): Promise<HookJSONOutput> {
 		const hookInput = input as SessionStartHookInput;
-		this.logService.trace(`[ClaudeCodeSession] SessionStart Hook: source=${hookInput.source}, sessionId=${hookInput.session_id}`);
-
-		emitHookOTelSpan(this.otelService, 'SessionStart', 'SessionStart', hookInput.session_id,
-			{ source: hookInput.source, cwd: hookInput.cwd });
-
-		return { continue: true };
+		return withHookOTelSpan(this.otelService, 'SessionStart', 'SessionStart', hookInput.session_id,
+			{ source: hookInput.source, cwd: hookInput.cwd }, async () => {
+				this.logService.trace(`[ClaudeCodeSession] SessionStart Hook: source=${hookInput.source}, sessionId=${hookInput.session_id}`);
+				return { continue: true };
+			});
 	}
 }
 registerClaudeHook('SessionStart', SessionStartLoggingHook);
@@ -55,12 +54,11 @@ export class SessionEndLoggingHook implements HookCallbackMatcher {
 
 	private async _handle(input: HookInput): Promise<HookJSONOutput> {
 		const hookInput = input as SessionEndHookInput;
-		this.logService.trace(`[ClaudeCodeSession] SessionEnd Hook: reason=${hookInput.reason}, sessionId=${hookInput.session_id}`);
-
-		emitHookOTelSpan(this.otelService, 'SessionEnd', 'SessionEnd', hookInput.session_id,
-			{ reason: hookInput.reason });
-
-		return { continue: true };
+		return withHookOTelSpan(this.otelService, 'SessionEnd', 'SessionEnd', hookInput.session_id,
+			{ reason: hookInput.reason }, async () => {
+				this.logService.trace(`[ClaudeCodeSession] SessionEnd Hook: reason=${hookInput.reason}, sessionId=${hookInput.session_id}`);
+				return { continue: true };
+			});
 	}
 }
 registerClaudeHook('SessionEnd', SessionEndLoggingHook);

--- a/src/extension/chatSessions/claude/node/hooks/subagentHooks.ts
+++ b/src/extension/chatSessions/claude/node/hooks/subagentHooks.ts
@@ -13,7 +13,7 @@ import {
 } from '@anthropic-ai/claude-agent-sdk';
 import { ILogService } from '../../../../../platform/log/common/logService';
 import { IOTelService } from '../../../../../platform/otel/common/index';
-import { emitHookOTelSpan, registerClaudeHook } from '../../common/claudeHookRegistry';
+import { registerClaudeHook, withHookOTelSpan } from '../../common/claudeHookRegistry';
 
 /**
  * Logging hook for SubagentStart events.
@@ -30,12 +30,11 @@ export class SubagentStartLoggingHook implements HookCallbackMatcher {
 
 	private async _handle(input: HookInput): Promise<HookJSONOutput> {
 		const hookInput = input as SubagentStartHookInput;
-		this.logService.trace(`[ClaudeCodeSession] SubagentStart Hook: agentId=${hookInput.agent_id}, agentType=${hookInput.agent_type}`);
-
-		emitHookOTelSpan(this.otelService, 'SubagentStart', 'SubagentStart', hookInput.session_id,
-			{ agent_id: hookInput.agent_id, agent_type: hookInput.agent_type });
-
-		return { continue: true };
+		return withHookOTelSpan(this.otelService, 'SubagentStart', 'SubagentStart', hookInput.session_id,
+			{ agent_id: hookInput.agent_id, agent_type: hookInput.agent_type }, async () => {
+				this.logService.trace(`[ClaudeCodeSession] SubagentStart Hook: agentId=${hookInput.agent_id}, agentType=${hookInput.agent_type}`);
+				return { continue: true };
+			});
 	}
 }
 registerClaudeHook('SubagentStart', SubagentStartLoggingHook);
@@ -55,12 +54,11 @@ export class SubagentStopLoggingHook implements HookCallbackMatcher {
 
 	private async _handle(input: HookInput): Promise<HookJSONOutput> {
 		const hookInput = input as SubagentStopHookInput;
-		this.logService.trace(`[ClaudeCodeSession] SubagentStop Hook: stopHookActive=${hookInput.stop_hook_active}`);
-
-		emitHookOTelSpan(this.otelService, 'SubagentStop', 'SubagentStop', hookInput.session_id,
-			{ stop_hook_active: hookInput.stop_hook_active });
-
-		return { continue: true };
+		return withHookOTelSpan(this.otelService, 'SubagentStop', 'SubagentStop', hookInput.session_id,
+			{ stop_hook_active: hookInput.stop_hook_active }, async () => {
+				this.logService.trace(`[ClaudeCodeSession] SubagentStop Hook: stopHookActive=${hookInput.stop_hook_active}`);
+				return { continue: true };
+			});
 	}
 }
 registerClaudeHook('SubagentStop', SubagentStopLoggingHook);

--- a/src/extension/chatSessions/claude/node/hooks/toolHooks.ts
+++ b/src/extension/chatSessions/claude/node/hooks/toolHooks.ts
@@ -13,10 +13,10 @@ import {
 	PreToolUseHookInput
 } from '@anthropic-ai/claude-agent-sdk';
 import { ILogService } from '../../../../../platform/log/common/logService';
-import { IOTelService } from '../../../../../platform/otel/common/index';
+import { IOTelService, SpanStatusCode, truncateForOTel } from '../../../../../platform/otel/common/index';
 import { IRequestLogger } from '../../../../../platform/requestLogger/node/requestLogger';
 import { LanguageModelTextPart } from '../../../../../vscodeTypes';
-import { emitHookOTelSpan, registerClaudeHook } from '../../common/claudeHookRegistry';
+import { registerClaudeHook, withHookOTelSpan } from '../../common/claudeHookRegistry';
 import { ClaudeToolNames } from '../../common/claudeTools';
 import { IClaudeSessionStateService } from '../claudeSessionStateService';
 
@@ -35,12 +35,11 @@ export class PreToolUseLoggingHook implements HookCallbackMatcher {
 
 	private async _handle(input: HookInput, toolID: string | undefined): Promise<HookJSONOutput> {
 		const hookInput = input as PreToolUseHookInput;
-		this.logService.trace(`[ClaudeCodeSession] PreToolUse Hook: tool=${hookInput.tool_name}, toolUseID=${toolID}`);
-
-		emitHookOTelSpan(this.otelService, 'PreToolUse', `PreToolUse:${hookInput.tool_name}`, hookInput.session_id,
-			{ tool_name: hookInput.tool_name, tool_input: hookInput.tool_input });
-
-		return { continue: true };
+		return withHookOTelSpan(this.otelService, 'PreToolUse', `PreToolUse:${hookInput.tool_name}`, hookInput.session_id,
+			{ tool_name: hookInput.tool_name, tool_input: hookInput.tool_input }, async () => {
+				this.logService.trace(`[ClaudeCodeSession] PreToolUse Hook: tool=${hookInput.tool_name}, toolUseID=${toolID}`);
+				return { continue: true };
+			});
 	}
 }
 registerClaudeHook('PreToolUse', PreToolUseLoggingHook);
@@ -66,32 +65,37 @@ export class PostToolUseLoggingHook implements HookCallbackMatcher {
 		const id = toolID ?? hookInput.session_id;
 		const response = hookInput.tool_response;
 
-		this.logService.trace(`[ClaudeCodeSession] PostToolUse Hook: tool=${hookInput.tool_name}, toolUseID=${toolID}`);
+		return withHookOTelSpan(this.otelService, 'PostToolUse', `PostToolUse:${hookInput.tool_name}`, hookInput.session_id,
+			{ tool_name: hookInput.tool_name, tool_input: hookInput.tool_input }, async span => {
+				this.logService.trace(`[ClaudeCodeSession] PostToolUse Hook: tool=${hookInput.tool_name}, toolUseID=${toolID}`);
 
-		const output = typeof response === 'string' ? response : JSON.stringify(response);
-		emitHookOTelSpan(this.otelService, 'PostToolUse', `PostToolUse:${hookInput.tool_name}`, hookInput.session_id,
-			{ tool_name: hookInput.tool_name, tool_input: hookInput.tool_input }, { output });
+				// Record tool response output on the span for the debug panel
+				try {
+					const output = typeof response === 'string' ? response : JSON.stringify(response);
+					span.setAttribute('copilot_chat.hook_output', truncateForOTel(output));
+				} catch { /* swallow */ }
 
-		// Log the tool call to the request logger with the tool response as text content
-		const capturingToken = this.sessionStateService.getCapturingTokenForSession(hookInput.session_id);
-		const logToolCall = () => {
-			this.requestLogger.logToolCall(
-				id,
-				hookInput.tool_name,
-				hookInput.tool_input,
-				{
-					content: [new LanguageModelTextPart(typeof response === 'string' ? response : JSON.stringify(response, undefined, 2))]
+				// Log the tool call to the request logger with the tool response as text content
+				const capturingToken = this.sessionStateService.getCapturingTokenForSession(hookInput.session_id);
+				const logToolCall = () => {
+					this.requestLogger.logToolCall(
+						id,
+						hookInput.tool_name,
+						hookInput.tool_input,
+						{
+							content: [new LanguageModelTextPart(typeof response === 'string' ? response : JSON.stringify(response, undefined, 2))]
+						}
+					);
+				};
+
+				if (capturingToken) {
+					await this.requestLogger.captureInvocation(capturingToken, async () => logToolCall());
+				} else {
+					logToolCall();
 				}
-			);
-		};
 
-		if (capturingToken) {
-			await this.requestLogger.captureInvocation(capturingToken, async () => logToolCall());
-		} else {
-			logToolCall();
-		}
-
-		return { continue: true };
+				return { continue: true };
+			});
 	}
 }
 registerClaudeHook('PostToolUse', PostToolUseLoggingHook);
@@ -116,31 +120,35 @@ export class PostToolUseFailureLoggingHook implements HookCallbackMatcher {
 		const hookInput = input as PostToolUseFailureHookInput;
 		const id = toolID ?? hookInput.session_id;
 
-		this.logService.trace(`[ClaudeCodeSession] PostToolUseFailure Hook: tool=${hookInput.tool_name}, error=${hookInput.error}, isInterrupt=${hookInput.is_interrupt}`);
+		return withHookOTelSpan(this.otelService, 'PostToolUseFailure', `PostToolUseFailure:${hookInput.tool_name}`, hookInput.session_id,
+			{ tool_name: hookInput.tool_name, tool_input: hookInput.tool_input, error: hookInput.error }, async span => {
+				this.logService.trace(`[ClaudeCodeSession] PostToolUseFailure Hook: tool=${hookInput.tool_name}, error=${hookInput.error}, isInterrupt=${hookInput.is_interrupt}`);
 
-		emitHookOTelSpan(this.otelService, 'PostToolUseFailure', `PostToolUseFailure:${hookInput.tool_name}`, hookInput.session_id,
-			{ tool_name: hookInput.tool_name, tool_input: hookInput.tool_input, error: hookInput.error }, { error: hookInput.error });
+				// Override the default success status — this hook reports a tool failure
+				span.setAttribute('copilot_chat.hook_result_kind', 'error');
+				span.setStatus(SpanStatusCode.ERROR, hookInput.error);
 
-		// Log the failed tool call to the request logger with the error as text content
-		const capturingToken = this.sessionStateService.getCapturingTokenForSession(hookInput.session_id);
-		const logToolCall = () => {
-			this.requestLogger.logToolCall(
-				id,
-				hookInput.tool_name,
-				hookInput.tool_input,
-				{
-					content: [new LanguageModelTextPart(`Error: ${hookInput.error}${hookInput.is_interrupt ? ' (interrupted)' : ''}`)]
+				// Log the failed tool call to the request logger with the error as text content
+				const capturingToken = this.sessionStateService.getCapturingTokenForSession(hookInput.session_id);
+				const logToolCall = () => {
+					this.requestLogger.logToolCall(
+						id,
+						hookInput.tool_name,
+						hookInput.tool_input,
+						{
+							content: [new LanguageModelTextPart(`Error: ${hookInput.error}${hookInput.is_interrupt ? ' (interrupted)' : ''}`)]
+						}
+					);
+				};
+
+				if (capturingToken) {
+					await this.requestLogger.captureInvocation(capturingToken, async () => logToolCall());
+				} else {
+					logToolCall();
 				}
-			);
-		};
 
-		if (capturingToken) {
-			await this.requestLogger.captureInvocation(capturingToken, async () => logToolCall());
-		} else {
-			logToolCall();
-		}
-
-		return { continue: true };
+				return { continue: true };
+			});
 	}
 }
 registerClaudeHook('PostToolUseFailure', PostToolUseFailureLoggingHook);

--- a/src/extension/chatSessions/claude/node/test/claudeCodeAgentOTel.spec.ts
+++ b/src/extension/chatSessions/claude/node/test/claudeCodeAgentOTel.spec.ts
@@ -21,8 +21,8 @@ import { ClaudeCodeSession } from '../claudeCodeAgent';
 import { IClaudeCodeSdkService } from '../claudeCodeSdkService';
 import { ClaudeLanguageModelServer } from '../claudeLanguageModelServer';
 import { IClaudeSessionStateService } from '../claudeSessionStateService';
-// Side-effect import: registers SessionStart/SessionEnd hooks in the global registry
-import '../hooks/sessionHooks';
+// Side-effect import: registers all hook handlers in the global registry
+import '../hooks/index';
 
 const TEST_MODEL_ID = 'claude-3-sonnet';
 const TEST_PERMISSION_MODE: PermissionMode = 'acceptEdits';
@@ -442,7 +442,7 @@ describe('Claude Session OTel Tool Spans', () => {
 		expect(hookSpan!.status.code).toBe(1); // SpanStatusCode.OK
 	});
 
-	it('records hook output on successful hook invocation', async () => {
+	it('records hook input on successful hook invocation', async () => {
 		const sessionId = 'otel-hook-3';
 		const sdkService = createSdkServiceWithHooks((sid, hooks) => (async function* () {
 			await invokeHook(hooks, 'SessionStart', { session_id: sid, source: 'test', cwd: '/workspace' });


### PR DESCRIPTION
Adds OpenTelemetry span tracking for Claude SDK hook executions so they appear in the Agent debug panel and troubleshoot logs