### PR TITLE
sessions: port Copilot CLI PR detection to session open

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
@@ -13,13 +13,14 @@ import { IVSCodeExtensionContext } from '../../../platform/extContext/common/ext
 import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
 import { getGitHubRepoInfoFromContext, IGitService, RepoContext } from '../../../platform/git/common/gitService';
 import { toGitUri } from '../../../platform/git/common/utils';
+import { derivePullRequestState } from '../../../platform/github/common/githubAPI';
 import { IOctoKitService } from '../../../platform/github/common/githubService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IPromptsService, ParsedPromptFile } from '../../../platform/promptFiles/common/promptsService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
 import { isUri } from '../../../util/common/types';
-import { DeferredPromise, IntervalTimer, SequencerByKey, ThrottledDelayer } from '../../../util/vs/base/common/async';
+import { DeferredPromise, IntervalTimer, SequencerByKey } from '../../../util/vs/base/common/async';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
 import { isCancellationError } from '../../../util/vs/base/common/errors';
 import { Emitter, Event } from '../../../util/vs/base/common/event';
@@ -171,13 +172,6 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 	public readonly onDidCommitChatSessionItem: Event<{ original: vscode.ChatSessionItem; modified: vscode.ChatSessionItem }> = this._onDidCommitChatSessionItem.event;
 
 	private readonly controller: vscode.ChatSessionItemController;
-	private static readonly _PR_DETECTION_RECHECK_INTERVAL = 60_000; // ms before re-checking a session that had no PR
-	private readonly _prDetectionDelayer = this._register(new ThrottledDelayer<void>(2000));
-	private readonly _prDetectionPendingSessions = new Map<string, { branchName: string; repositoryPath: string }>();
-	/** Sessions where a PR was found and persisted — permanently skip further detection. */
-	private readonly _prDetectionDone = new Set<string>();
-	/** Sessions checked without finding a PR — stores the timestamp so we can re-check after a cooldown. */
-	private readonly _prDetectionLastChecked = new Map<string, number>();
 	private readonly newSessions = new ResourceMap<vscode.ChatSessionItem>();
 	/**
 	 * ID of the last used folder in an untitled workspace (for defaulting selection).
@@ -262,7 +256,6 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 		}
 		this._register(this.sessionService.onDidDeleteSession(async (e) => {
 			controller.items.delete(SessionIdForCLI.getResource(e));
-			this.clearPrDetectionState(e);
 		}));
 		this._register(this.sessionService.onDidChangeSession(async (e) => {
 			const item = await this.toChatSessionItem(e);
@@ -290,12 +283,6 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 		this._register(this.copilotCLIAgents.onDidChangeAgents(() => {
 			this._onDidChangeChatSessionProviderOptions.fire();
 		}));
-	}
-
-	private clearPrDetectionState(sessionId: string): void {
-		this._prDetectionPendingSessions.delete(sessionId);
-		this._prDetectionDone.delete(sessionId);
-		this._prDetectionLastChecked.delete(sessionId);
 	}
 
 	public async refreshSession(refreshOptions: { reason: 'update'; sessionId: string } | { reason: 'delete'; sessionId: string }): Promise<void> {
@@ -382,17 +369,6 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 		// Status
 		const status = session.status ?? vscode.ChatSessionStatus.Completed;
 
-		// Async PR detection for completed sessions without a pull request URL.
-		// Sessions are collected and checked in a debounced batch to avoid
-		// excessive API calls when the session list refreshes rapidly.
-		if (this.shouldDetectPullRequest(session.id, status, worktreeProperties, changes)) {
-			this._prDetectionPendingSessions.set(session.id, {
-				branchName: worktreeProperties!.branchName,
-				repositoryPath: worktreeProperties!.repositoryPath,
-			});
-			this._prDetectionDelayer.trigger(async () => this.processPendingPrDetections()).catch(() => { /* expected on dispose */ });
-		}
-
 		// Metadata
 		const metadata = worktreeProperties
 			? {
@@ -406,6 +382,9 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 				worktreePath: worktreeProperties?.worktreePath,
 				pullRequestUrl: worktreeProperties.version === 2
 					? worktreeProperties.pullRequestUrl
+					: undefined,
+				pullRequestState: worktreeProperties.version === 2
+					? worktreeProperties.pullRequestState
 					: undefined,
 				firstCheckpointRef: worktreeProperties.version === 2
 					? worktreeProperties.firstCheckpointRef
@@ -432,84 +411,43 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 	}
 
 	/**
-	 * Processes all pending PR detection requests in a single batch.
-	 * Called by the debounced delayer after rapid-fire `toChatSessionItem` calls settle.
+	 * Detects a pull request for a session when the user opens it.
+	 * If a PR is found, persists the URL and notifies the UI.
 	 */
-	private async processPendingPrDetections(): Promise<void> {
-		const pending = new Map(this._prDetectionPendingSessions);
-		this._prDetectionPendingSessions.clear();
+	public async detectPullRequestOnSessionOpen(sessionId: string): Promise<void> {
+		try {
+			const worktreeProperties = await this.copilotCLIWorktreeManagerService.getWorktreeProperties(sessionId);
+			if (worktreeProperties?.version !== 2
+				|| worktreeProperties.pullRequestState === 'merged'
+				|| !worktreeProperties.branchName
+				|| !worktreeProperties.repositoryPath) {
+				return;
+			}
 
-		for (const [sessionId, { branchName, repositoryPath }] of pending) {
-			try {
-				const prUrl = await detectPullRequestFromGitHubAPI(
-					branchName,
-					repositoryPath,
-					this.gitService,
-					this.octoKitService,
-					this.logService,
-				);
+			const prResult = await detectPullRequestFromGitHubAPI(
+				worktreeProperties.branchName,
+				worktreeProperties.repositoryPath,
+				this.gitService,
+				this.octoKitService,
+				this.logService,
+			);
 
-				if (prUrl) {
-					const currentProperties = await this.copilotCLIWorktreeManagerService.getWorktreeProperties(sessionId);
-					if (currentProperties?.version === 2 && !currentProperties.pullRequestUrl) {
-						const updated: typeof currentProperties = {
-							...currentProperties,
-							pullRequestUrl: prUrl,
-							changes: undefined,
-						};
-						await this.copilotCLIWorktreeManagerService.setWorktreeProperties(sessionId, updated);
-						this.refreshSession({ reason: 'update', sessionId });
-					}
-
-					// Mark permanently only after the PR URL has been persisted successfully.
-					this._prDetectionDone.add(sessionId);
-					this._prDetectionLastChecked.delete(sessionId);
-				} else {
-					// No PR yet — record the timestamp so we can re-check after a cooldown.
-					this._prDetectionLastChecked.set(sessionId, Date.now());
+			if (prResult) {
+				const currentProperties = await this.copilotCLIWorktreeManagerService.getWorktreeProperties(sessionId);
+				if (currentProperties?.version === 2
+					&& (currentProperties.pullRequestUrl !== prResult.url || currentProperties.pullRequestState !== prResult.state)) {
+					await this.copilotCLIWorktreeManagerService.setWorktreeProperties(sessionId, {
+						...currentProperties,
+						pullRequestUrl: prResult.url,
+						pullRequestState: prResult.state,
+						changes: undefined,
+					});
+					await this.refreshSession({ reason: 'update', sessionId });
 				}
-			} catch (error) {
-				// Do not record a timestamp — the session will be retried on the next refresh.
-				this.logService.debug(`[CopilotCLIChatSessionItemProvider] Failed to detect pull request via GitHub API for session ${sessionId}, will retry: ${error instanceof Error ? error.message : String(error)}`);
 			}
+		} catch (error) {
+			this.logService.trace(`[CopilotCLIChatSessionItemProvider] Failed to detect pull request on session open for ${sessionId}: ${error instanceof Error ? error.message : String(error)}`);
 		}
-	}
-
-	/**
-	 * Determines whether a session is a candidate for async PR detection.
-	 * Skips sessions that are not completed, not v2 worktrees, already have a
-	 * PR URL, have no file changes, or have already been checked.
-	 */
-	private shouldDetectPullRequest(
-		sessionId: string,
-		status: vscode.ChatSessionStatus,
-		worktreeProperties: Awaited<ReturnType<IChatSessionWorktreeService['getWorktreeProperties']>>,
-		changes: readonly vscode.ChatSessionChangedFile2[],
-	): boolean {
-		if (status !== vscode.ChatSessionStatus.Completed
-			|| worktreeProperties?.version !== 2
-			|| worktreeProperties.pullRequestUrl
-			|| !worktreeProperties.branchName
-			|| !worktreeProperties.repositoryPath
-			|| changes.length === 0) {
-			return false;
-		}
-
-		// Skip sessions where a PR was already found.
-		if (this._prDetectionDone.has(sessionId)) {
-			return false;
-		}
-
-		// Allow re-checking after a cooldown so PRs created after session completion are detected.
-		const lastChecked = this._prDetectionLastChecked.get(sessionId);
-		if (lastChecked !== undefined) {
-			const elapsed = Date.now() - lastChecked;
-			if (elapsed < CopilotCLIChatSessionContentProvider._PR_DETECTION_RECHECK_INTERVAL) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 
 	public notifySessionOptionsChange(resource: vscode.Uri, updates: ReadonlyArray<{ optionId: string; value: string | vscode.ChatSessionProviderOptionItem }>): void {
@@ -564,6 +502,10 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 	async provideChatSessionContentForExistingSession(resource: Uri, token: vscode.CancellationToken): Promise<vscode.ChatSession> {
 		const copilotcliSessionId = SessionIdForCLI.parse(resource);
 		this._currentSessionId = copilotcliSessionId;
+
+		// Fire-and-forget: detect PR when the user opens a session.
+		void this.detectPullRequestOnSessionOpen(copilotcliSessionId);
+
 		const folderRepo = await this.folderRepositoryManager.getFolderRepository(copilotcliSessionId, undefined, token);
 		const [history, title] = await Promise.all([
 			this.getSessionHistory(copilotcliSessionId, folderRepo, token),
@@ -1485,9 +1427,12 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 
 	private async handlePullRequestCreated(session: ICopilotCLISession): Promise<void> {
 		let prUrl = session.createdPullRequestUrl;
+		let prState: string | undefined;
 
 		if (!prUrl) {
-			prUrl = await this.detectPullRequestForSession(session.sessionId);
+			const detectedPr = await this.detectPullRequestForSession(session.sessionId);
+			prUrl = detectedPr?.url;
+			prState = detectedPr?.state;
 		}
 
 		if (!prUrl) {
@@ -1500,6 +1445,7 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 				await this.copilotCLIWorktreeManagerService.setWorktreeProperties(session.sessionId, {
 					...worktreeProperties,
 					pullRequestUrl: prUrl,
+					pullRequestState: prState,
 					changes: undefined,
 				});
 				await this.contentProvider.refreshSession({ reason: 'update', sessionId: session.sessionId });
@@ -1514,7 +1460,7 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 	 * session's worktree branch. This covers cases where the MCP tool failed to
 	 * report a PR URL, or the user created the PR externally (e.g., via github.com).
 	 */
-	private async detectPullRequestForSession(sessionId: string): Promise<string | undefined> {
+	private async detectPullRequestForSession(sessionId: string): Promise<{ url: string; state: string } | undefined> {
 		try {
 			const worktreeProperties = await this.copilotCLIWorktreeManagerService.getWorktreeProperties(sessionId);
 			if (!worktreeProperties?.branchName || !worktreeProperties.repositoryPath) {
@@ -2528,7 +2474,7 @@ async function detectPullRequestFromGitHubAPI(
 	gitService: IGitService,
 	octoKitService: IOctoKitService,
 	logService: ILogService,
-): Promise<string | undefined> {
+): Promise<{ url: string; state: string } | undefined> {
 	const repoContext = await gitService.getRepository(URI.file(repositoryPath));
 	if (!repoContext) {
 		return undefined;
@@ -2547,8 +2493,9 @@ async function detectPullRequestFromGitHubAPI(
 	);
 
 	if (pr?.url) {
-		logService.trace(`[detectPullRequestFromGitHubAPI] Detected pull request via GitHub API: ${pr.url}`);
-		return pr.url;
+		const prState = derivePullRequestState(pr);
+		logService.trace(`[detectPullRequestFromGitHubAPI] Detected pull request via GitHub API: ${pr.url} ${prState}`);
+		return { url: pr.url, state: prState };
 	}
 
 	return undefined;

--- a/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessions.spec.ts
+++ b/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessions.spec.ts
@@ -1,0 +1,307 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as vscode from 'vscode';
+// eslint-disable-next-line no-duplicate-imports
+import * as vscodeShim from 'vscode';
+vi.mock('../copilotCLIShim.ps1', () => ({ default: '# mock powershell script' }));
+import { InMemoryConfigurationService } from '../../../../platform/configuration/test/common/inMemoryConfigurationService';
+import { IRunCommandExecutionService } from '../../../../platform/commands/common/runCommandExecutionService';
+import { DefaultsOnlyConfigurationService } from '../../../../platform/configuration/common/defaultsOnlyConfigurationService';
+import { IVSCodeExtensionContext } from '../../../../platform/extContext/common/extensionContext';
+import { IFileSystemService } from '../../../../platform/filesystem/common/fileSystemService';
+import { IGitService, RepoContext } from '../../../../platform/git/common/gitService';
+import { PullRequestSearchItem } from '../../../../platform/github/common/githubAPI';
+import { IOctoKitService } from '../../../../platform/github/common/githubService';
+import { ILogService } from '../../../../platform/log/common/logService';
+import { MockExtensionContext } from '../../../../platform/test/node/extensionContext';
+import { IWorkspaceService, NullWorkspaceService } from '../../../../platform/workspace/common/workspaceService';
+import { mock } from '../../../../util/common/test/simpleMock';
+import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
+import { Event } from '../../../../util/vs/base/common/event';
+import { Disposable } from '../../../../util/vs/base/common/lifecycle';
+import { URI } from '../../../../util/vs/base/common/uri';
+import { IChatSessionWorkspaceFolderService } from '../../common/chatSessionWorkspaceFolderService';
+import { ChatSessionWorktreeProperties, IChatSessionWorktreeService } from '../../common/chatSessionWorktreeService';
+import { IFolderRepositoryManager } from '../../common/folderRepositoryManager';
+import { emptyWorkspaceInfo } from '../../common/workspaceInfo';
+import { ICustomSessionTitleService } from '../../copilotcli/common/customSessionTitleService';
+import { ICopilotCLIAgents } from '../../copilotcli/node/copilotCli';
+import { ICopilotCLISession } from '../../copilotcli/node/copilotcliSession';
+import { ICopilotCLISessionService } from '../../copilotcli/node/copilotcliSessionService';
+import { ICopilotCLISessionTracker } from '../../copilotcli/vscode-node/copilotCLISessionTracker';
+import { CopilotCLIChatSessionContentProvider } from '../copilotCLIChatSessions';
+import { ICopilotCLITerminalIntegration } from '../copilotCLITerminalIntegration';
+
+beforeAll(() => {
+	(vscodeShim as Record<string, unknown>).chat = {
+		createChatSessionItemController: () => ({
+			id: 'copilotcli',
+			items: {
+				get: () => undefined,
+				add: () => { },
+				delete: () => { },
+				replace: () => { },
+				[Symbol.iterator]: function* () { },
+				forEach: () => { },
+			},
+			createChatSessionItem: (resource: vscode.Uri, label: string): vscode.ChatSessionItem => ({ resource, label }),
+			dispose: () => { },
+		}),
+	};
+});
+
+class TestAgentsService extends mock<ICopilotCLIAgents>() {
+	declare readonly _serviceBrand: undefined;
+	override onDidChangeAgents = Event.None;
+}
+
+class TestSessionService extends mock<ICopilotCLISessionService>() {
+	declare readonly _serviceBrand: undefined;
+	override onDidChangeSessions = Event.None;
+	override onDidDeleteSession = Event.None;
+	override onDidChangeSession = Event.None;
+	override onDidCreateSession = Event.None;
+	override getSessionWorkingDirectory = vi.fn(() => undefined);
+	override getSessionItem = vi.fn(async () => undefined);
+	override getAllSessions = vi.fn(async () => []);
+	override createNewSessionId = vi.fn(() => 'new-session');
+	override isNewSessionId = vi.fn(() => false);
+	override deleteSession = vi.fn(async () => { });
+	override renameSession = vi.fn(async () => { });
+	override getSession = vi.fn(async () => ({
+		object: {
+			sessionId: 'session-1',
+			workspace: emptyWorkspaceInfo,
+			getChatHistory: async () => [],
+		},
+		dispose: () => { },
+	} as unknown as { object: ICopilotCLISession; dispose(): void }));
+	override createSession = vi.fn(async () => {
+		throw new Error('Not implemented');
+	});
+	override forkSession = vi.fn(async () => 'forked-session');
+	override tryGetPartialSesionHistory = vi.fn(async () => undefined);
+}
+
+class TestWorktreeService extends mock<IChatSessionWorktreeService>() {
+	declare readonly _serviceBrand: undefined;
+	override getWorktreeProperties = vi.fn(async (_sessionId: string | vscode.Uri): Promise<ChatSessionWorktreeProperties | undefined> => undefined);
+	override setWorktreeProperties = vi.fn(async () => { });
+	override getWorktreeChanges = vi.fn(async () => []);
+}
+
+class TestWorkspaceFolderService extends mock<IChatSessionWorkspaceFolderService>() {
+	declare readonly _serviceBrand: undefined;
+	override getWorkspaceChanges = vi.fn(async () => []);
+}
+
+class TestFolderRepositoryManager extends mock<IFolderRepositoryManager>() {
+	declare readonly _serviceBrand: undefined;
+	override setNewSessionFolder = vi.fn();
+	override deleteNewSessionFolder = vi.fn();
+	override getFolderRepository = vi.fn(async () => ({
+		folder: undefined,
+		repository: undefined,
+		worktree: undefined,
+		worktreeProperties: undefined,
+		trusted: undefined,
+	}));
+	override initializeFolderRepository = vi.fn(async () => ({
+		folder: undefined,
+		repository: undefined,
+		worktree: undefined,
+		worktreeProperties: undefined,
+		trusted: undefined,
+	}));
+	override getRepositoryInfo = vi.fn(async () => ({ repository: undefined, headBranchName: undefined }));
+	override getFolderMRU = vi.fn(async () => []);
+	override deleteMRUEntry = vi.fn(async () => { });
+}
+
+class TestGitService extends mock<IGitService>() {
+	declare readonly _serviceBrand: undefined;
+	override onDidOpenRepository = Event.None;
+	override onDidCloseRepository = Event.None;
+	override onDidFinishInitialization = Event.None;
+	override activeRepository = { get: () => undefined } as IGitService['activeRepository'];
+	override repositories: RepoContext[] = [];
+
+	setRepo(repo: RepoContext): void {
+		this.repositories = [repo];
+	}
+
+	override getRepository = vi.fn(async () => this.repositories[0]);
+}
+
+class TestOctoKitService extends mock<IOctoKitService>() {
+	declare readonly _serviceBrand: undefined;
+	override findPullRequestByHeadBranch = vi.fn(async (): Promise<PullRequestSearchItem | undefined> => undefined);
+}
+
+class TestSessionTracker extends mock<ICopilotCLISessionTracker>() {
+	declare readonly _serviceBrand: undefined;
+	override getSessionIds = vi.fn(() => []);
+	override getTerminal = vi.fn(async () => undefined);
+}
+
+class TestTerminalIntegration extends Disposable implements ICopilotCLITerminalIntegration {
+	declare readonly _serviceBrand: undefined;
+	openTerminal = vi.fn(async () => undefined);
+	setTerminalSessionDir = vi.fn();
+	setSessionDirResolver = vi.fn();
+}
+
+class TestRunCommandExecutionService extends mock<IRunCommandExecutionService>() {
+	declare readonly _serviceBrand: undefined;
+	override executeCommand = vi.fn(async () => undefined);
+}
+
+class TestCustomSessionTitleService extends mock<ICustomSessionTitleService>() {
+	declare readonly _serviceBrand: undefined;
+	override getCustomSessionTitle = vi.fn(async () => 'Session Title');
+	override setCustomSessionTitle = vi.fn(async () => { });
+	override generateSessionTitle = vi.fn(async () => undefined);
+}
+
+function createProvider() {
+	const agents = new TestAgentsService();
+	const sessionService = new TestSessionService();
+	const worktreeService = new TestWorktreeService();
+	const workspaceService = new NullWorkspaceService([URI.file('/workspace')]);
+	const fileSystem = new class extends mock<IFileSystemService>() { declare readonly _serviceBrand: undefined; }();
+	const gitService = new TestGitService();
+	const folderRepositoryManager = new TestFolderRepositoryManager();
+	const configurationService = new InMemoryConfigurationService(new DefaultsOnlyConfigurationService());
+	const customSessionTitleService = new TestCustomSessionTitleService();
+	const context = new MockExtensionContext() as unknown as IVSCodeExtensionContext;
+	const sessionTracker = new TestSessionTracker();
+	const terminalIntegration = new TestTerminalIntegration();
+	const commandExecutionService = new TestRunCommandExecutionService();
+	const workspaceFolderService = new TestWorkspaceFolderService();
+	const octoKitService = new TestOctoKitService();
+	const logService = new class extends mock<ILogService>() {
+		declare readonly _serviceBrand: undefined;
+		override trace = vi.fn();
+		override error = vi.fn();
+	}();
+
+	const provider = new CopilotCLIChatSessionContentProvider(
+		agents,
+		sessionService,
+		worktreeService,
+		workspaceService as IWorkspaceService,
+		fileSystem,
+		gitService,
+		folderRepositoryManager,
+		configurationService,
+		customSessionTitleService,
+		context,
+		sessionTracker,
+		terminalIntegration,
+		commandExecutionService,
+		workspaceFolderService,
+		octoKitService,
+		logService,
+	);
+
+	return {
+		provider,
+		sessionService,
+		worktreeService,
+		gitService,
+		octoKitService,
+	};
+}
+
+describe('CopilotCLIChatSessionContentProvider', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('triggers pull request detection when opening an existing session', async () => {
+		const { provider } = createProvider();
+		const detectSpy = vi.spyOn(provider, 'detectPullRequestOnSessionOpen').mockResolvedValue();
+
+		await provider.provideChatSessionContentForExistingSession(
+			URI.from({ scheme: 'copilotcli', path: '/session-1' }),
+			CancellationToken.None,
+		);
+
+		expect(detectSpy).toHaveBeenCalledWith('session-1');
+	});
+
+	it('persists detected pull request url and state on session open', async () => {
+		const { provider, worktreeService, gitService, octoKitService } = createProvider();
+		const refreshSpy = vi.spyOn(provider, 'refreshSession').mockResolvedValue();
+		const worktreeProperties: ChatSessionWorktreeProperties = {
+			version: 2,
+			baseCommit: 'abc123',
+			baseBranchName: 'main',
+			branchName: 'copilot/test-branch',
+			repositoryPath: '/repo',
+			worktreePath: '/worktree',
+		};
+
+		worktreeService.getWorktreeProperties.mockResolvedValue(worktreeProperties);
+		gitService.setRepo({
+			rootUri: URI.file('/repo'),
+			kind: 'repository',
+			remotes: ['origin'],
+			remoteFetchUrls: ['https://github.com/testowner/testrepo.git'],
+		} as unknown as RepoContext);
+		octoKitService.findPullRequestByHeadBranch.mockResolvedValue({
+			id: 'pr-42',
+			number: 42,
+			title: 'Test PR',
+			url: 'https://github.com/testowner/testrepo/pull/42',
+			state: 'OPEN',
+			isDraft: false,
+			createdAt: '2026-01-01T00:00:00Z',
+			updatedAt: '2026-01-01T00:00:00Z',
+			author: { login: 'testowner' },
+			repository: { owner: { login: 'testowner' }, name: 'testrepo' },
+			additions: 1,
+			deletions: 0,
+			files: { totalCount: 1 },
+			fullDatabaseId: 42,
+			headRefOid: 'deadbeef',
+			headRefName: 'copilot/test-branch',
+			body: '',
+		});
+
+		await provider.detectPullRequestOnSessionOpen('session-1');
+
+		expect(worktreeService.setWorktreeProperties).toHaveBeenCalledWith(
+			'session-1',
+			expect.objectContaining({
+				pullRequestUrl: 'https://github.com/testowner/testrepo/pull/42',
+				pullRequestState: 'open',
+			}),
+		);
+		expect(refreshSpy).toHaveBeenCalledWith({ reason: 'update', sessionId: 'session-1' });
+	});
+
+	it('skips session-open detection for merged pull requests', async () => {
+		const { provider, worktreeService, octoKitService } = createProvider();
+		const mergedProperties: ChatSessionWorktreeProperties = {
+			version: 2,
+			baseCommit: 'abc123',
+			baseBranchName: 'main',
+			branchName: 'copilot/test-branch',
+			repositoryPath: '/repo',
+			worktreePath: '/worktree',
+			pullRequestState: 'merged',
+		};
+
+		worktreeService.getWorktreeProperties.mockResolvedValue(mergedProperties);
+
+		await provider.detectPullRequestOnSessionOpen('session-1');
+
+		expect(octoKitService.findPullRequestByHeadBranch).not.toHaveBeenCalled();
+		expect(worktreeService.setWorktreeProperties).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What changed

- ported the PR detection flow in `chatSessions/vscode-node/copilotCLIChatSessions.ts` to match PR #4699
- removed the old refresh-time/debounced PR detection path
- trigger PR detection when an existing Copilot CLI session is opened instead
- persist both `pullRequestUrl` and `pullRequestState` when detection succeeds
- added focused unit coverage for the new session-open behavior

## Why

The newer node-side chat sessions file still had the older background refresh-based detection logic. This brings it in sync with the behavior already introduced elsewhere so PR metadata is discovered at session open time and state stays consistent.

## Validation

- `npm run compile`
- `npm run lint`
- `npm run test:unit -- src/extension/chatSessions/vscode-node/test/copilotCLIChatSessions.spec.ts`

## Reviewer notes

- the new tests mock `copilotCLIShim.ps1` the same way other terminal-related specs do so Vitest can import the module cleanly
- `handlePullRequestCreated` was also updated to preserve `pullRequestState` for consistency with the session-open detection path