### PR TITLE
Guard Copilot CLI shell history restore

### DIFF
--- a/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts
+++ b/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts
@@ -1074,7 +1074,11 @@ function formatCreateToolInvocation(invocation: ChatToolInvocationPart, toolCall
  * Extracts a `cd <dir> &&` (or PowerShell equivalent) prefix from a command line,
  * returning the directory and remaining command.
  */
-export function extractCdPrefix(commandLine: string, isPowershell: boolean): { directory: string; command: string } | undefined {
+export function extractCdPrefix(commandLine: string | undefined, isPowershell: boolean): { directory: string; command: string } | undefined {
+	if (!commandLine) {
+		return undefined;
+	}
+
 	const cdPrefixMatch = commandLine.match(
 		isPowershell
 			? /^(?:cd(?: \/d)?|Set-Location(?: -Path)?) (?<dir>"[^"]*"|[^\s]+) ?(?:&&|;)\s+(?<suffix>.+)$/i
@@ -1095,7 +1099,7 @@ export function extractCdPrefix(commandLine: string, isPowershell: boolean): { d
 /**
  * Returns presentationOverrides only when the cd prefix directory matches the working directory.
  */
-export function getCdPresentationOverrides(commandLine: string, isPowershell: boolean, workingDirectory?: URI): { commandLine: string } | undefined {
+export function getCdPresentationOverrides(commandLine: string | undefined, isPowershell: boolean, workingDirectory?: URI): { commandLine: string } | undefined {
 	const cdPrefix = extractCdPrefix(commandLine, isPowershell);
 	if (!cdPrefix || !workingDirectory) {
 		return undefined;
@@ -1129,10 +1133,11 @@ function formatShellInvocationCompleted(invocation: ChatToolInvocationPart, tool
 	// Lets remove the last line containing the exit code from the output.
 	const text = (exitCode !== undefined ? resultContent.replace(/<exited with exit code \d+>$/, '').trimEnd() : resultContent).replace(/\n/g, '\r\n');
 	const isPowershell = toolCall.toolName === 'powershell';
-	const presentationOverrides = getCdPresentationOverrides(toolCall.arguments.command, isPowershell, workingDirectory);
+	const command = toolCall.arguments.command ?? '';
+	const presentationOverrides = getCdPresentationOverrides(command, isPowershell, workingDirectory);
 	const toolSpecificData: ChatTerminalToolInvocationData = {
 		commandLine: {
-			original: presentationOverrides?.commandLine ?? toolCall.arguments.command
+			original: presentationOverrides?.commandLine ?? command
 		},
 		language: isPowershell ? 'powershell' : 'bash',
 		presentationOverrides,

--- a/src/extension/chatSessions/copilotcli/common/test/copilotCLITools.spec.ts
+++ b/src/extension/chatSessions/copilotcli/common/test/copilotCLITools.spec.ts
@@ -153,6 +153,52 @@ describe('CopilotCLITools', () => {
 			expect((markdownParts[0] as any).value?.value || (markdownParts[0] as any).value).toContain('All tests are passing.');
 		});
 
+		it('tolerates failed bash invocations with missing command arguments', () => {
+			const events: any[] = [
+				{ type: 'user.message', data: { content: 'Check it', attachments: [] } },
+				{
+					type: 'assistant.message',
+					data: {
+						content: 'Let me check that:',
+						toolRequests: [
+							{
+								toolCallId: 'bash-missing-command',
+								name: 'bash',
+								arguments: {},
+								type: 'function',
+								intentionSummary: 'Running command'
+							}
+						]
+					}
+				},
+				{ type: 'tool.execution_start', data: { toolName: 'bash', toolCallId: 'bash-missing-command', arguments: {} } },
+				{
+					type: 'tool.execution_complete',
+					data: {
+						toolCallId: 'bash-missing-command',
+						success: false,
+						error: {
+							message: 'Unterminated string in JSON at position 64 (line 1 column 65)',
+							code: 'failure'
+						}
+					}
+				}
+			];
+
+			const turns = buildChatHistoryFromEvents('', undefined, events, getVSCodeRequestId, delegationSummary, logger);
+			expect(turns).toHaveLength(2);
+
+			const responseTurn = turns[1] as ChatResponseTurn2;
+			const responseParts: any = (responseTurn as any).response;
+			const parts: any[] = (responseParts.parts ?? responseParts._parts ?? responseParts);
+			const toolInvocations = parts.filter(p => p instanceof ChatToolInvocationPart);
+			expect(toolInvocations).toHaveLength(1);
+
+			const bashInvocation = toolInvocations[0] as ChatToolInvocationPart;
+			expect(getInvocationMessageText(bashInvocation)).toContain('Unterminated string in JSON');
+			expect((bashInvocation.toolSpecificData as any).commandLine.original).toBe('');
+		});
+
 		it('converts file attachments to references on user messages', () => {
 			const events: any[] = [
 				{
@@ -816,6 +862,10 @@ describe('CopilotCLITools', () => {
 		it('returns undefined for command with only cd and no suffix', () => {
 			expect(extractCdPrefix('cd /home/user', false)).toBeUndefined();
 		});
+
+		it('returns undefined for missing command input', () => {
+			expect(extractCdPrefix(undefined, false)).toBeUndefined();
+		});
 	});
 
 	describe('formatShellInvocation with presentationOverrides', () => {
@@ -992,4 +1042,3 @@ describe('CopilotCLITools', () => {
 		});
 	});
 });
-


### PR DESCRIPTION
Handle malformed persisted bash or powershell tool calls that are missing a command during chat history restore, and add a regression test for the broken session payload.