### PR TITLE
Make output channel logging resilient to shutdown

### DIFF
--- a/src/platform/log/vscode/outputChannelLogTarget.ts
+++ b/src/platform/log/vscode/outputChannelLogTarget.ts
@@ -20,22 +20,27 @@ export class NewOutputChannelLogTarget implements ILogTarget {
 	}
 
 	logIt(level: LogLevel, metadataStr: string, ...extra: any[]) {
-		switch (level) {
-			case LogLevel.Trace:
-				this._outputChannel.trace(metadataStr);
-				break;
-			case LogLevel.Debug:
-				this._outputChannel.debug(metadataStr);
-				break;
-			case LogLevel.Info:
-				this._outputChannel.info(metadataStr);
-				break;
-			case LogLevel.Warning:
-				this._outputChannel.warn(metadataStr);
-				break;
-			case LogLevel.Error:
-				this._outputChannel.error(metadataStr);
-				break;
+		try {
+			switch (level) {
+				case LogLevel.Trace:
+					this._outputChannel.trace(metadataStr);
+					break;
+				case LogLevel.Debug:
+					this._outputChannel.debug(metadataStr);
+					break;
+				case LogLevel.Info:
+					this._outputChannel.info(metadataStr);
+					break;
+				case LogLevel.Warning:
+					this._outputChannel.warn(metadataStr);
+					break;
+				case LogLevel.Error:
+					this._outputChannel.error(metadataStr);
+					break;
+			}
+		} catch {
+			// The output channel may be closed during extension host shutdown
+			// (see https://github.com/microsoft/vscode/issues/303916)
 		}
 	}
 


### PR DESCRIPTION
During extension host shutdown, the VS Code debug channel is closed before extension subscriptions are disposed. This causes our `m4t.remove` handler to throw an unhandled promise rejection when it tries to log via the already-closed output channel.

This wraps the output channel calls in `NewOutputChannelLogTarget.logIt()` in a try-catch so logging silently degrades instead of throwing.

Fixes https://github.com/microsoft/vscode/issues/303916
Fixes https://github.com/microsoft/vscode-copilot-release/issues/14173