### PR TITLE
Allow previous_response_id after server-side compaction

### DIFF
--- a/src/platform/endpoint/node/responsesApi.ts
+++ b/src/platform/endpoint/node/responsesApi.ts
@@ -108,7 +108,7 @@ function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMe
 
 	const statefulMarkerAndIndex = !ignoreStatefulMarker && getStatefulMarkerAndIndex(modelId, messages);
 	let previousResponseId: string | undefined;
-	if (latestCompactionMessageIndex === undefined && statefulMarkerAndIndex) {
+	if (statefulMarkerAndIndex) {
 		previousResponseId = statefulMarkerAndIndex.statefulMarker;
 		messages = messages.slice(statefulMarkerAndIndex.index + 1);
 	}


### PR DESCRIPTION
## Summary

Remove the guard that prevented using `previous_response_id` (stateful marker) when compaction data was present in the message history.

Server-side compaction is transparent to the response ID chain — after compaction, the server retains the compacted context tied to the response ID, so `previous_response_id` remains valid and avoids re-sending the full history (including the compaction blob).

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **Compaction + previous_response_id compatibility**: Verified via a test script against `gpt-5.4` that `previous_response_id` chaining works across compaction boundaries. Turn 3 triggered compaction and turn 4 succeeded using `previous_response_id` from turn 3.
- **Server retains compacted state**: The compaction blob only needs to be round-tripped on HTTP requests without `previous_response_id`. When the stateful marker is set (WebSocket reuse or HTTP with marker), the server already has the compacted context.
- **Minimal change**: Only removed the `latestCompactionMessageIndex === undefined` guard from the condition. The compaction slicing logic before it is still correct for the HTTP fallback path.

</details>

## Changes

- `src/platform/endpoint/node/responsesApi.ts`: Removed check that blocked `previous_response_id` when compaction data existed in message history.