### PR TITLE
nes: fix: do not include URI if targetDocument == activeDocument

### DIFF
--- a/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
+++ b/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
@@ -33,7 +33,6 @@ import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { clamp } from '../../../util/vs/base/common/numbers';
 import { autorun, IObservable, observableFromEvent } from '../../../util/vs/base/common/observable';
 import { basename } from '../../../util/vs/base/common/path';
-import { URI } from '../../../util/vs/base/common/uri';
 import { StringEdit } from '../../../util/vs/editor/common/core/edits/stringEdit';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { LineCheck } from '../../inlineChat/vscode-node/naturalLanguageHint';
@@ -417,7 +416,7 @@ export class InlineCompletionProviderImpl extends Disposable implements InlineCo
 				isInlineCompletion = !!inlineSuggestion;
 				completionItem = serveAsCompletionsProvider && !isInlineCompletion ?
 					undefined :
-					this.createCompletionItem(doc, document, position, inlineSuggestion?.range ?? range, result, inlineSuggestion?.newText, targetDocument.uri);
+					this.createCompletionItem(doc, document, inlineSuggestion?.range ?? range, result, inlineSuggestion?.newText);
 			} else { // NES is not for the active doc but a different one
 				completionItem = serveAsCompletionsProvider ? undefined : {
 					range,
@@ -517,11 +516,9 @@ export class InlineCompletionProviderImpl extends Disposable implements InlineCo
 	private createCompletionItem(
 		doc: IVSCodeObservableDocument,
 		document: TextDocument,
-		position: Position,
 		range: Range,
 		result: NonNullable<(NextEditResult | DiagnosticsNextEditResult)['result']>,
 		insertTextOverride?: string,
-		uri?: URI,
 	): Omit<NesCompletionItem, 'telemetryBuilder' | 'info' | 'showInlineEditMenu' | 'action' | 'wasShown' | 'isInlineEdit'> | undefined {
 
 		if (!result.edit) {
@@ -541,7 +538,6 @@ export class InlineCompletionProviderImpl extends Disposable implements InlineCo
 			insertText: insertTextOverride ?? result.edit.newText,
 			displayLocation,
 			command: result.action,
-			uri,
 		};
 	}
 


### PR DESCRIPTION
because UI starts rendering everything as NES UI (ie not ghost text even is isInlineEdit: false)

fixes https://github.com/microsoft/vscode/issues/304748