### PR TITLE
Validate image dimensions before sending to Anthropic Messages API

### DIFF
--- a/src/platform/endpoint/node/messagesApi.ts
+++ b/src/platform/endpoint/node/messagesApi.ts
@@ -6,6 +6,7 @@
 import { ContentBlockParam, DocumentBlockParam, ImageBlockParam, MessageParam, RedactedThinkingBlockParam, TextBlockParam, ThinkingBlockParam, ToolReferenceBlockParam, ToolResultBlockParam } from '@anthropic-ai/sdk/resources';
 import { Raw } from '@vscode/prompt-tsx';
 import { Response } from '../../../platform/networking/common/fetcherService';
+import { getImageDimensions } from '../../../util/common/imageUtils';
 import { AsyncIterableObject } from '../../../util/vs/base/common/async';
 import { SSEParser } from '../../../util/vs/base/common/sseParser';
 import { generateUuid } from '../../../util/vs/base/common/uuid';
@@ -372,6 +373,29 @@ function tryParseToolReferences(content: ContentBlockParam[], validToolNames?: S
 		.map((name): ToolReferenceBlockParam => ({ type: 'tool_reference', tool_name: name }));
 }
 
+/**
+ * Maximum allowed image dimension (width or height) for the Anthropic Messages API.
+ * Images exceeding this limit in either dimension will be rejected.
+ * See: https://docs.anthropic.com/en/docs/build-with-claude/vision#image-requirements
+ */
+const ANTHROPIC_MAX_IMAGE_DIMENSION = 8000;
+
+function validateImageDimensions(dataUrl: string): void {
+	try {
+		const { width, height } = getImageDimensions(dataUrl);
+		if (width > ANTHROPIC_MAX_IMAGE_DIMENSION || height > ANTHROPIC_MAX_IMAGE_DIMENSION) {
+			throw new Error(
+				`Image dimensions ${width}x${height} exceed the maximum allowed size of ${ANTHROPIC_MAX_IMAGE_DIMENSION}x${ANTHROPIC_MAX_IMAGE_DIMENSION} pixels. Please resize the image and try again.`
+			);
+		}
+	} catch (e) {
+		if (e instanceof Error && e.message.includes('exceed the maximum allowed size')) {
+			throw e;
+		}
+		// If we can't read dimensions (corrupted header, etc.), let the API handle it
+	}
+}
+
 function rawContentToAnthropicContent(content: readonly Raw.ChatCompletionContentPart[], cacheTtl?: '5m' | '1h'): ContentBlockParam[] {
 	const convertedContent: ContentBlockParam[] = [];
 
@@ -387,6 +411,7 @@ function rawContentToAnthropicContent(content: readonly Raw.ChatCompletionConten
 				// Parse data URL: data:image/png;base64,<data>
 				const match = url.match(/^data:(image\/(?:jpeg|png|gif|webp));base64,(.+)$/);
 				if (match) {
+					validateImageDimensions(url);
 					convertedContent.push({
 						type: 'image',
 						source: {

--- a/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -157,6 +157,100 @@ suite('rawMessagesToMessagesAPI', function () {
 		expect(findBlock(content, 'text')).toBeDefined();
 	});
 
+	suite('image dimension validation', function () {
+
+		/**
+		 * Creates a minimal PNG data URL with the specified dimensions encoded in the IHDR header.
+		 * PNG format: 8-byte signature + IHDR chunk (4-byte length + 4-byte type + 4-byte width + 4-byte height + 5 more bytes).
+		 */
+		function makePngDataUrl(width: number, height: number): string {
+			const bytes = new Uint8Array(25);
+			// PNG signature
+			bytes.set([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A], 0);
+			// IHDR chunk length (13 bytes)
+			bytes.set([0x00, 0x00, 0x00, 0x0D], 8);
+			// "IHDR"
+			bytes.set([0x49, 0x48, 0x44, 0x52], 12);
+			// Width (big-endian uint32)
+			const view = new DataView(bytes.buffer);
+			view.setUint32(16, width, false);
+			// Height (big-endian uint32)
+			view.setUint32(20, height, false);
+			// Bit depth (8) — needed for valid header parsing
+			bytes[24] = 0x08;
+
+			let binary = '';
+			for (const byte of bytes) {
+				binary += String.fromCharCode(byte);
+			}
+			return `data:image/png;base64,${btoa(binary)}`;
+		}
+
+		test('throws for image exceeding max dimension in width', function () {
+			const oversizedUrl = makePngDataUrl(8001, 100);
+			const messages: Raw.ChatMessage[] = [
+				{
+					role: Raw.ChatRole.User,
+					content: [{
+						type: Raw.ChatCompletionContentPartKind.Image,
+						imageUrl: { url: oversizedUrl },
+					}],
+				},
+			];
+
+			expect(() => rawMessagesToMessagesAPI(messages)).toThrowError(/8001x100.*exceed the maximum allowed size.*8000x8000/);
+		});
+
+		test('throws for image exceeding max dimension in height', function () {
+			const oversizedUrl = makePngDataUrl(100, 9000);
+			const messages: Raw.ChatMessage[] = [
+				{
+					role: Raw.ChatRole.User,
+					content: [{
+						type: Raw.ChatCompletionContentPartKind.Image,
+						imageUrl: { url: oversizedUrl },
+					}],
+				},
+			];
+
+			expect(() => rawMessagesToMessagesAPI(messages)).toThrowError(/100x9000.*exceed the maximum allowed size.*8000x8000/);
+		});
+
+		test('allows image within max dimensions', function () {
+			const validUrl = makePngDataUrl(8000, 8000);
+			const messages: Raw.ChatMessage[] = [
+				{
+					role: Raw.ChatRole.User,
+					content: [{
+						type: Raw.ChatCompletionContentPartKind.Image,
+						imageUrl: { url: validUrl },
+					}],
+				},
+			];
+
+			const result = rawMessagesToMessagesAPI(messages);
+			const content = assertContentArray(result.messages[0].content);
+			expect(findBlock<ImageBlockParam>(content, 'image')).toBeDefined();
+		});
+
+		test('allows small image', function () {
+			const validUrl = makePngDataUrl(100, 200);
+			const messages: Raw.ChatMessage[] = [
+				{
+					role: Raw.ChatRole.User,
+					content: [{
+						type: Raw.ChatCompletionContentPartKind.Image,
+						imageUrl: { url: validUrl },
+					}],
+				},
+			];
+
+			const result = rawMessagesToMessagesAPI(messages);
+			const content = assertContentArray(result.messages[0].content);
+			expect(findBlock<ImageBlockParam>(content, 'image')).toBeDefined();
+		});
+	});
+
 	suite('custom tool search tool_reference conversion', function () {
 
 		function makeToolSearchMessages(toolNames: string[]): Raw.ChatMessage[] {


### PR DESCRIPTION
## Problem

When a tool result (e.g. `get_changed_files`) includes a base64 image that exceeds Anthropic's 8000px dimension limit, the API returns an opaque `400` error:

```
400 {"message":"messages.7.content.2.image.source.base64.data: At least one of the image dimensions exceed max allowed size: 8000 pixels"}
```

This crashes the entire request with no actionable guidance for the user.

## Solution

Add pre-flight dimension validation in `rawContentToAnthropicContent()` before pushing base64 images to the Anthropic content array:

- **`validateImageDimensions()`** — uses `getImageDimensions()` from `imageUtils.ts` to parse the image header and check width/height against the 8000px limit
- Throws a clear, user-friendly error: `"Image dimensions 9000x6000 exceed the maximum allowed size of 8000x8000 pixels. Please resize the image and try again."`
- Gracefully skips validation if image headers are unreadable (lets the API handle those cases)

## Testing

- 4 new unit tests covering oversized width, oversized height, boundary (8000x8000), and small images
- All 34 tests in `messagesApi.spec.ts` pass
- 0 compilation errors
