### PR TITLE
nes: log tree: fix: XtabProvider debug log tree nesting

### DIFF
--- a/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
+++ b/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
@@ -556,7 +556,7 @@ export class ClaudeCodeSession extends Disposable {
 			const promptLabel = request.prompt.filter(p => p.type === 'text').at(-1)?.text ?? 'Claude Session Prompt';
 			this.sessionStateService.setCapturingTokenForSession(
 				this.sessionId,
-				new CapturingToken(promptLabel, 'claude', false, false, undefined, undefined, this.sessionId)
+				new CapturingToken(promptLabel, 'claude', undefined, undefined, this.sessionId)
 			);
 
 			// Emit a user_message span event for the debug panel

--- a/src/extension/chatSessions/claude/vscode-node/slashCommands/terminalCommand.ts
+++ b/src/extension/chatSessions/claude/vscode-node/slashCommands/terminalCommand.ts
@@ -108,7 +108,7 @@ export class TerminalSlashCommand implements IClaudeSlashCommandHandler {
 			// Set capturing token only after terminal is successfully created to avoid leaking stale session state
 			this.sessionStateService.setCapturingTokenForSession(
 				sessionId,
-				new CapturingToken(`Claude CLI (${sessionId})`, 'claude', false)
+				new CapturingToken(`Claude CLI (${sessionId})`, 'claude')
 			);
 
 			this.logService.info(`[TerminalSlashCommand] Created terminal with Claude CLI configured on port ${config.port}, command: ${cliCommand}, sessionId: ${sessionId}`);

--- a/src/extension/chatSessions/claude/vscode-node/slashCommands/test/terminalCommand.spec.ts
+++ b/src/extension/chatSessions/claude/vscode-node/slashCommands/test/terminalCommand.spec.ts
@@ -234,7 +234,6 @@ describe('TerminalSlashCommand', () => {
 				expect.objectContaining({
 					label: `Claude CLI (${TEST_SESSION_ID})`,
 					icon: 'claude',
-					flattenSingleChild: false,
 				})
 			);
 		});

--- a/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -228,7 +228,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		}
 		const label = getPromptLabel(input);
 		const promptLabel = truncate(label, 50);
-		const capturingToken = new CapturingToken(`Copilot CLI | ${promptLabel}`, 'worktree', false, true, undefined, undefined, this.sessionId);
+		const capturingToken = new CapturingToken(`Copilot CLI | ${promptLabel}`, 'worktree', undefined, undefined, this.sessionId);
 		const isAlreadyBusyWithAnotherRequest = !!this._status && (this._status === ChatSessionStatus.InProgress || this._status === ChatSessionStatus.NeedsInput);
 		this._toolInvocationToken = request.toolInvocationToken;
 

--- a/src/extension/completions-core/vscode-node/extension/src/vscodeInlineCompletionItemProvider.ts
+++ b/src/extension/completions-core/vscode-node/extension/src/vscodeInlineCompletionItemProvider.ts
@@ -114,7 +114,7 @@ export class CopilotInlineCompletionItemProvider extends Disposable implements I
 
 		const label = `Ghost | ${basename(doc.uri.toString())} (v${doc.version})`;
 
-		const capturingToken = new CapturingToken(label, undefined, true, true);
+		const capturingToken = new CapturingToken(label, undefined);
 
 		return await this.requestLogger.captureInvocation(capturingToken, async () => {
 

--- a/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -1258,7 +1258,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		// Start the provider call - this runs in the background and populates the cache
 		const label = `NES | spec | ${basename(doc.id.toUri().fsPath)} (v${doc.version.get()})`;
 
-		const capturingToken = new CapturingToken(label, undefined, false, true);
+		const capturingToken = new CapturingToken(label, undefined);
 
 		void this._requestLogger.captureInvocation(capturingToken, async () => {
 			try {

--- a/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
+++ b/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
@@ -221,7 +221,7 @@ export class InlineCompletionProviderImpl extends Disposable implements InlineCo
 	): Promise<NesCompletionList | undefined> {
 		const label = `NES | ${basename(document.uri.fsPath)} (v${document.version})`;
 
-		const capturingToken = new CapturingToken(label, undefined, true, true);
+		const capturingToken = new CapturingToken(label, undefined);
 
 		assert(context.changeHint === undefined || NesChangeHint.is(context.changeHint), 'Expected changeHint to be of type TriggerNes or undefined');
 		const changeHint = context.changeHint as NesChangeHint | undefined;

--- a/src/extension/log/vscode-node/requestLogTree.ts
+++ b/src/extension/log/vscode-node/requestLogTree.ts
@@ -588,10 +588,6 @@ class ChatRequestProvider extends Disposable implements vscode.TreeDataProvider<
 
 	getChildren(element?: TreeItem | undefined): vscode.ProviderResult<TreeItem[]> {
 		if (element instanceof ChatPromptItem) {
-			// If mainEntryId is set, filter out the main entry from children
-			if (element.mainEntryId) {
-				return element.children.filter(child => child.id !== element.mainEntryId);
-			}
 			return element.children;
 		} else if (element) {
 			return [];
@@ -600,17 +596,15 @@ class ChatRequestProvider extends Disposable implements vscode.TreeDataProvider<
 			const tokenToPrompt = new Map<CapturingToken, ChatPromptItem>();
 
 			for (const currReq of this.requestLogger.getRequests()) {
-				// Skip entries that are dynamically hidden (e.g. skipped/cancelled live NES requests)
-				if (currReq.kind === LoggedInfoKind.Request &&
-					currReq.entry.type === LoggedRequestKind.MarkdownContentRequest &&
-					currReq.entry.isVisible && !currReq.entry.isVisible()) {
-					continue;
-				}
-
-				const currReqTreeItem = this.logToTreeItem(currReq);
-
 				if (!currReq.token) {
-					result.push(currReqTreeItem);
+					// Skip non-main hidden entries (e.g. skipped/cancelled live NES requests)
+					if (currReq.kind === LoggedInfoKind.Request &&
+						currReq.entry.type === LoggedRequestKind.MarkdownContentRequest &&
+						currReq.entry.isVisible && !currReq.entry.isVisible()) {
+						continue;
+					}
+
+					result.push(this.logToTreeItem(currReq));
 					continue;
 				}
 
@@ -621,30 +615,38 @@ class ChatRequestProvider extends Disposable implements vscode.TreeDataProvider<
 					result.push(prompt);
 				}
 
+				// If this entry is the main entry for the group (a MarkdownContentRequest
+				// whose debugName matches the token label), associate it directly with the
+				// parent ChatPromptItem — don't add it as a child. The entry stays in the
+				// request logger for virtual document serving; only tree nesting changes.
+				// Only wire the main entry if it is visible — for live NES/Ghost entries,
+				// isVisible() can be false (e.g. skipped/cancelled); wiring a hidden entry
+				// would make it visible again via the parent's icon and click command.
+				if (currReq.kind === LoggedInfoKind.Request &&
+					currReq.entry.type === LoggedRequestKind.MarkdownContentRequest &&
+					currReq.entry.debugName === currReq.token.label) {
+					const isHidden = currReq.entry.isVisible && !currReq.entry.isVisible();
+					if (!isHidden) {
+						prompt.setMainEntry(currReq);
+					}
+					continue;
+				}
+
+				// Skip non-main hidden entries
+				if (currReq.kind === LoggedInfoKind.Request &&
+					currReq.entry.type === LoggedRequestKind.MarkdownContentRequest &&
+					currReq.entry.isVisible && !currReq.entry.isVisible()) {
+					continue;
+				}
+
+				const currReqTreeItem = this.logToTreeItem(currReq);
 				const alreadyIncluded = prompt.children.find(existingChild => existingChild.id === currReqTreeItem.id);
 				if (!alreadyIncluded) {
 					prompt.children.push(currReqTreeItem);
 				}
 			}
 
-			// Post-process: flatten single-child items and promote main entries
-			const processed: (ChatPromptItem | TreeChildItem)[] = [];
-			for (const item of result) {
-				if (item instanceof ChatPromptItem) {
-					if (item.token.flattenSingleChild && item.children.length === 1) {
-						processed.push(item.children[0]);
-					} else {
-						if (item.token.promoteMainEntry) {
-							item.promoteMainEntry();
-						}
-						processed.push(item);
-					}
-				} else {
-					processed.push(item);
-				}
-			}
-
-			return filterMap(processed, r => {
+			return filterMap(result, r => {
 				if (!this.filters.itemIncluded(r)) {
 					return undefined;
 				}
@@ -679,11 +681,6 @@ class ChatPromptItem extends vscode.TreeItem {
 	override readonly contextValue = 'chatprompt';
 	public children: TreeChildItem[] = [];
 	public override id: string | undefined;
-	/**
-	 * The ID of the main entry that was promoted to this parent item.
-	 * When set, clicking the parent opens this entry and it's excluded from children.
-	 */
-	public mainEntryId: string | undefined;
 
 	public static create(info: LoggedInfo, request: CapturingToken) {
 		const existing = ChatPromptItem.ids.get(info);
@@ -691,60 +688,52 @@ class ChatPromptItem extends vscode.TreeItem {
 			return existing;
 		}
 
-		// Check if this first info should be promoted to the main entry
-		let mainEntryId: string | undefined;
-		if (request.promoteMainEntry && info.kind === LoggedInfoKind.Request) {
-			const requestInfo = info as ILoggedRequestInfo;
-			if (requestInfo.entry.debugName === request.label) {
-				mainEntryId = info.id;
-			}
-		}
-
-		const item = new ChatPromptItem(request, mainEntryId);
+		const item = new ChatPromptItem(request);
 		item.id = info.id + '-prompt';
 		ChatPromptItem.ids.set(info, item);
 		return item;
 	}
 
-	protected constructor(public readonly token: CapturingToken, mainEntryId?: string) {
+	protected constructor(public readonly token: CapturingToken) {
 		super(token.label, vscode.TreeItemCollapsibleState.Expanded);
 		if (token.icon) {
 			this.iconPath = new vscode.ThemeIcon(token.icon);
 		}
-		if (mainEntryId) {
-			this.mainEntryId = mainEntryId;
-			this.command = {
-				command: 'vscode.open',
-				title: '',
-				arguments: [vscode.Uri.parse(ChatRequestScheme.buildUri({ kind: 'request', id: mainEntryId }))]
-			};
-		}
 	}
 
-	public promoteMainEntry() {
-		const child = this.children.find(child => child.label === this.label);
-		if (!child || child.id === undefined) {
+	/**
+	 * Associate a main entry directly with this parent item.
+	 * The main entry's icon and click command are shown on the parent node.
+	 * The entry is NOT added as a child — it stays in the request logger
+	 * for virtual document serving only.
+	 */
+	public setMainEntry(info: ILoggedRequestInfo): void {
+		if (info.entry.type !== LoggedRequestKind.MarkdownContentRequest) {
 			return;
 		}
-		this.mainEntryId = child.id;
-		if (child.iconPath) {
-			this.iconPath = child.iconPath;
+		const resolvedIcon = resolveMarkdownIcon(info.entry);
+		if (resolvedIcon !== undefined) {
+			this.iconPath = new vscode.ThemeIcon(resolvedIcon.id);
 		}
 		this.command = {
 			command: 'vscode.open',
 			title: '',
-			arguments: [vscode.Uri.parse(ChatRequestScheme.buildUri({ kind: 'request', id: this.mainEntryId }))]
+			arguments: [vscode.Uri.parse(ChatRequestScheme.buildUri({ kind: 'request', id: info.id }))]
 		};
 	}
 
 	public withFilteredChildren(filter: (child: TreeChildItem) => boolean): ChatPromptItem {
-		const item = new ChatPromptItem(this.token, this.mainEntryId);
+		const item = new ChatPromptItem(this.token);
 		item.children = this.children.filter(filter);
 		item.id = this.id;
 		item.iconPath = this.iconPath;
 		item.command = this.command;
+		item.collapsibleState = item.children.length > 0
+			? vscode.TreeItemCollapsibleState.Expanded
+			: vscode.TreeItemCollapsibleState.None;
 		return item;
 	}
+
 }
 
 class ToolCallItem extends vscode.TreeItem {

--- a/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -141,8 +141,6 @@ export class DefaultIntentRequestHandler {
 			const capturingToken = new CapturingToken(
 				this.request.prompt,
 				'comment',
-				false,
-				false,
 				this.request.subAgentInvocationId,
 				this.request.subAgentName,
 				// For subagents, use invocation ID as chatSessionId so spans get their own log file

--- a/src/extension/prompt/node/promptCategorizer.ts
+++ b/src/extension/prompt/node/promptCategorizer.ts
@@ -195,8 +195,6 @@ export class PromptCategorizerService implements IPromptCategorizerService {
 			const capturingToken = new CapturingToken(
 				'categorization',
 				undefined,
-				false,
-				false,
 				undefined,
 				undefined,
 				undefined,

--- a/src/extension/prompt/node/summarizer.ts
+++ b/src/extension/prompt/node/summarizer.ts
@@ -83,8 +83,6 @@ export class ChatSummarizerProvider implements vscode.ChatSummarizer {
 		const capturingToken = new CapturingToken(
 			'summarize',
 			undefined,
-			false,
-			false,
 			undefined,
 			undefined,
 			undefined,

--- a/src/extension/prompt/node/title.ts
+++ b/src/extension/prompt/node/title.ts
@@ -47,8 +47,6 @@ export class ChatTitleProvider implements vscode.ChatTitleProvider {
 		const capturingToken = new CapturingToken(
 			'title',
 			undefined,
-			false,
-			false,
 			undefined,
 			undefined,
 			undefined,

--- a/src/extension/replay/vscode-node/test/chatReplayNotebook.spec.ts
+++ b/src/extension/replay/vscode-node/test/chatReplayNotebook.spec.ts
@@ -56,7 +56,7 @@ describe('ChatReplayNotebookSerializer', () => {
 		it('creates notebook cells from a real logger export with prompt, tool call, and response', async () => {
 			// This test validates the full pipeline using the TestRequestLogger
 			// It should catch any changes to the request logger export format that break the notebook parser
-			const userPromptToken = new CapturingToken('create a hello world file', 'comment', false);
+			const userPromptToken = new CapturingToken('create a hello world file', 'comment');
 
 			await logger.captureInvocation(userPromptToken, async () => {
 				// 1. Tool call - creates the file
@@ -123,7 +123,7 @@ describe('ChatReplayNotebookSerializer', () => {
 			// This tests the real response format from model completions
 			// ChatMLSuccess entries have response: { type: 'success', message: 'the text' }
 			// We use TestRequestLogger.addEntry() with a ChatMLSuccess entry to test the real pipeline
-			const userPromptToken = new CapturingToken('test query', 'comment', false);
+			const userPromptToken = new CapturingToken('test query', 'comment');
 
 			await logger.captureInvocation(userPromptToken, async () => {
 				// Create a ChatMLSuccess entry with a mock result - this matches how real model responses are logged
@@ -264,13 +264,13 @@ describe('ChatReplayNotebookSerializer', () => {
 
 		it('creates notebook cells for multiple prompts with mixed entry types', async () => {
 			// First prompt
-			const firstToken = new CapturingToken('what files are in this directory?', 'comment', false);
+			const firstToken = new CapturingToken('what files are in this directory?', 'comment');
 			await logger.captureInvocation(firstToken, async () => {
 				logger.logToolCall('tool-1', 'list_dir', { path: '/workspace' }, createMockToolResult('file1.ts\nfile2.ts\nREADME.md'));
 			});
 
 			// Second prompt
-			const secondToken = new CapturingToken('read the README file', 'comment', false);
+			const secondToken = new CapturingToken('read the README file', 'comment');
 			await logger.captureInvocation(secondToken, async () => {
 				logger.logToolCall('tool-2', 'read_file', { path: '/workspace/README.md' }, createMockToolResult('# My Project\n\nThis is a test project.'));
 
@@ -323,7 +323,7 @@ describe('ChatReplayNotebookSerializer', () => {
 			});
 
 			// Add an entry with a token
-			const userToken = new CapturingToken('test prompt', 'comment', false);
+			const userToken = new CapturingToken('test prompt', 'comment');
 			await logger.captureInvocation(userToken, async () => {
 				logger.logToolCall('tool-1', 'test_tool', {}, { content: [] });
 			});
@@ -337,7 +337,7 @@ describe('ChatReplayNotebookSerializer', () => {
 		});
 
 		it('preserves tool call arguments and response in exported JSON', async () => {
-			const token = new CapturingToken('search for something', 'comment', false);
+			const token = new CapturingToken('search for something', 'comment');
 
 			const toolArgs = {
 				query: 'find me files',
@@ -591,7 +591,7 @@ describe('chatReplayExport', () => {
 
 	describe('createChatReplayExport', () => {
 		it('creates valid export structure', async () => {
-			const token = new CapturingToken('test prompt', 'comment', false);
+			const token = new CapturingToken('test prompt', 'comment');
 			await logger.captureInvocation(token, async () => {
 				logger.logToolCall('t1', 'test_tool', { arg: 'value' }, { content: [] });
 			});
@@ -617,7 +617,7 @@ describe('chatReplayExport', () => {
 
 	describe('serializeChatReplayExport', () => {
 		it('produces valid JSON', async () => {
-			const token = new CapturingToken('prompt', 'comment', false);
+			const token = new CapturingToken('prompt', 'comment');
 			await logger.captureInvocation(token, async () => {
 				logger.logToolCall('t1', 'tool', {}, { content: [] });
 			});

--- a/src/extension/tools/node/executionSubagentTool.ts
+++ b/src/extension/tools/node/executionSubagentTool.ts
@@ -79,8 +79,6 @@ class ExecutionSubagentTool implements ICopilotTool<IExecutionSubagentParams> {
 		const executionSubagentToken = new CapturingToken(
 			`Execution: ${options.input.query.substring(0, 50)}${options.input.query.length > 50 ? '...' : ''}`,
 			'execution',
-			false,
-			false,
 			subAgentInvocationId,
 			'execution'  // subAgentName for trajectory tracking
 		);

--- a/src/extension/tools/node/searchSubagentTool.ts
+++ b/src/extension/tools/node/searchSubagentTool.ts
@@ -90,8 +90,6 @@ class SearchSubagentTool implements ICopilotTool<ISearchSubagentParams> {
 		const searchSubagentToken = new CapturingToken(
 			`Search: ${options.input.query.substring(0, 50)}${options.input.query.length > 50 ? '...' : ''}`,
 			'search',
-			false,
-			false,
 			subAgentInvocationId,
 			'search',  // subAgentName for trajectory tracking
 			// Use invocation ID as chatSessionId so spans get their own log file

--- a/src/platform/requestLogger/common/capturingToken.ts
+++ b/src/platform/requestLogger/common/capturingToken.ts
@@ -17,16 +17,6 @@ export class CapturingToken {
 		 */
 		public readonly icon: string | undefined,
 		/**
-		 * Whether to flatten a single child request under this token.
-		 */
-		public readonly flattenSingleChild: boolean,
-		/**
-		 * When true, the parent tree item becomes clickable and acts as the main entry.
-		 * The main entry (identified by debugName starting with the token's label prefix) is
-		 * excluded from the children list and its content is shown when clicking the parent.
-		 */
-		public readonly promoteMainEntry: boolean = false,
-		/**
 		 * Optional pre-assigned subAgentInvocationId as session id for trajectory tracking.
 		 * When set, the trajectory will use this ID instead of generating a new one,
 		 * enabling explicit linking between parent tool calls and subagent trajectories.


### PR DESCRIPTION
## Problem

XtabProvider entries sometimes appeared unnested at the top level of the Chat Debug log tree instead of under their NES parent entry.

## Root Cause

\`flattenSingleChild=true\` on the NES \`CapturingToken\` promoted the XtabProvider child to the top level when the sibling NES \`MarkdownContentRequest\` entry was hidden (via \`setIsSkipped()\` or cancellation). The hidden entry was skipped entirely in the tree's grouping loop, making XtabProvider the sole visible child, which then got flattened.

## Fix

Remove \`flattenSingleChild\` and \`promoteMainEntry\` from \`CapturingToken\` entirely, making it a pure correlation token with no rendering hints.

Instead of adding the NES log context document as a child entry that gets "promoted" into the parent, \`ChatPromptItem\` now directly owns the document via \`setMainEntry()\`. A \`MarkdownContentRequest\` whose \`debugName\` matches the token's \`label\` is wired to the parent's icon and click command — never added as a tree child. This means hidden entries cannot displace XtabProvider from its parent.

Groups with no visible children render as non-expandable leaf items (no arrow). Groups with children render expanded.

## Changes

- **\`CapturingToken\`**: Removed \`flattenSingleChild\` and \`promoteMainEntry\` constructor params
- **\`requestLogTree.ts\`**: Rewrote \`getChildren()\` grouping — main entries are associated directly with the parent via \`setMainEntry()\`, never added as children. Removed post-processing loop. \`withFilteredChildren()\` sets \`collapsibleState\` based on children count.
- **12 caller files + 2 test files**: Updated \`CapturingToken\` constructor args