### PR TITLE
fix: use os.devNull for OTel null sink

### DIFF
--- a/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
+++ b/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
@@ -7,7 +7,7 @@ import type { internal, LocalSessionMetadata, Session, SessionContext, SessionEv
 import * as l10n from '@vscode/l10n';
 import { createReadStream } from 'node:fs';
 import * as fs from 'node:fs/promises';
-import { EOL } from 'node:os';
+import { devNull, EOL } from 'node:os';
 import { createInterface } from 'node:readline';
 import type { ChatRequest, ChatSessionItem } from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
@@ -177,7 +177,7 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 					// Use file exporter to /dev/null so the SDK creates OtelSessionTracker
 					// (for debug panel) but writes spans nowhere.
 					process.env['COPILOT_OTEL_EXPORTER_TYPE'] = 'file';
-					process.env['COPILOT_OTEL_FILE_EXPORTER_PATH'] = process.platform === 'win32' ? 'NUL' : '/dev/null';
+					process.env['COPILOT_OTEL_FILE_EXPORTER_PATH'] = devNull;
 				}
 				return new internal.LocalSessionManager({ telemetryService: new internal.NoopTelemetryService(), flushDebounceMs: undefined, settings: undefined, version: undefined });
 			}


### PR DESCRIPTION
## Problem

When user OTel is disabled (the default), the Copilot CLI session service forces a file exporter to a null sink so the SDK creates `OtelSessionTracker` for the debug panel without exporting to any collector.

On Windows, the path was set to the bare string `'NUL'`:
```typescript
process.env['COPILOT_OTEL_FILE_EXPORTER_PATH'] = process.platform === 'win32' ? 'NUL' : '/dev/null';
```

However, Node.js's `fs.openSync('NUL', 'a')` treats `NUL` as a **relative path** and creates a literal file named `NUL` in `process.cwd()` — which for VS Code is the app install folder (`AppData\Local\Programs\Microsoft VS Code Insiders\`). This file accumulates ~1.4MB of OTel JSON-lines telemetry data per agent session, and its presence in the install directory triggers VS Code update errors.

Tracked in https://github.com/microsoft/vscode/issues/304313

## Fix

Replace the manual platform conditional with Node.js's built-in `os.devNull` (available since Node 16), which returns `\\.\nul` on Windows and `/dev/null` on Unix — both of which are correctly handled by `fs.openSync` as null device paths.

## Verification

- ✅ TypeScript compilation: 0 errors
- ✅ `os.devNull` correctly resolves and accepts writes without creating files (verified on Linux)
- ⏳ Windows: needs manual verification that no `NUL` file is created in the VS Code install folder after an agent session