### PR TITLE
PromptsServiceImpl: avoid using openTextDocument to not trigger validation

### DIFF
--- a/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
+++ b/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
@@ -413,7 +413,7 @@ describe('CopilotCLIChatSessionParticipant.handleRequest', () => {
 			workspaceFolderService,
 			telemetry,
 			logger,
-			new PromptsServiceImpl(new NullWorkspaceService()),
+			new PromptsServiceImpl(new NullWorkspaceService(), fileSystem),
 			delegationService,
 			folderRepositoryManager,
 			configurationService,
@@ -758,7 +758,7 @@ describe('CopilotCLIChatSessionParticipant.handleRequest', () => {
 			workspaceFolderService,
 			telemetry,
 			logService,
-			new PromptsServiceImpl(new NullWorkspaceService()),
+			new PromptsServiceImpl(new NullWorkspaceService(), new MockFileSystemService()),
 			new class extends mock<IChatDelegationSummaryService>() {
 				override async summarize(_context: vscode.ChatContext, _token: vscode.CancellationToken): Promise<string | undefined> {
 					return undefined;
@@ -1903,7 +1903,7 @@ describe('CopilotCLIChatSessionParticipant.handleRequest', () => {
 				workspaceFolderService,
 				telemetry,
 				logService,
-				new PromptsServiceImpl(new NullWorkspaceService()),
+				new PromptsServiceImpl(new NullWorkspaceService(), new MockFileSystemService()),
 				nullDelegationService,
 				folderRepositoryManager,
 				configurationService,

--- a/src/platform/promptFiles/common/promptsServiceImpl.ts
+++ b/src/platform/promptFiles/common/promptsServiceImpl.ts
@@ -5,19 +5,33 @@
 
 import { raceCancellationError } from '../../../util/vs/base/common/async';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
+import { extUriBiasedIgnorePathCase } from '../../../util/vs/base/common/resources';
 import { URI } from '../../../util/vs/base/common/uri';
 import { PromptFileParser } from '../../../util/vs/workbench/contrib/chat/common/promptSyntax/promptFileParser';
+import { IFileSystemService } from '../../filesystem/common/fileSystemService';
 import { IWorkspaceService } from '../../workspace/common/workspaceService';
 import { IPromptsService, ParsedPromptFile } from './promptsService';
 
 export class PromptsServiceImpl implements IPromptsService {
 	declare _serviceBrand: undefined;
 	constructor(
-		@IWorkspaceService private readonly workspaceService: IWorkspaceService
+		@IWorkspaceService private readonly workspaceService: IWorkspaceService,
+		@IFileSystemService private readonly fileService: IFileSystemService,
 	) { }
 
 	public async parseFile(uri: URI, token: CancellationToken): Promise<ParsedPromptFile> {
-		const doc = await raceCancellationError(this.workspaceService.openTextDocument(uri), token);
-		return new PromptFileParser().parse(uri, doc.getText());
+		// a temporary workaround to avoid the creating text document to read the file content, which triggers the validation of the file in core (fixed in 1.114)
+		const getTextContent = async (uri: URI) => {
+			const existingDoc = this.workspaceService.textDocuments.find(doc => extUriBiasedIgnorePathCase.isEqual(doc.uri, uri));
+			if (!existingDoc) {
+				// if the document is not already open in the workspace, check if the file exists on disk before trying to open it, to avoid triggering unwanted "file not found" errors from the text document service
+				const bytes = await this.fileService.readFile(uri);
+				return new TextDecoder().decode(bytes);
+			} else {
+				return existingDoc.getText();
+			}
+		};
+		const text = await raceCancellationError(getTextContent(uri), token);
+		return new PromptFileParser().parse(uri, text);
 	}
 }


### PR DESCRIPTION
This avoids TextDocuments beeing created and validations beeing triggered.
Temporary fix for https://github.com/microsoft/vscode/issues/304778 and https://github.com/microsoft/vscode/issues/304857

PromptsServiceImpl.parseFile is only used by the CLI SDK since last week. The change can have negative side effect, e.g. when agent files/prompt files use different encodings.
The change will be reverted for 1.114 (next week) with a proper fix in the validation and change event triggering