### PR TITLE
Fix hook commands that pass file URIs to spawn

### DIFF
--- a/src/platform/chat/node/hookExecutor.ts
+++ b/src/platform/chat/node/hookExecutor.ts
@@ -9,6 +9,7 @@ import type { CancellationToken, ChatHookCommand, Uri } from 'vscode';
 import { basename, join } from '../../../util/vs/base/common/path';
 import { isWindows } from '../../../util/vs/base/common/platform';
 import { removeAnsiEscapeCodes } from '../../../util/vs/base/common/strings';
+import { URI } from '../../../util/vs/base/common/uri';
 import { ILogService } from '../../log/common/logService';
 import { HookCommandResultKind, IHookCommandResult, IHookExecutor } from '../common/hookExecutor';
 import { IHooksOutputChannel } from '../common/hooksOutputChannel';
@@ -48,8 +49,9 @@ export class NodeHookExecutor implements IHookExecutor {
 
 	private _spawn(hook: ChatHookCommand, input: unknown, token: CancellationToken): Promise<IHookCommandResult> {
 		const cwd = hook.cwd ? uriToFsPath(hook.cwd) : homedir();
+		const command = sanitizeHookCommand(hook.command);
 
-		const child = spawn(hook.command, [], {
+		const child = spawn(command, [], {
 			stdio: 'pipe',
 			cwd,
 			env: { ...process.env, ...hook.env },
@@ -175,6 +177,41 @@ function uriToFsPath(uri: Uri): string {
 	}
 	// Fallback for URI-like objects
 	return (uri as { path: string }).path;
+}
+
+const fileUriTokenRegex = /(^|[\s=:(\[{,;])(["']?)(file:\/\/[^\s"'`|&;()<>\]}]+)\2(?=$|[\s)\]};,|&<>])/g;
+
+function sanitizeHookCommand(command: string): string {
+	return command.replace(fileUriTokenRegex, (match, prefix: string, quote: string, uriText: string) => {
+		const fsPath = getFileUriFsPath(uriText);
+		if (!fsPath) {
+			return match;
+		}
+
+		const sanitizedPath = quote ? fsPath : quoteArgForShell(fsPath);
+		return `${prefix}${quote}${sanitizedPath}${quote}`;
+	});
+}
+
+function getFileUriFsPath(uriText: string): string | undefined {
+	try {
+		const parsed = URI.parse(uriText);
+		if (parsed.scheme !== 'file') {
+			return undefined;
+		}
+
+		return parsed.fsPath;
+	} catch {
+		return undefined;
+	}
+}
+
+function quoteArgForShell(arg: string): string {
+	if (!(/[\s"'$`\\|&;()<>]/.test(arg))) {
+		return arg;
+	}
+
+	return `"${arg.replace(/["\\]/g, '\\$&')}"`;
 }
 
 

--- a/src/platform/chat/test/node/hookExecutor.spec.ts
+++ b/src/platform/chat/test/node/hookExecutor.spec.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { spawn } from 'child_process';
 import { EventEmitter } from 'events';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ChatHookCommand } from 'vscode';
@@ -34,6 +35,11 @@ function createMockChild(): MockChildProcess {
 		kill: vi.fn(),
 	});
 	return child;
+}
+
+function getSpawnCommand(): string {
+	const calls = vi.mocked(spawn).mock.calls;
+	return String(calls.at(-1)?.[0]);
 }
 
 /**
@@ -167,6 +173,54 @@ describe('NodeHookExecutor', () => {
 
 		// Verify the command ran successfully (cwd is passed to spawn options)
 		expect(result.kind).toBe(HookCommandResultKind.Success);
+	});
+
+	test('sanitizes file URIs in hook commands before spawn', async () => {
+		const promise = executor.executeCommand(
+			cmd('cat file:///tmp/example.txt'),
+			undefined,
+			CancellationToken.None
+		);
+		completeChild(child, { stdout: 'ok', exitCode: 0 });
+		await promise;
+
+		expect(getSpawnCommand()).toBe('cat /tmp/example.txt');
+	});
+
+	test('quotes sanitized file URIs with spaces in hook commands', async () => {
+		const promise = executor.executeCommand(
+			cmd('cat file:///tmp/my%20file.txt'),
+			undefined,
+			CancellationToken.None
+		);
+		completeChild(child, { stdout: 'ok', exitCode: 0 });
+		await promise;
+
+		expect(getSpawnCommand()).toBe('cat "/tmp/my file.txt"');
+	});
+
+	test('preserves existing quotes around sanitized file URIs', async () => {
+		const promise = executor.executeCommand(
+			cmd('cat "file:///tmp/my%20file.txt"'),
+			undefined,
+			CancellationToken.None
+		);
+		completeChild(child, { stdout: 'ok', exitCode: 0 });
+		await promise;
+
+		expect(getSpawnCommand()).toBe('cat "/tmp/my file.txt"');
+	});
+
+	test('does not sanitize non-file URIs in hook commands', async () => {
+		const promise = executor.executeCommand(
+			cmd('cat vscode-remote://ssh-remote+test/workspace/file.txt'),
+			undefined,
+			CancellationToken.None
+		);
+		completeChild(child, { stdout: 'ok', exitCode: 0 });
+		await promise;
+
+		expect(getSpawnCommand()).toBe('cat vscode-remote://ssh-remote+test/workspace/file.txt');
 	});
 
 	test('handles spawn error as non-blocking error', async () => {


### PR DESCRIPTION
Fixes microsoft/vscode#304555

## Summary
- sanitize `file://` tokens in hook command strings before invoking `spawn`
- preserve existing quoting and re-quote decoded paths that contain spaces
- add regression tests for file URIs, quoted file URIs, spaced paths, and non-file URI passthrough

## Test plan
- [x] Run `NodeHookExecutor` unit tests
- [x] Run `npm run typecheck`