### PR TITLE
Fix addLog: use regex with global flag and fix backtick no-op

### DIFF
--- a/src/extension/inlineEdits/vscode-node/features/diagnosticsBasedCompletions/diagnosticsCompletions.ts
+++ b/src/extension/inlineEdits/vscode-node/features/diagnosticsBasedCompletions/diagnosticsCompletions.ts
@@ -150,7 +150,7 @@ export class DiagnosticInlineEditRequestLogContext {
 
 	private _logs: string[] = [];
 	addLog(content: string): void {
-		this._logs.push(content.replace('\n', '\\n').replace('\t', '\\t').replace('`', '\`') + '\n');
+		this._logs.push(content.replace(/\n/g, '\\n').replace(/\t/g, '\\t').replace(/`/g, '\\`') + '\n');
 	}
 
 	private _markedToBeLogged: boolean = false;

--- a/src/platform/inlineEdits/common/inlineEditLogContext.ts
+++ b/src/platform/inlineEdits/common/inlineEditLogContext.ts
@@ -571,7 +571,7 @@ export class InlineEditRequestLogContext {
 
 	private _logs: string[] = [];
 	addLog(content: string): void {
-		this._logs.push(content.replace('\n', '\\n').replace('\t', '\\t').replace('`', '\`') + '\n');
+		this._logs.push(content.replace(/\n/g, '\\n').replace(/\t/g, '\\t').replace(/`/g, '\\`') + '\n');
 	}
 
 	private _rebaseFailure: MarkdownLoggable | undefined;


### PR DESCRIPTION
Fixes microsoft/vscode#308368

The `addLog` methods in `InlineEditRequestLogContext` and `DiagnosticInlineEditRequestLogContext` use `String.prototype.replace()` with a string first argument. This only replaces the first occurrence.

Additionally, the backtick replacement is a complete no-op: in JavaScript, `'\`'` is not a recognized escape sequence, so the backslash is silently dropped and the replacement string evaluates to just a plain backtick. The call `.replace('`', '\`')` replaces backtick with backtick and does nothing.

**Three bugs per line, two affected files:**

| # | Bug | Cause |
|---|-----|-------|
| 1 | Only first `\n` escaped | `String.prototype.replace` with string arg has no global semantics |
| 2 | Only first `\t` escaped | Same as above |
| 3 | Backtick escaping is a no-op | `'\`' === '`'` in JavaScript (not a recognized escape sequence) |

**Before:**
```ts
this._logs.push(content.replace('\n', '\\n').replace('\t', '\\t').replace('`', '\`') + '\n');
```

**After:**
```ts
this._logs.push(content.replace(/\n/g, '\\n').replace(/\t/g, '\\t').replace(/`/g, '\\`') + '\n');
```

Both files contain identical buggy code from the initial commit. The fix uses regex literals with the global flag for all three replacements so that every occurrence is properly escaped in the markdown log output.