### PR TITLE
Early exclude a few more code dirs

### DIFF
--- a/src/platform/workspaceChunkSearch/node/workspaceFileIndex.ts
+++ b/src/platform/workspaceChunkSearch/node/workspaceFileIndex.ts
@@ -153,16 +153,40 @@ const EXCLUDE_EXTENSIONS = new Set([
 ]);
 
 const EXCLUDED_FOLDERS = [
-	'node_modules',
-	'venv',
 	'out',
 	'dist',
 	'.git',
+	'.svn',
+	'.hg',
 	'.yarn',
-	'.npm',
-	'.venv',
+
 	'foo.asar',
 	'.vscode-test',
+
+	// JS/TS build outputs
+	'node_modules',
+	'bower_components',
+	'.next',
+	'.npm',
+	'.nuxt',
+	'.turbo',
+	'.parcel-cache',
+
+	// Python
+	'__pycache__',
+	'venv',
+	'.venv',
+
+	'.mypy_cache',
+	'.pytest_cache',
+	'.ruff_cache',
+	'.tox',
+
+	// Other
+	'Pods',
+	'.gradle',
+	'.terraform',
+	'.nyc_output',
 ];
 
 const EXCLUDED_FILES = [


### PR DESCRIPTION
Files in these dirs should not be indexed. We already filter these out for external ingest but can do this earlier in the process 