### PR TITLE
Fix bug with Execution Subagent not being disabled (vscode#304648)

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
 				"icon": "$(play)",
 				"userDescription": "%copilot.tools.executionSubagent.description%",
 				"modelDescription": "Launch an iterative execution-focused subagent that performs an execution-based task.\nUSE THIS INSTEAD OF RUNNING INDIVIDUAL COMMANDS WITH run_in_terminal EXCEPT IN THE RARE CASES THAT YOU NEED THE FULL OUTPUT OF A COMMAND.\nHere are some examples of how it can be used:\n- Run tests and filter the output to summarize which tests failed and why.\n- Install all dependencies of a project.\nReturns: A list of commands that were run, along with relevant excerpts of each command's output.\nInput fields:\n- query: What to execute, and what to look for in the output. Can include exact commands to run, or a description of an execution task.\n- description: Short user-visible invocation message.\nNOTE: In the subagent query, make sure to specify any restrictions or guidelines on running commands provided by the user earlier in the conversation.\nFor example, if the user instructs the agent to not edit files in a particular directory, make sure to include that instruction in the subagent query when relevant.",
-				"when": "config.github.copilot.chat.enableExecutionSubagent",
+				"when": "config.github.copilot.chat.executionSubagent.enabled",
 				"inputSchema": {
 					"type": "object",
 					"properties": {


### PR DESCRIPTION
Addresses issue with execution subagent showing up even when all tools are disabled ([vscode#304648](https://github.com/microsoft/vscode/issues/304648)).

This adds `executionSubagent` to the family of `execute` tools, meaning that it will show up in the tool picker. Additionally, it disables `canBeReferencedInPrompt` in order to prevent it being triggered by the user.