### PR TITLE
nes: patch-based: fix: set correct edit window for cached items (#4702)

### DIFF
--- a/src/extension/xtab/common/promptCrafting.ts
+++ b/src/extension/xtab/common/promptCrafting.ts
@@ -376,11 +376,11 @@ export function clipPreservingRange(
 	return Result.ok(new OffsetRange(linesOffsetStart, linesOffsetEndExcl));
 }
 
-class ClippedDocument {
+export class ClippedDocument {
 	constructor(
 		/** The lines of the document that were kept after clipping. */
 		public readonly lines: string[],
-		/** The range in the original document that corresponds to the kept lines. */
+		/** The line range in the original document that corresponds to the kept lines. */
 		public readonly keptRange: OffsetRange,
 	) { }
 }

--- a/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
+++ b/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
@@ -78,10 +78,9 @@ export class XtabCustomDiffPatchResponseHandler {
 					: XtabCustomDiffPatchResponseHandler.resolveTargetDocument(edit.filePath, workspaceRoot) ?? activeDocumentId; // FIXME@ulugbekna: it's wrong to fallback to active document but just ignoring edits is also bad
 				yield {
 					edit: XtabCustomDiffPatchResponseHandler.resolveEdit(edit),
-					window,
-					originalWindow,
-					isFromCursorJump: true,
+					isFromCursorJump: false,
 					targetDocument,
+					window,
 				} satisfies StreamedEdit;
 			}
 		} catch (e: unknown) {

--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -58,7 +58,7 @@ import { UserInteractionMonitor } from '../../inlineEdits/common/userInteraction
 import { IgnoreImportChangesAspect } from '../../inlineEdits/node/importFiltering';
 import { isInlineSuggestion } from '../common/inlineSuggestion';
 import { LintErrors } from '../common/lintErrors';
-import { constructTaggedFile, getUserPrompt, N_LINES_ABOVE, N_LINES_AS_CONTEXT, N_LINES_BELOW, PromptPieces } from '../common/promptCrafting';
+import { ClippedDocument, constructTaggedFile, getUserPrompt, N_LINES_ABOVE, N_LINES_AS_CONTEXT, N_LINES_BELOW, PromptPieces } from '../common/promptCrafting';
 import { countTokensForLines, toUniquePath } from '../common/promptCraftingUtils';
 import { ISimilarFilesContextService } from '../common/similarFilesContextService';
 import { nes41Miniv3SystemPrompt, simplifiedPrompt, systemPromptTemplate, unifiedModelSystemPrompt, xtab275SystemPrompt } from '../common/systemMessages';
@@ -405,6 +405,8 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			endpoint,
 			modelServiceConfig,
 			messages,
+			currentDocument,
+			clippedTaggedCurrentDoc,
 			editWindow,
 			editWindowLines,
 			cursorOriginalLinesOffset,
@@ -585,6 +587,8 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		endpoint: IChatEndpoint,
 		modelServiceConfig: xtabPromptOptions.ModelConfiguration,
 		messages: Raw.ChatMessage[],
+		currentDocument: CurrentDocument,
+		clippedTaggedCurrentDoc: ClippedDocument,
 		editWindow: OffsetRange,
 		editWindowLines: string[],
 		cursorOriginalLinesOffset: number,
@@ -613,6 +617,8 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			endpoint,
 			modelServiceConfig,
 			messages,
+			currentDocument,
+			clippedTaggedCurrentDoc,
 			editWindow,
 			editWindowLines,
 			cursorOriginalLinesOffset,
@@ -661,6 +667,8 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		endpoint: IChatEndpoint,
 		modelServiceConfig: xtabPromptOptions.ModelConfiguration,
 		messages: Raw.ChatMessage[],
+		currentDocument: CurrentDocument,
+		clippedTaggedCurrentDoc: ClippedDocument,
 		editWindow: OffsetRange,
 		editWindowLines: string[],
 		cursorOriginalLinesOffset: number,
@@ -833,13 +841,15 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			cleanedLinesStream = remainingLinesStream;
 		} else if (opts.responseFormat === xtabPromptOptions.ResponseFormat.CustomDiffPatch) {
 			const activeDoc = request.getActiveDocument();
+			const lastLine = currentDocument.lines[clippedTaggedCurrentDoc.keptRange.endExclusive - 1];
+			const lastLineLength = lastLine.length;
+			const pseudoEditWindow = currentDocument.transformer.getOffsetRange(new Range(clippedTaggedCurrentDoc.keptRange.start + 1, 1, clippedTaggedCurrentDoc.keptRange.endExclusive, lastLineLength + 1));
 			return yield* XtabCustomDiffPatchResponseHandler.handleResponse(
 				linesStream,
 				request.documentBeforeEdits,
 				activeDoc.id,
 				activeDoc.workspaceRoot,
-				editWindow,
-				originalEditWindow,
+				pseudoEditWindow,
 			);
 		} else if (opts.responseFormat === xtabPromptOptions.ResponseFormat.UnifiedWithXml) {
 			const linesIter = linesStream[Symbol.asyncIterator]();


### PR DESCRIPTION
fix #4702

fixes https://github.com/microsoft/vscode/issues/305169