### PR TITLE
Harden workspace instructions and init against content bloat

### DIFF
--- a/assets/prompts/init.prompt.md
+++ b/assets/prompts/init.prompt.md
@@ -8,28 +8,38 @@ Related skill: `agent-customization`. Load and follow **workspace-instructions.m
 
 Bootstrap workspace instructions (`.github/copilot-instructions.md` or `AGENTS.md` if already present).
 
+Shorter is better. Unnecessary content actively hurts agent performance and increases cost. A very short file, or recommending no file, is a valid outcome.
+
 ## Workflow
 
 1. **Discover existing conventions**
    Search: `**/{.github/copilot-instructions.md,AGENT.md,AGENTS.md,CLAUDE.md,.cursorrules,.windsurfrules,.clinerules,.cursor/rules/**,.windsurf/rules/**,.clinerules/**,README.md}`
 
 2. **Explore the codebase** via subagent, 1-3 in parallel if needed
-   Find essential knowledge that helps an AI agent be immediately productive:
-   - Build/test commands (agents run these automatically)
-   - Architecture decisions and component boundaries
+   Look for things an agent genuinely **cannot** discover from config files, imports, or code:
+   - Non-standard or surprising build/test setup (skip anything obvious from `package.json`)
+   - Architectural decisions that contradict what agents would assume from reading the code
    - Project-specific conventions that differ from common practices
-   - Potential pitfalls or common development environment issues
-   - Key files/directories that exemplify patterns
+   - Environment pitfalls or gotchas that cause silent failures
 
    Also inventory existing documentation (`docs/**/*.md`, `CONTRIBUTING.md`, `ARCHITECTURE.md`, etc.) to identify topics that should be linked, not duplicated.
 
-3. **Generate or merge**
-   - New file: Use template from workspace-instructions.md, include only relevant sections
-   - Existing file: Preserve valuable content, update outdated sections, remove duplication
+3. **Filter ruthlessly**
+   Apply the **inclusion test** from workspace-instructions.md to every candidate item. Each must be:
+   - **Undiscoverable**: agent can't find it from config files, imports, or code
+   - **Stable**: won't go stale when files are renamed or code changes
+   - **Global**: applies to every task type in this repo
+
+   Discard anything that fails. Track items that are valuable but not global; these become skill or instruction suggestions.
+
+4. **Generate or merge**
+   - New file: Use template from workspace-instructions.md, include only sections that survived filtering
+   - Existing file: Preserve valuable content, **remove** content that fails the inclusion test, update outdated sections
    - Follow the **Link, don't embed** principle from workspace-instructions.md
 
-4. **Iterate**
+5. **Iterate**
    - Ask for feedback on unclear or incomplete sections
+   - For task-specific patterns that failed the globality test, suggest creating skills or `applyTo`-based file instructions instead
    - If the workspace is complex, suggest applyTo-based instructions for specific areas (e.g., frontend, backend, tests)
 
 Once finalized, suggest example prompts to see it in action, and propose related agent-customizations to create next (`/create-(agent|hook|instruction|prompt|skill) …`), explaining the customization and how it would be used in practice.

--- a/assets/prompts/skills/agent-customization/references/workspace-instructions.md
+++ b/assets/prompts/skills/agent-customization/references/workspace-instructions.md
@@ -9,7 +9,7 @@ Guidelines that automatically apply to all chat requests across your entire work
 | `copilot-instructions.md` | `.github/` | Project-wide standards (recommended, cross-editor) |
 | `AGENTS.md` | Root or subfolders | Open standard, monorepo hierarchy support |
 
-Use **only one**—not both.
+Use **only one**, not both.
 
 ## AGENTS.md Hierarchy
 
@@ -23,24 +23,36 @@ For monorepos, the closest file in the directory tree takes precedence:
 
 Use nested `AGENTS.md` files for monorepos when different areas need different defaults.
 
+## Inclusion Test
+
+Every line must pass **all three** tests before going in. Content that fails any test should be omitted or redirected (see below).
+
+| Test | Question | If it fails |
+|------|----------|---------------|
+| **Undiscoverable** | Can the agent figure this out from config files, imports, or code? | Don't document; trust the explore step |
+| **Stable** | Will this go stale when files are renamed or code changes? | Link to the source of truth instead of copying |
+| **Global** | Does this apply to literally every task type in this repo? | Move to a file instruction (`applyTo`) or skill |
+
+Shorter files outperform longer ones. An almost-empty file, or no file, is a valid outcome.
+
 ## Template
 
-Only include sections the workspace benefits from:
+Only include sections the workspace benefits from. Most projects need only one or two.
 
 ```markdown
-# Project Guidelines
+# {Project Name} Instructions
 
 ## Code Style
-{Language and formatting preferences—reference key files that exemplify patterns}
+{ONLY conventions not enforced by linters or visible in existing code}
 
 ## Architecture
-{Major components, service boundaries, the "why" behind structural decisions}
+{Decisions that contradict what agents would assume from reading the code}
 
-## Build and Test
-{Commands to install, build, test—agents will attempt to run these}
+## Environment
+{ONLY non-standard setup that agents would get wrong. Skip anything discoverable from package.json or config files}
 
 ## Conventions
-{Patterns that differ from common practices—include specific examples}
+{Patterns that differ from common practices. Include specific examples}
 ```
 
 For large repos, link to detailed docs instead of embedding: `See docs/TESTING.md for test conventions.`
@@ -53,10 +65,11 @@ For large repos, link to detailed docs instead of embedding: `See docs/TESTING.m
 
 ## Core Principles
 
-1. **Minimal by default**: Only what's relevant to *every* task
+1. **Minimal by default**: Only what passes the inclusion test. Every line costs instruction budget across all sessions
 2. **Concise and actionable**: Every line should guide behavior
-3. **Link, don't embed**: Reference docs instead of copying content. Search for existing docs (`docs/**/*.md`, `CONTRIBUTING.md`, etc.) and catalog what they cover—only inline agent-critical gotchas not documented elsewhere
+3. **Link, don't embed**: Reference docs instead of copying content. Search for existing docs (`docs/**/*.md`, `CONTRIBUTING.md`, etc.) and catalog what they cover. Only inline agent-critical gotchas not documented elsewhere
 4. **Keep current**: Update when practices change
+5. **Redirect, don't include**: Content that's valuable but not global belongs in [file instructions](./instructions.md) (`applyTo`) or [skills](./skills.md), not here
 
 ## Anti-patterns
 
@@ -64,3 +77,8 @@ For large repos, link to detailed docs instead of embedding: `See docs/TESTING.m
 - **Kitchen sink**: Everything instead of what matters most
 - **Duplicating docs**: Copying README instead of linking
 - **Obvious instructions**: Conventions already enforced by linters
+- **Listing scripts**: Copying `package.json` scripts; agents read `package.json` directly
+- **Routine structure descriptions**: Directory trees or codebase overviews that restate what agents discover by exploring. Only document structure when genuinely unconventional or ambiguous
+- **Naming discoverable tools**: "We use React Router" when it's in dependencies. Only clarify when alternatives overlap
+- **Fragile file paths**: Referencing specific files/services that will move or be renamed
+- **Task-specific patterns**: Implementation patterns that only apply to certain work (use skills instead)


### PR DESCRIPTION
## Summary

Research ([Gloaguen et al., 2026](https://arxiv.org/abs/2602.11988)) shows that LLM-generated context files reduce agent task success rates by ~3% while increasing inference cost by >20%. Agents faithfully follow instructions, so unnecessary or stale content actively misleads rather than helping. This PR hardens both the workspace instructions reference and the `/init` prompt to produce shorter, higher-quality output.

## Changes

### `workspace-instructions.md`
- **Inclusion test**: New 3-part gate (undiscoverable, stable, global) with fail-to-action guidance
- **Template revision**: Qualified all section placeholders; renamed "Build and Test" to "Environment" (only non-standard setup)
- **Core principles**: Added "Redirect, don't include" for scoped content; instruction budget framing
- **Anti-patterns**: 5 new concrete examples (listing scripts, routine structure descriptions, naming discoverable tools, fragile file paths, task-specific patterns)

### `init.prompt.md`
- **Brevity bias**: Explicit statement that shorter is better and an empty file is valid
- **Exploration targets**: Tightened to focus on what agents genuinely cannot discover
- **New step 3 (Filter ruthlessly)**: Applies the inclusion test; tracks non-global items for skill/instruction suggestions
- **Iterate step**: Now suggests creating skills or `applyTo`-based instructions for task-specific patterns

## Motivation

Inspired by [Never Run Claude /init](https://www.aihero.dev/never-run-claude-init) and the AGENTbench paper. Key insights:
- Agents explore codebases just-in-time and discover most content on their own
- Static overviews, script listings, and directory trees are redundant with what agents already read
- Content that's valuable but not globally relevant should live in skills or file instructions, not workspace instructions
- Every line in workspace instructions burns instruction budget across all sessions