### PR TITLE
fix: enable content capture for CLI debug panel by default

### DIFF
--- a/docs/monitoring/agent_monitoring.md
+++ b/docs/monitoring/agent_monitoring.md
@@ -426,6 +426,8 @@ The extension wrapper span (`invoke_agent copilotcli`, service `copilot-chat`) p
 
 **Agent Debug Log panel**: CLI sessions show the full SDK hierarchy in the Tree View — identical to what appears in Grafana/Jaeger. This works even when OTel export is disabled, because the SDK's internal tracing is always active for the debug panel.
 
+> **Content in the debug panel**: When OTel export is disabled (the default), the debug panel automatically captures full prompt/response content. When OTel export is enabled, content capture is controlled by the `captureContent` setting — the same flag applies to both the debug panel and OTLP export. To see content in the debug panel while OTel is enabled, set `github.copilot.chat.otel.captureContent` to `true`.
+
 ### Copilot CLI (Terminal Session)
 
 Terminal CLI sessions ("New Copilot CLI Session") run as a separate process. When OTel is enabled, the extension forwards `COPILOT_OTEL_ENABLED` and `OTEL_EXPORTER_OTLP_ENDPOINT` to the terminal process. Terminal traces appear as **independent root traces** (service `github-copilot`) — they are not linked to extension traces.

--- a/docs/monitoring/agent_monitoring_arch.md
+++ b/docs/monitoring/agent_monitoring_arch.md
@@ -202,6 +202,43 @@ The CLI SDK's OTel (`OtelLifecycle`) is **always initialized** regardless of use
 When user OTel is **disabled**: SDK spans flow through bridge → debug panel only (no OTLP export).
 When user OTel is **enabled**: SDK spans flow through bridge → debug panel AND through SDK's own `BatchSpanProcessor` → OTLP.
 
+### Content Capture Behavior Matrix
+
+The CLI SDK uses a single `captureContent` flag (`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`) that controls content capture for **both** the debug panel and OTLP export. The extension sets this flag before SDK initialization based on the following precedence:
+
+| # | OTel Enabled | `captureContent` env | `captureContent` setting | SDK Flag | Debug Panel Content | OTLP Content |
+|---|---|---|---|---|---|---|
+| 1 | No | unset | unset | `true` | Yes | N/A (file → /dev/null) |
+| 2 | No | unset | `true` | `true` | Yes | N/A (file → /dev/null) |
+| 3 | No | unset | `false` | `true` | Yes | N/A (file → /dev/null) |
+| 4 | Yes | unset | unset | `false` | No | No |
+| 5 | Yes | unset | `true` | `true` | Yes | Yes |
+| 6 | Yes | unset | `false` | `false` | No | No |
+| 7 | Yes | `true` | any | `true` | Yes | Yes |
+| 8 | Yes | `false` | any | `false` | No | No |
+| 9 | No | `true` | any | `true` | Yes | N/A (file → /dev/null) |
+| 10 | No | `false` | any | `false` | No | N/A (file → /dev/null) |
+
+**Key design decisions:**
+
+- **Rows 1–3**: When OTel is disabled, the extension forces `captureContent=true` so the debug panel always shows full content. OTLP is suppressed via a file exporter to `/dev/null`, so no content leaks externally.
+- **Rows 4–6**: When OTel is enabled, the extension respects the user's `captureContent` setting because OTLP is active and content may be exported to an external collector.
+- **Rows 7–8, 9–10**: Explicit env var overrides always win (standard OTel precedence).
+
+> **Known Limitation: Single `captureContent` Flag**
+>
+> The CLI SDK exposes a single `captureContent` boolean that applies to both local (debug panel) and remote (OTLP) channels. There is no way to enable content for the debug panel while suppressing it from OTLP, or vice versa. This means:
+>
+> - When OTel is enabled with `captureContent: false` (the default), the debug panel also loses prompt/response bodies.
+> - To see content in the debug panel while OTel is enabled, set `captureContent: true` — but this also sends content to OTLP.
+>
+> **Why can't this be fixed at the extension level?**
+> - The SDK captures content at span creation time. By the time spans reach the bridge or exporter, the content is either present or absent — it cannot be added or removed after the fact.
+> - `ReadableSpan` objects are immutable; neither the bridge nor an OTLP exporter can selectively strip or inject attributes.
+> - Running two SDK instances with different `captureContent` flags is not architecturally feasible.
+>
+> A future SDK enhancement could provide separate flags for local vs. export channels.
+
 ### `service.name` Values
 
 | Source | `service.name` |

--- a/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
+++ b/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
@@ -155,11 +155,21 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 				if (!process.env['COPILOT_OTEL_ENABLED']) {
 					process.env['COPILOT_OTEL_ENABLED'] = 'true';
 				}
+				// Default content capture to 'true' for the debug panel. When user OTel
+				// is enabled, their captureContent setting overrides this default below.
+				// When user OTel is disabled, the default gives debug panel content.
+				// If the user explicitly set the env var, respect their choice.
+				if (!process.env['OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT']) {
+					process.env['OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT'] = 'true';
+				}
 				if (this._otelService.config.enabled) {
 					const otelEnv = deriveCopilotCliOTelEnv(this._otelService.config);
 					for (const [key, value] of Object.entries(otelEnv)) {
 						process.env[key] = value;
 					}
+					// When user OTel is enabled, their captureContent config takes
+					// precedence over the debug-panel default set above.
+					process.env['OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT'] = String(this._otelService.config.captureContent);
 				} else {
 					// User OTel disabled: ensure SDK doesn't export to any external collector.
 					// Use file exporter to /dev/null so the SDK creates OtelSessionTracker


### PR DESCRIPTION
## Problem

When OTel export is **disabled** (the default), the CLI debug panel shows no prompt/response content because `captureContent` defaults to `false`.

## Fix

Force `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` for the CLI SDK when OTel export is disabled. OTLP leakage is impossible because a file exporter to `/dev/null` suppresses all export.

When OTel export is **enabled**, the user's `captureContent` setting is respected (applies to both debug panel and OTLP — SDK limitation, documented below).

## Changes

**Code** — `copilotcliSessionService.ts`: After `deriveCopilotCliOTelEnv()`, override `captureContent` to `true` when OTel is disabled.

**Docs**:
- `agent_monitoring_arch.md`: Added content capture behavior matrix (10-row table) and "Known Limitation: Single captureContent Flag" callout explaining why debug panel and OTLP can't have independent settings.
- `agent_monitoring.md`: Added user-facing note on debug panel content behavior.

## Testing

Verified debug panel shows full content with OTel disabled (default case). Verified content respects user setting when OTel is enabled.