### PR TITLE
Fix Gemini 400 errors from orphaned tool calls during conversation summarization

### DIFF
--- a/src/extension/intents/node/toolCallingLoop.ts
+++ b/src/extension/intents/node/toolCallingLoop.ts
@@ -1408,7 +1408,7 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 				if (next.role === Raw.ChatRole.Assistant) {
 					break;
 				}
-				if (next.role === Raw.ChatRole.Tool && next.toolCallId) {
+				if (next.role === Raw.ChatRole.Tool && next.toolCallId !== undefined) {
 					toolResultIds.add(next.toolCallId);
 				}
 			}

--- a/src/extension/intents/test/node/validateToolMessages.spec.ts
+++ b/src/extension/intents/test/node/validateToolMessages.spec.ts
@@ -244,4 +244,19 @@ describe('validateToolMessagesCore', () => {
 		expect(filterReasons).toHaveLength(0);
 		expect(strippedToolCallCount).toBe(1);
 	});
+
+	it('correctly matches tool results with empty-string toolCallId', () => {
+		// Edge case: empty string is a valid tool call ID and should not be treated as falsy
+		const messages: Raw.ChatMessage[] = [
+			assistantMsg('calling', [tc('', 'readFile')]),
+			toolMsg('', 'result'),
+		];
+
+		const { messages: result, strippedToolCallCount } = ToolCallingLoop.validateToolMessagesCore(messages, geminiOpts);
+		expect(result).toHaveLength(2);
+		const asstMsg = result[0] as Raw.AssistantChatMessage;
+		expect(asstMsg.toolCalls).toHaveLength(1);
+		expect(asstMsg.toolCalls![0].id).toBe('');
+		expect(strippedToolCallCount).toBe(0);
+	});
 });

--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -12,7 +12,7 @@ import { IChatHookService, PreCompactHookInput } from '../../../../platform/chat
 import { ChatFetchResponseType, ChatLocation, ChatResponse, FetchSuccess } from '../../../../platform/chat/common/commonTypes';
 import { IHistoricalTurn, ISessionTranscriptService } from '../../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
-import { isAnthropicFamily } from '../../../../platform/endpoint/common/chatModelCapabilities';
+import { isAnthropicFamily, isGeminiFamily } from '../../../../platform/endpoint/common/chatModelCapabilities';
 import { IEndpointProvider } from '../../../../platform/endpoint/common/endpointProvider';
 import { ILogService } from '../../../../platform/log/common/logService';
 import { IChatEndpoint } from '../../../../platform/networking/common/networking';
@@ -702,9 +702,36 @@ class ConversationHistorySummarizer {
 				stripCacheBreakpoints(summarizationPrompt);
 			}
 
+			let messages = ToolCallingLoop.stripInternalToolCallIds(summarizationPrompt);
+			// Gemini strictly requires every function_call to have a matching function_response.
+			// When prompt-tsx prunes tool result messages due to token budget, orphaned tool_calls
+			// can remain, causing a 400 INVALID_ARGUMENT error. Strip them for Gemini models.
+			if (isGeminiFamily(endpoint)) {
+				const validationResult = ToolCallingLoop.validateToolMessagesCore(messages, { stripOrphanedToolCalls: true });
+				messages = validationResult.messages;
+				if (validationResult.strippedToolCallCount > 0) {
+					this.logInfo(`Stripped ${validationResult.strippedToolCallCount} orphaned tool calls from summarization prompt`, mode);
+					/* __GDPR__
+						"summarization.strippedOrphanedToolCalls" : {
+							"owner": "vijayu",
+							"comment": "Tracks when orphaned tool calls are stripped from the summarization prompt for Gemini models",
+							"strippedToolCallCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Number of orphaned tool_calls stripped from the summarization prompt." },
+							"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model ID." },
+							"mode": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The summarization mode (simple or full)." }
+						}
+					*/
+					this.telemetryService.sendMSFTTelemetryEvent('summarization.strippedOrphanedToolCalls', {
+						model: endpoint.model,
+						mode,
+					}, {
+						strippedToolCallCount: validationResult.strippedToolCallCount,
+					});
+				}
+			}
+
 			summaryResponse = await endpoint.makeChatRequest2({
 				debugName: `summarizeConversationHistory-${mode}`,
-				messages: ToolCallingLoop.stripInternalToolCallIds(summarizationPrompt),
+				messages,
 				finishedCb: undefined,
 				location: ChatLocation.Other,
 				requestOptions: {


### PR DESCRIPTION
Gemini models return 400 INVALID_ARGUMENT ("number of function response parts != function call parts") during long Agent mode conversations. This happens when conversation summarization triggers and prompt-tsx prunes ToolMessage responses  leaving orphaned tool_calls without matching function_response messages.