### PR TITLE
Fix memory tool invocation messages leaking session IDs and missing file widgets

### DIFF
--- a/src/extension/tools/node/memoryTool.tsx
+++ b/src/extension/tools/node/memoryTool.tsx
@@ -169,15 +169,14 @@ export class MemoryTool implements ICopilotTool<MemoryToolParams> {
 		const command = options.input.command;
 		const path = command === 'rename' ? (options.input as IRenameParams).old_path ?? (options.input as IRenameParams).path : options.input.path;
 
-		if (path && !isRepoPath(path)) {
-			return this._prepareLocalInvocation(command, path, options.chatSessionResource);
-		}
-		return this._prepareRepoInvocation(command, path);
+		return this._prepareLocalInvocation(command, path ?? '/memories/', options.chatSessionResource);
 	}
 
 	private _prepareLocalInvocation(command: string, path: string, chatSessionResource?: vscode.Uri): vscode.PreparedToolInvocation {
-		// Directory paths (e.g. /memories/, /memories/session/) — show verb only, no file widget
-		if (path.endsWith('/')) {
+		// Directory paths (e.g. /memories/, /memories/session/, /memories/session) — show verb only, no file widget.
+		// Use normalizePath to handle paths with or without trailing slash consistently.
+		const normalized = normalizePath(path);
+		if (path.endsWith('/') || normalized === '/memories/session/' || normalized === '/memories/repo/' || isMemoriesRoot(path)) {
 			switch (command) {
 				case 'view':
 					return { invocationMessage: l10n.t('Reading memory'), pastTenseMessage: l10n.t('Read memory') };
@@ -205,27 +204,6 @@ export class MemoryTool implements ICopilotTool<MemoryToolParams> {
 				return { invocationMessage: new MarkdownString(l10n.t('Renaming memory {0}', fw)), pastTenseMessage: new MarkdownString(l10n.t('Renamed memory {0}', fw)) };
 			default:
 				return { invocationMessage: new MarkdownString(l10n.t('Updating memory {0}', fw)), pastTenseMessage: new MarkdownString(l10n.t('Updated memory {0}', fw)) };
-		}
-	}
-
-	private _prepareRepoInvocation(command: string, path: string | undefined): vscode.PreparedToolInvocation {
-		const fileName = path ? path.split('/').pop() || path : undefined;
-		const suffix = fileName ? ` ${fileName}` : '';
-		switch (command) {
-			case 'view':
-				return { invocationMessage: l10n.t('Reading memory{0}', suffix), pastTenseMessage: l10n.t('Read memory{0}', suffix) };
-			case 'create':
-				return { invocationMessage: l10n.t('Creating memory file{0}', suffix), pastTenseMessage: l10n.t('Created memory file{0}', suffix) };
-			case 'str_replace':
-				return { invocationMessage: l10n.t('Updating memory file{0}', suffix), pastTenseMessage: l10n.t('Updated memory file{0}', suffix) };
-			case 'insert':
-				return { invocationMessage: l10n.t('Inserting into memory file{0}', suffix), pastTenseMessage: l10n.t('Inserted into memory file{0}', suffix) };
-			case 'delete':
-				return { invocationMessage: l10n.t('Deleting memory{0}', suffix), pastTenseMessage: l10n.t('Deleted memory{0}', suffix) };
-			case 'rename':
-				return { invocationMessage: l10n.t('Renaming memory{0}', suffix), pastTenseMessage: l10n.t('Renamed memory{0}', suffix) };
-			default:
-				return { invocationMessage: l10n.t('Updating memory{0}', suffix), pastTenseMessage: l10n.t('Updated memory{0}', suffix) };
 		}
 	}
 

--- a/src/extension/tools/node/test/memoryTool.spec.tsx
+++ b/src/extension/tools/node/test/memoryTool.spec.tsx
@@ -15,6 +15,7 @@ import { CancellationToken } from '../../../../util/vs/base/common/cancellation'
 import { URI } from '../../../../util/vs/base/common/uri';
 import { SyncDescriptor } from '../../../../util/vs/platform/instantiation/common/descriptors';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
+import { MarkdownString } from '../../../../vscodeTypes';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
 import { IAgentMemoryService, RepoMemoryEntry } from '../../common/agentMemoryService';
 import { MemoryTool } from '../memoryTool';
@@ -694,13 +695,13 @@ suite('MemoryTool', () => {
 			expect(prepared.invocationMessage).toContain('Reading memory');
 		});
 
-		test('falls back to plain text for repo paths', () => {
+		test('uses file widget for repo file paths', () => {
 			const result = tool.prepareInvocation({
 				input: { command: 'create', path: '/memories/repo/fact.json', file_text: '{}' },
 			} as never, CancellationToken.None);
-			const prepared = result as { invocationMessage: string; pastTenseMessage: string };
-			expect(typeof prepared.invocationMessage).toBe('string');
-			expect(prepared.invocationMessage).toContain('fact.json');
+			const prepared = result as { invocationMessage: MarkdownString; pastTenseMessage: MarkdownString };
+			expect(prepared.invocationMessage).toBeInstanceOf(MarkdownString);
+			expect(prepared.invocationMessage.value).toContain('fact.json');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/vscode/issues/303692

1. **Session ID leak**: Viewing `/memories/session` (without trailing slash) bypassed the directory guard and showed the raw base64 session ID directory in the file widget (e.g. `📁 ODJmMGMxZTAt...`)
2. **Repo path issues**: `/memories/repo/` showed raw path in message; `/memories/repo` showed just `repo` as plain text; repo file paths had no clickable file widget
3. **Dead code**: `_prepareRepoInvocation` was only reachable when path was undefined (an error case caught elsewhere)

<img width="1150" height="754" alt="image" src="https://github.com/user-attachments/assets/f579df3f-8942-4f3b-b997-8b8ab9d2aab6" />
