### PR TITLE
refactor: improve HTTP/2 GOAWAY and network error retry resilience

### DIFF
--- a/src/platform/networking/common/networking.ts
+++ b/src/platform/networking/common/networking.ts
@@ -435,18 +435,22 @@ function networkRequest(
 }
 
 export function canRetryOnceNetworkError(reason: any) {
-	return [
-		'ECONNRESET',
-		'ETIMEDOUT',
-		'ERR_CONNECTION_RESET',
-		'ERR_NETWORK_CHANGED',
-		'ERR_HTTP2_INVALID_SESSION',
-		'ERR_HTTP2_STREAM_CANCEL',
-		'ERR_HTTP2_GOAWAY_SESSION',
-		'ERR_HTTP2_PROTOCOL_ERROR',
-		'ERR_FAILED',
-	].includes(reason?.code);
+	return retryableNetworkErrors.has(reason?.code) || retryableNetworkErrors.has(reason?.message);
 }
+
+const retryableNetworkErrors = new Set([
+	// Node.js/undici error codes
+	'ECONNRESET',
+	'ETIMEDOUT',
+	'ERR_HTTP2_GOAWAY_SESSION',
+	'ERR_HTTP2_INVALID_SESSION',
+	'ERR_HTTP2_STREAM_CANCEL',
+	'ERR_HTTP2_PROTOCOL_ERROR',
+	// Electron error messages
+	'net::ERR_CONNECTION_RESET',
+	'net::ERR_NETWORK_CHANGED',
+	'net::ERR_FAILED',
+]);
 
 export function postRequest(
 	accessor: ServicesAccessor,

--- a/src/platform/networking/node/fetcherFallback.ts
+++ b/src/platform/networking/node/fetcherFallback.ts
@@ -95,36 +95,16 @@ export async function fetchWithFallbacks(availableFetchers: readonly IFetcher[],
 	try {
 		return { response: await fetcher.fetch(url, options) };
 	} catch (err) {
+		// Transient electron errors: retry once on the same fetcher with a fresh connection.
+		if (isRetryableElectronError((err as Error)?.message)) {
+			return { response: await retryAfterDisconnect(fetcher, url, options, err, (err as Error).message, logService, telemetryService) };
+		}
+
 		// For net::ERR_FAILED from network process crash, disconnect and retry once.
 		if (fetcher.isNetworkProcessCrashedError(err)) {
-			const fetcherId = fetcher.getUserAgentLibrary();
-			logService.info(`FetcherService: ${fetcherId} hit network process crash error (${(err as Error)?.message}), retrying after disconnect...`);
 			try {
-				await fetcher.disconnectAll();
-				const response = await fetcher.fetch(url, options);
-				logService.info(`FetcherService: ${fetcherId} retry after crash succeeded.`);
-				/* __GDPR__
-					"fetcherCrashRetry" : {
-						"owner": "deepak1556",
-						"comment": "Sent when a fetcher retries after a network process crash error",
-						"fetcher": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The fetcher that crashed" },
-						"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the retry recovered or failed" },
-						"error": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The error message" }
-					}
-				*/
-				telemetryService?.sendTelemetryEvent('fetcherCrashRetry', { github: true, microsoft: true }, {
-					fetcher: fetcherId,
-					outcome: 'recovered',
-					error: collectSingleLineErrorMessage(err, true),
-				});
-				return { response };
+				return { response: await retryAfterDisconnect(fetcher, url, options, err, 'network-process-crash', logService, telemetryService) };
 			} catch (retryErr) {
-				logService.info(`FetcherService: ${fetcherId} retry also failed (${(retryErr as Error)?.message}), checking for demotion...`);
-				telemetryService?.sendTelemetryEvent('fetcherCrashRetry', { github: true, microsoft: true }, {
-					fetcher: fetcherId,
-					outcome: 'failed',
-					error: collectSingleLineErrorMessage(retryErr, true),
-				});
 				err = retryErr;
 			}
 		}
@@ -150,6 +130,66 @@ export async function fetchWithFallbacks(availableFetchers: readonly IFetcher[],
 			(err as any)._fetcherDemotion = { updatedFetchers: updatedFetchers.length > 0 ? updatedFetchers : undefined, updatedKnownBadFetchers };
 		}
 		throw err;
+	}
+}
+
+const retryableElectronErrors = [
+	'net::ERR_NETWORK_CHANGED',
+	'net::ERR_CONNECTION_RESET',
+];
+
+function isRetryableElectronError(message: string | undefined): boolean {
+	if (!message) {
+		return false;
+	}
+	return retryableElectronErrors.some(token => message.includes(token));
+}
+
+/**
+ * Disconnect all connections on the fetcher and retry the request once.
+ * Returns the response on success, throws on failure.
+ */
+async function retryAfterDisconnect(
+	fetcher: IFetcher,
+	url: string,
+	options: FetchOptions,
+	originalErr: unknown,
+	reason: string,
+	logService: ILogService,
+	telemetryService: ITelemetryService | undefined,
+): Promise<Response> {
+	const fetcherId = fetcher.getUserAgentLibrary();
+	logService.info(`FetcherService: ${fetcherId} hit ${reason}, retrying after disconnect...`);
+	try {
+		await fetcher.disconnectAll();
+		const response = await fetcher.fetch(url, options);
+		logService.info(`FetcherService: ${fetcherId} retry after ${reason} succeeded.`);
+		/* __GDPR__
+			"fetcherTransientRetry" : {
+				"owner": "AurSol",
+				"comment": "Sent when a fetcher retries after a transient error",
+				"fetcher": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The fetcher that retried" },
+				"reason": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The type of error that triggered the retry" },
+				"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the retry recovered or failed" },
+				"error": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The error message" }
+			}
+		*/
+		telemetryService?.sendTelemetryEvent('fetcherTransientRetry', { github: true, microsoft: true }, {
+			fetcher: fetcherId,
+			reason,
+			outcome: 'recovered',
+			error: collectSingleLineErrorMessage(originalErr, true),
+		});
+		return response;
+	} catch (retryErr) {
+		logService.info(`FetcherService: ${fetcherId} retry after ${reason} also failed (${(retryErr as Error)?.message}).`);
+		telemetryService?.sendTelemetryEvent('fetcherTransientRetry', { github: true, microsoft: true }, {
+			fetcher: fetcherId,
+			reason,
+			outcome: 'failed',
+			error: collectSingleLineErrorMessage(retryErr, true),
+		});
+		throw retryErr;
 	}
 }
 

--- a/src/platform/networking/node/nodeFetchFetcher.ts
+++ b/src/platform/networking/node/nodeFetchFetcher.ts
@@ -5,9 +5,8 @@
 
 import * as stream from 'stream';
 import * as undici from 'undici';
-import { Lazy } from '../../../util/vs/base/common/lazy';
 import { IEnvService } from '../../env/common/envService';
-import { HeadersImpl, IHeaders, ReportFetchEvent, WebSocketConnection, WebSocketConnectOptions } from '../common/fetcherService';
+import { FetchOptions, HeadersImpl, IHeaders, ReportFetchEvent, Response, WebSocketConnection, WebSocketConnectOptions } from '../common/fetcherService';
 import { BaseFetchFetcher } from './baseFetchFetcher';
 
 export class NodeFetchFetcher extends BaseFetchFetcher {
@@ -26,6 +25,26 @@ export class NodeFetchFetcher extends BaseFetchFetcher {
 		return NodeFetchFetcher.ID;
 	}
 
+	override async fetch(url: string, options: FetchOptions): Promise<Response> {
+		try {
+			return await super.fetch(url, options);
+		} catch (e) {
+			if (isGracefulGoawayError(e)) {
+				await this.disconnectAll();
+				return await super.fetch(url, options);
+			}
+			throw e;
+		}
+	}
+
+	override async disconnectAll(): Promise<void> {
+		const currentAgent = agent;
+		if (currentAgent) {
+			agent = undefined;
+			await currentAgent.close();
+		}
+	}
+
 	isInternetDisconnectedError(_e: any): boolean {
 		return false;
 	}
@@ -35,15 +54,37 @@ export class NodeFetchFetcher extends BaseFetchFetcher {
 	}
 }
 
+/**
+ * Detects a graceful HTTP/2 GOAWAY error (error code 0 = NO_ERROR).
+ * These occur during server-side connection draining
+ * and are safe to retry on a new connection.
+ */
+export function isGracefulGoawayError(e: any): boolean {
+	const message = String(e?.message || '');
+	const causeMessage = String(e?.cause?.message || '');
+	const combined = message + ' ' + causeMessage;
+	if (combined.includes('GOAWAY') && combined.includes('code 0')) {
+		return true;
+	}
+	return false;
+}
+
 function getFetch(): typeof globalThis.fetch {
 	const fetch = (globalThis as any).__vscodePatchedFetch || globalThis.fetch;
 	return function (input: string | URL | globalThis.Request, init?: RequestInit) {
-		return fetch(input, { dispatcher: agent.value, ...init });
+		return fetch(input, { dispatcher: getOrCreateAgent(), ...init });
 	};
 }
 
-// Cache agent to reuse connections.
-const agent = new Lazy(() => new undici.Agent({ allowH2: true }));
+function getOrCreateAgent(): undici.Agent {
+	if (!agent) {
+		agent = new undici.Agent({ allowH2: true });
+	}
+	return agent;
+}
+
+// Mutable agent reference — recreated on disconnectAll() to ensure fresh connections.
+let agent: undici.Agent | undefined;
 
 export function createWebSocket(url: string, options?: WebSocketConnectOptions): WebSocketConnection {
 	const wsAgent = new undici.Agent();

--- a/src/platform/networking/node/test/nodeFetchGoaway.spec.ts
+++ b/src/platform/networking/node/test/nodeFetchGoaway.spec.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { isGracefulGoawayError } from '../nodeFetchFetcher';
+
+describe('isGracefulGoawayError', () => {
+	it('detects GOAWAY with code 0 in message', () => {
+		const err = new Error('"GOAWAY" frame received with code 0');
+		expect(isGracefulGoawayError(err)).toBe(true);
+	});
+
+	it('detects GOAWAY with code 0 in cause message', () => {
+		const cause = new Error('"GOAWAY" frame received with code 0');
+		const err = new Error('fetch failed', { cause });
+		expect(isGracefulGoawayError(err)).toBe(true);
+	});
+
+	it('does not match GOAWAY with non-zero error codes', () => {
+		const err = new Error('"GOAWAY" frame received with code 2');
+		expect(isGracefulGoawayError(err)).toBe(false);
+	});
+
+	it('does not match non-GOAWAY errors', () => {
+		const err = new Error('ECONNRESET');
+		expect(isGracefulGoawayError(err)).toBe(false);
+	});
+
+	it('does not match null/undefined', () => {
+		expect(isGracefulGoawayError(null)).toBe(false);
+		expect(isGracefulGoawayError(undefined)).toBe(false);
+	});
+
+	it('does not match error with code 0 but no GOAWAY', () => {
+		const err = new Error('connection reset with code 0');
+		expect(isGracefulGoawayError(err)).toBe(false);
+	});
+
+	it('handles HTTP/2 prefixed GOAWAY message', () => {
+		const err = new Error('HTTP/2: "GOAWAY" frame received with code 0');
+		expect(isGracefulGoawayError(err)).toBe(true);
+	});
+});

--- a/src/platform/networking/vscode-node/test/fetcherServiceCrash.spec.ts
+++ b/src/platform/networking/vscode-node/test/fetcherServiceCrash.spec.ts
@@ -225,4 +225,67 @@ describe('FetcherService network process crash handling', () => {
 			expect(service.getUserAgentLibrary()).toBe('electron-fetch');
 		});
 	});
+
+	describe('ERR_NETWORK_CHANGED retry on same fetcher', () => {
+		function createNetworkChangedError(): Error {
+			return new Error('net::ERR_NETWORK_CHANGED');
+		}
+
+		it('retries once on the same fetcher and succeeds', async () => {
+			const networkChangedError = createNetworkChangedError();
+			const electronFetcher = createMockFetcher('electron-fetch', {
+				responses: [networkChangedError, createOkResponse()], // initial fails, retry succeeds
+				isFetcherError: (e) => e?.message?.startsWith('net::'),
+			});
+			const nodeFetcher = createMockFetcher('node-fetch', {
+				responses: [createOkResponse()],
+			});
+
+			const service = createFetcherService([electronFetcher, nodeFetcher]);
+
+			const response = await service.fetch('https://example.com', { callSite: 'test' });
+			expect(response.status).toBe(200);
+
+			// electron-fetch should still be the primary fetcher
+			expect(service.getUserAgentLibrary()).toBe('electron-fetch');
+		});
+
+		it('throws the retry error if the retry also fails', async () => {
+			const networkChangedError = createNetworkChangedError();
+			const retryError = new Error('net::ERR_CONNECTION_REFUSED');
+			const electronFetcher = createMockFetcher('electron-fetch', {
+				responses: [networkChangedError, retryError], // initial + retry both fail
+				isFetcherError: (e) => e?.message?.startsWith('net::'),
+			});
+			const nodeFetcher = createMockFetcher('node-fetch', {
+				responses: [createOkResponse()],
+			});
+
+			const service = createFetcherService([electronFetcher, nodeFetcher]);
+
+			// Should throw the retry error, not the original
+			await expect(service.fetch('https://example.com', { callSite: 'test' })).rejects.toThrow('net::ERR_CONNECTION_REFUSED');
+
+			// electron-fetch should still be the primary fetcher (no demotion for network change)
+			expect(service.getUserAgentLibrary()).toBe('electron-fetch');
+		});
+
+		it('does not interfere with crash retry logic', async () => {
+			// Non-ERR_NETWORK_CHANGED errors should still go through crash retry path
+			const crashError = createCrashError();
+			const electronFetcher = createMockFetcher('electron-fetch', {
+				responses: [crashError, createOkResponse()],
+				isNetworkProcessCrashedError: (e) => e === crashError,
+				isFetcherError: (e) => e?.message?.startsWith('net::'),
+			});
+			const nodeFetcher = createMockFetcher('node-fetch', {
+				responses: [createOkResponse()],
+			});
+
+			const service = createFetcherService([electronFetcher, nodeFetcher]);
+
+			const response = await service.fetch('https://example.com', { callSite: 'test' });
+			expect(response.status).toBe(200);
+		});
+	});
 });


### PR DESCRIPTION
- Retry graceful HTTP/2 GOAWAY (code 0) transparently in node-fetcher before surfacing as an error.

- Retry transient electron errors (ERR_NETWORK_CHANGED, etc.) on the same fetcher with a fresh connection in fetchWithFallbacks before falling back to a different fetcher.

- Fix canRetryOnceNetworkError to also check error .message for electron net:: errors, which were previously silently missed on the networkRequest path.