### PR TITLE
feat: formalize deferred vs non-deferred tool status as opt-in on ICopilotTools

### DIFF
--- a/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -10,7 +10,8 @@ import { ChatFetchResponseType, ChatLocation } from '../../../platform/chat/comm
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { CustomDataPartMimeTypes } from '../../../platform/endpoint/common/endpointTypes';
 import { ILogService } from '../../../platform/log/common/logService';
-import { ContextManagementResponse, getContextManagementFromConfig, isAnthropicContextEditingEnabled, isAnthropicMemoryToolEnabled, isAnthropicToolSearchEnabled, nonDeferredToolNames, TOOL_SEARCH_TOOL_NAME, TOOL_SEARCH_TOOL_TYPE, ToolSearchToolResult, ToolSearchToolSearchResult } from '../../../platform/networking/common/anthropic';
+import { ContextManagementResponse, getContextManagementFromConfig, isAnthropicContextEditingEnabled, isAnthropicMemoryToolEnabled, isAnthropicToolSearchEnabled, TOOL_SEARCH_TOOL_NAME, TOOL_SEARCH_TOOL_TYPE, ToolSearchToolResult, ToolSearchToolSearchResult } from '../../../platform/networking/common/anthropic';
+import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
 import { IResponseDelta, OpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { APIUsage } from '../../../platform/networking/common/openai';
 import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, type OTelModelOptions, StdAttr, truncateForOTel } from '../../../platform/otel/common/index';
@@ -39,6 +40,7 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 		@IExperimentationService private readonly _experimentationService: IExperimentationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IOTelService private readonly _otelService: IOTelService,
+		@IToolDeferralService private readonly _toolDeferralService: IToolDeferralService,
 	) {
 		super(AnthropicLMProvider.providerName.toLowerCase(), AnthropicLMProvider.providerName, knownModels, byokStorageService, logService);
 
@@ -168,7 +170,7 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 				}
 
 				// Mark tools for deferred loading when tool search is enabled, except for frequently used tools
-				const shouldDefer = toolSearchEnabled ? !nonDeferredToolNames.has(tool.name) : undefined;
+				const shouldDefer = toolSearchEnabled ? !this._toolDeferralService.isNonDeferredTool(tool.name) : undefined;
 
 				if (!tool.inputSchema) {
 					tools.push({
@@ -205,7 +207,7 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 				const allowedDomains = this._configurationService.getConfig(ConfigKey.AnthropicWebSearchAllowedDomains);
 				const blockedDomains = this._configurationService.getConfig(ConfigKey.AnthropicWebSearchBlockedDomains);
 				const userLocation = this._configurationService.getConfig(ConfigKey.AnthropicWebSearchUserLocation);
-				const shouldDeferWebSearch = toolSearchEnabled ? !nonDeferredToolNames.has('web_search') : undefined;
+				const shouldDeferWebSearch = toolSearchEnabled ? !this._toolDeferralService.isNonDeferredTool('web_search') : undefined;
 
 				const webSearchTool: Anthropic.Beta.BetaWebSearchTool20250305 = {
 					name: 'web_search',

--- a/src/extension/extension/vscode-node/services.ts
+++ b/src/extension/extension/vscode-node/services.ts
@@ -136,6 +136,8 @@ import { FixCookbookService, IFixCookbookService } from '../../prompts/node/inli
 import { WorkspaceMutationManager } from '../../testing/node/setupTestsFileManager';
 import { AgentMemoryService, IAgentMemoryService } from '../../tools/common/agentMemoryService';
 import { IMemoryCleanupService, MemoryCleanupService } from '../../tools/common/memoryCleanupService';
+import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
+import { ToolDeferralService } from '../../tools/common/toolDeferralService';
 import { IToolsService } from '../../tools/common/toolsService';
 import { ToolsService } from '../../tools/vscode-node/toolsService';
 import { LanguageContextServiceImpl } from '../../typescriptContext/vscode-node/languageContextService';
@@ -162,6 +164,7 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 	builder.define(IDiffService, new DiffServiceImpl());
 	builder.define(ITokenizerProvider, new SyncDescriptor(TokenizerProvider, [true]));
 	builder.define(IToolsService, new SyncDescriptor(ToolsService));
+	builder.define(IToolDeferralService, new ToolDeferralService());
 	builder.define(IAgentMemoryService, new SyncDescriptor(AgentMemoryService));
 	builder.define(IMemoryCleanupService, new SyncDescriptor(MemoryCleanupService));
 	builder.define(IChatDiskSessionResources, new SyncDescriptor(ChatDiskSessionResources));

--- a/src/extension/prompts/node/agent/anthropicPrompts.tsx
+++ b/src/extension/prompts/node/agent/anthropicPrompts.tsx
@@ -6,7 +6,8 @@
 import { BasePromptElementProps, PromptElement, PromptElementProps, PromptPiece, PromptSizing } from '@vscode/prompt-tsx';
 import type { LanguageModelToolInformation } from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
-import { CUSTOM_TOOL_SEARCH_NAME, isAnthropicContextEditingEnabled, isAnthropicCustomToolSearchEnabled, isAnthropicToolSearchEnabled, nonDeferredToolNames, TOOL_SEARCH_TOOL_NAME } from '../../../../platform/networking/common/anthropic';
+import { CUSTOM_TOOL_SEARCH_NAME, isAnthropicContextEditingEnabled, isAnthropicCustomToolSearchEnabled, isAnthropicToolSearchEnabled, TOOL_SEARCH_TOOL_NAME } from '../../../../platform/networking/common/anthropic';
+import { IToolDeferralService } from '../../../../platform/networking/common/toolDeferralService';
 import { IChatEndpoint } from '../../../../platform/networking/common/networking';
 import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { ToolName } from '../../../tools/common/toolNames';
@@ -33,6 +34,7 @@ class ToolSearchToolPrompt extends PromptElement<ToolSearchToolPromptProps> {
 		props: PromptElementProps<ToolSearchToolPromptProps>,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IExperimentationService private readonly experimentationService: IExperimentationService,
+		@IToolDeferralService private readonly toolDeferralService: IToolDeferralService,
 	) {
 		super(props);
 	}
@@ -51,7 +53,7 @@ class ToolSearchToolPrompt extends PromptElement<ToolSearchToolPromptProps> {
 
 		// Get the list of deferred tools (tools not in the non-deferred set)
 		const deferredTools = this.props.availableTools
-			.filter(tool => !nonDeferredToolNames.has(tool.name))
+			.filter(tool => !this.toolDeferralService.isNonDeferredTool(tool.name))
 			.map(tool => tool.name)
 			.sort();
 
@@ -497,6 +499,7 @@ class ToolSearchToolPromptOptimized extends PromptElement<ToolSearchToolPromptPr
 	constructor(
 		props: PromptElementProps<ToolSearchToolPromptProps>,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IToolDeferralService private readonly toolDeferralService: IToolDeferralService,
 	) {
 		super(props);
 	}
@@ -513,7 +516,7 @@ class ToolSearchToolPromptOptimized extends PromptElement<ToolSearchToolPromptPr
 		}
 
 		const deferredTools = this.props.availableTools
-			.filter(tool => !nonDeferredToolNames.has(tool.name))
+			.filter(tool => !this.toolDeferralService.isNonDeferredTool(tool.name))
 			.map(tool => tool.name)
 			.sort();
 

--- a/src/extension/test/node/services.ts
+++ b/src/extension/test/node/services.ts
@@ -77,6 +77,8 @@ import { IToolsService } from '../../tools/common/toolsService';
 import { IToolEmbeddingsComputer } from '../../tools/common/virtualTools/toolEmbeddingsComputer';
 import { ToolGroupingService } from '../../tools/common/virtualTools/toolGroupingService';
 import '../../tools/node/allTools';
+import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
+import { ToolDeferralService } from '../../tools/common/toolDeferralService';
 import { TestToolsService } from '../../tools/node/test/testToolsService';
 import { TestToolEmbeddingsComputer } from '../../tools/test/node/virtualTools/testVirtualTools';
 import { ISimilarFilesContextService } from '../../xtab/common/similarFilesContextService';
@@ -116,6 +118,7 @@ export function createExtensionUnitTestingServices(disposables: Pick<DisposableS
 	testingServiceCollection.define(IFeedbackReporter, new SyncDescriptor(NullFeedbackReporterImpl));
 	testingServiceCollection.define(IChatMLFetcher, new SyncDescriptor(MockChatMLFetcher));
 	testingServiceCollection.define(IToolsService, new SyncDescriptor(TestToolsService, [new Set()]));
+	testingServiceCollection.define(IToolDeferralService, new ToolDeferralService());
 	testingServiceCollection.define(IChatDiskSessionResources, new SyncDescriptor(ChatDiskSessionResources));
 	testingServiceCollection.define(IClaudeCodeSdkService, new SyncDescriptor(MockClaudeCodeSdkService));
 	testingServiceCollection.define(IClaudeToolPermissionService, new SyncDescriptor(MockClaudeToolPermissionService));

--- a/src/extension/test/vscode-node/services.ts
+++ b/src/extension/test/vscode-node/services.ts
@@ -123,6 +123,8 @@ import { FixCookbookService, IFixCookbookService } from '../../prompts/node/inli
 import { WorkspaceMutationManager } from '../../testing/node/setupTestsFileManager';
 import { AgentMemoryService, IAgentMemoryService } from '../../tools/common/agentMemoryService';
 import { EditToolLearningService, IEditToolLearningService } from '../../tools/common/editToolLearningService';
+import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
+import { ToolDeferralService } from '../../tools/common/toolDeferralService';
 import { IToolsService, NullToolsService } from '../../tools/common/toolsService';
 import { ToolGroupingService } from '../../tools/common/virtualTools/toolGroupingService';
 import { ToolGroupingCache } from '../../tools/common/virtualTools/virtualToolGroupCache';
@@ -201,6 +203,7 @@ export function createExtensionTestingServices(): TestingServiceCollection {
 	testingServiceCollection.define(IPromptPathRepresentationService, new SyncDescriptor(PromptPathRepresentationService));
 	testingServiceCollection.define(IPromptsService, new SyncDescriptor(PromptsServiceImpl));
 	testingServiceCollection.define(IToolsService, new SyncDescriptor(NullToolsService));
+	testingServiceCollection.define(IToolDeferralService, new ToolDeferralService());
 	testingServiceCollection.define(IChatDiskSessionResources, new SyncDescriptor(ChatDiskSessionResources));
 	testingServiceCollection.define(IChatSessionService, new SyncDescriptor(TestChatSessionService));
 	testingServiceCollection.define(INotebookService, new SyncDescriptor(SimulationNotebookService));

--- a/src/extension/tools/common/toolDeferralService.ts
+++ b/src/extension/tools/common/toolDeferralService.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
+import { ToolName } from './toolNames';
+import { ToolRegistry } from './toolsRegistry';
+
+/**
+ * Tool names not registered via ToolRegistry.registerTool that should also
+ * be non-deferred. These are core tools provided by VS Code or dynamically
+ * injected tools.
+ */
+const additionalNonDeferredToolNames = new Set<string>([
+	// Core tools provided by VS Code (not registered via ToolRegistry.registerTool)
+	ToolName.CoreRunInTerminal,
+	ToolName.CoreGetTerminalOutput,
+	ToolName.CoreRunSubagent,
+	ToolName.CoreRunTest,
+	ToolName.CoreAskQuestions,
+	// Model-specific tool registered via ToolRegistry.registerModelSpecificTool
+	ToolName.ToolSearch,
+	// Dynamically injected tools (no ToolName enum entry)
+	'task_complete',
+]);
+
+/**
+ * Service implementation for tool deferral checks.
+ * Registered in the DI container so consumers can access it via accessor.get().
+ */
+export class ToolDeferralService implements IToolDeferralService {
+	readonly _serviceBrand: undefined;
+
+	isNonDeferredTool(name: string): boolean {
+		return ToolRegistry.nonDeferredToolNames.has(name) || additionalNonDeferredToolNames.has(name);
+	}
+}

--- a/src/extension/tools/common/toolsRegistry.ts
+++ b/src/extension/tools/common/toolsRegistry.ts
@@ -90,6 +90,13 @@ export function isVscodeLanguageModelTool(tool: ICopilotTool<unknown>): tool is 
 
 export interface ICopilotToolCtor {
 	readonly toolName: ToolName;
+	/**
+	 * If true, this tool should always be immediately available (non-deferred)
+	 * when Anthropic tool search is enabled. Non-deferred tools are sent without
+	 * `defer_loading: true` and can receive cache_control breakpoints.
+	 * Defaults to false (deferred) when not set.
+	 */
+	readonly nonDeferred?: boolean;
 	new(...args: never[]): ICopilotTool<unknown>;
 }
 
@@ -106,6 +113,7 @@ export const ToolRegistry = new class {
 	private _tools: Array<ICopilotToolCtor> = [];
 	private _toolExtensions: Array<ICopilotToolExtensionCtor> = [];
 	private _modelSpecificTools = new ObservableMap<string, { definition: vscode.LanguageModelToolDefinition; tool: IModelSpecificToolCtor }>();
+	private _nonDeferredToolNames = new Set<string>();
 
 	public get modelSpecificTools() {
 		return this._modelSpecificTools.observable.map(v => [...v.values()]);
@@ -113,10 +121,17 @@ export const ToolRegistry = new class {
 
 	public registerTool(tool: ICopilotToolCtor) {
 		this._tools.push(tool);
+		if (tool.nonDeferred) {
+			this._nonDeferredToolNames.add(tool.toolName);
+		}
 	}
 
 	public getTools(): readonly ICopilotToolCtor[] {
 		return this._tools;
+	}
+
+	public get nonDeferredToolNames(): ReadonlySet<string> {
+		return this._nonDeferredToolNames;
 	}
 
 	public registerToolExtension(tool: ICopilotToolExtensionCtor) {

--- a/src/extension/tools/node/applyPatchTool.tsx
+++ b/src/extension/tools/node/applyPatchTool.tsx
@@ -63,6 +63,7 @@ export const applyPatch5Description = 'Use the `apply_patch` tool to edit files.
 
 export class ApplyPatchTool implements ICopilotTool<IApplyPatchToolParams> {
 	public static toolName = ToolName.ApplyPatch;
+	public static readonly nonDeferred = true;
 
 	private _promptContext: IBuildPromptContext | undefined;
 

--- a/src/extension/tools/node/codebaseTool.tsx
+++ b/src/extension/tools/node/codebaseTool.tsx
@@ -41,6 +41,7 @@ export interface ICodebaseToolParams {
 
 export class CodebaseTool implements vscode.LanguageModelTool<ICodebaseToolParams> {
 	public static readonly toolName = ToolName.Codebase;
+	public static readonly nonDeferred = true;
 
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,

--- a/src/extension/tools/node/createFileTool.tsx
+++ b/src/extension/tools/node/createFileTool.tsx
@@ -43,6 +43,7 @@ export interface ICreateFileParams {
 
 export class CreateFileTool implements ICopilotTool<ICreateFileParams> {
 	public static toolName = ToolName.CreateFile;
+	public static readonly nonDeferred = true;
 
 	private _promptContext: IBuildPromptContext | undefined;
 

--- a/src/extension/tools/node/executionSubagentTool.ts
+++ b/src/extension/tools/node/executionSubagentTool.ts
@@ -30,6 +30,7 @@ export interface IExecutionSubagentParams {
 
 class ExecutionSubagentTool implements ICopilotTool<IExecutionSubagentParams> {
 	public static readonly toolName = ToolName.ExecutionSubagent;
+	public static readonly nonDeferred = true;
 	private _inputContext: IBuildPromptContext | undefined;
 
 	constructor(

--- a/src/extension/tools/node/findFilesTool.tsx
+++ b/src/extension/tools/node/findFilesTool.tsx
@@ -31,6 +31,7 @@ export interface IFindFilesToolParams {
 
 export class FindFilesTool implements ICopilotTool<IFindFilesToolParams> {
 	public static readonly toolName = ToolName.FindFiles;
+	public static readonly nonDeferred = true;
 
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,

--- a/src/extension/tools/node/findTextInFilesTool.tsx
+++ b/src/extension/tools/node/findTextInFilesTool.tsx
@@ -42,6 +42,7 @@ const MaxResultsCap = 200;
 
 export class FindTextInFilesTool implements ICopilotTool<IFindTextInFilesToolParams> {
 	public static readonly toolName = ToolName.FindTextInFiles;
+	public static readonly nonDeferred = true;
 
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,

--- a/src/extension/tools/node/getErrorsTool.tsx
+++ b/src/extension/tools/node/getErrorsTool.tsx
@@ -42,6 +42,7 @@ interface IGetErrorsParams {
 
 export class GetErrorsTool extends Disposable implements ICopilotTool<IGetErrorsParams> {
 	public static readonly toolName = ToolName.GetErrors;
+	public static readonly nonDeferred = true;
 
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,

--- a/src/extension/tools/node/insertEditTool.tsx
+++ b/src/extension/tools/node/insertEditTool.tsx
@@ -37,6 +37,7 @@ export const InternalEditToolId = 'vscode_editFile_internal';
 
 export class EditFileTool implements ICopilotTool<IEditFileParams> {
 	public static toolName = ToolName.EditFile;
+	public static readonly nonDeferred = true;
 	private promptContext?: IBuildPromptContext;
 	constructor(
 		@IPromptPathRepresentationService protected readonly promptPathRepresentationService: IPromptPathRepresentationService,

--- a/src/extension/tools/node/listDirTool.tsx
+++ b/src/extension/tools/node/listDirTool.tsx
@@ -26,6 +26,7 @@ interface IListDirParams {
 
 class ListDirTool implements vscode.LanguageModelTool<IListDirParams> {
 	public static readonly toolName = ToolName.ListDirectory;
+	public static readonly nonDeferred = true;
 
 	private _promptContext: IBuildPromptContext | undefined;
 

--- a/src/extension/tools/node/manageTodoListTool.tsx
+++ b/src/extension/tools/node/manageTodoListTool.tsx
@@ -14,6 +14,7 @@ import { ICopilotTool, ToolRegistry } from '../common/toolsRegistry';
  */
 class ManageTodoListTool implements ICopilotTool<unknown> {
 	public static readonly toolName = ToolName.CoreManageTodoList;
+	public static readonly nonDeferred = true;
 
 	alternativeDefinition(tool: vscode.LanguageModelToolInformation, endpoint?: IChatEndpoint): vscode.LanguageModelToolInformation {
 		if (!isGpt5PlusFamily(endpoint)) {

--- a/src/extension/tools/node/memoryTool.tsx
+++ b/src/extension/tools/node/memoryTool.tsx
@@ -149,6 +149,7 @@ interface MemoryToolResult {
 
 export class MemoryTool implements ICopilotTool<MemoryToolParams> {
 	public static readonly toolName = ToolName.Memory;
+	public static readonly nonDeferred = true;
 
 	constructor(
 		@IFileSystemService private readonly fileSystemService: IFileSystemService,

--- a/src/extension/tools/node/multiReplaceStringTool.tsx
+++ b/src/extension/tools/node/multiReplaceStringTool.tsx
@@ -22,6 +22,7 @@ export interface IMultiReplaceStringToolParams {
 
 export class MultiReplaceStringTool extends AbstractReplaceStringTool<IMultiReplaceStringToolParams> {
 	public static toolName = ToolName.MultiReplaceString;
+	public static readonly nonDeferred = true;
 
 	protected extractReplaceInputs(input: IMultiReplaceStringToolParams): IAbstractReplaceStringInput[] {
 		return input.replacements.map(r => ({

--- a/src/extension/tools/node/readFileTool.tsx
+++ b/src/extension/tools/node/readFileTool.tsx
@@ -114,6 +114,7 @@ const getParamRanges = (params: ReadFileParams, snapshot: NotebookDocumentSnapsh
 
 export class ReadFileTool implements ICopilotTool<ReadFileParams> {
 	public static toolName = ToolName.ReadFile;
+	public static readonly nonDeferred = true;
 	private _promptContext: IBuildPromptContext | undefined;
 
 	constructor(

--- a/src/extension/tools/node/replaceStringTool.tsx
+++ b/src/extension/tools/node/replaceStringTool.tsx
@@ -22,6 +22,7 @@ export interface IReplaceStringToolParams {
 
 export class ReplaceStringTool<T extends IReplaceStringToolParams = IReplaceStringToolParams> extends AbstractReplaceStringTool<T> {
 	public static toolName = ToolName.ReplaceString;
+	public static readonly nonDeferred = true;
 
 	protected extractReplaceInputs(input: T): IAbstractReplaceStringInput[] {
 		return [{

--- a/src/extension/tools/node/searchSubagentTool.ts
+++ b/src/extension/tools/node/searchSubagentTool.ts
@@ -36,6 +36,7 @@ export interface ISearchSubagentParams {
 
 class SearchSubagentTool implements ICopilotTool<ISearchSubagentParams> {
 	public static readonly toolName = ToolName.SearchSubagent;
+	public static readonly nonDeferred = true;
 	private _inputContext: IBuildPromptContext | undefined;
 
 	constructor(

--- a/src/extension/tools/node/viewImageTool.tsx
+++ b/src/extension/tools/node/viewImageTool.tsx
@@ -26,6 +26,7 @@ export interface IViewImageParams {
 
 export class ViewImageTool implements ICopilotTool<IViewImageParams> {
 	public static readonly toolName = ToolName.ViewImage;
+	public static readonly nonDeferred = true;
 
 	private _promptContext: IBuildPromptContext | undefined;
 

--- a/src/extension/tools/vscode-node/fetchWebPageTool.tsx
+++ b/src/extension/tools/vscode-node/fetchWebPageTool.tsx
@@ -53,6 +53,7 @@ class FetchWebPageTool implements ICopilotTool<IFetchWebPageParams> {
 	}
 
 	public static readonly toolName = ToolName.FetchWebPage;
+	public static readonly nonDeferred = true;
 
 	prepareInvocation(_options: LanguageModelToolInvocationPrepareOptions<IFetchWebPageParams>, _token: CancellationToken): ProviderResult<PreparedToolInvocation> {
 		// The Core version of this tool handles the confirmation message & other messages

--- a/src/extension/tools/vscode-node/switchAgentTool.ts
+++ b/src/extension/tools/vscode-node/switchAgentTool.ts
@@ -16,6 +16,7 @@ interface ISwitchAgentParams {
 
 export class SwitchAgentTool implements ICopilotTool<ISwitchAgentParams> {
 	public static readonly toolName = ToolName.SwitchAgent;
+	public static readonly nonDeferred = true;
 
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<ISwitchAgentParams>, token: CancellationToken): Promise<vscode.LanguageModelToolResult> {
 		const { agentName } = options.input;

--- a/src/platform/endpoint/node/messagesApi.ts
+++ b/src/platform/endpoint/node/messagesApi.ts
@@ -13,10 +13,11 @@ import { IInstantiationService, ServicesAccessor } from '../../../util/vs/platfo
 import { ChatLocation } from '../../chat/common/commonTypes';
 import { ConfigKey, IConfigurationService } from '../../configuration/common/configurationService';
 import { ILogService } from '../../log/common/logService';
-import { AnthropicMessagesTool, ContextManagementResponse, CUSTOM_TOOL_SEARCH_NAME, getContextManagementFromConfig, isAnthropicContextEditingEnabled, isAnthropicCustomToolSearchEnabled, isAnthropicToolSearchEnabled, nonDeferredToolNames, ServerToolUse, TOOL_SEARCH_TOOL_NAME, TOOL_SEARCH_TOOL_TYPE, ToolSearchToolResult } from '../../networking/common/anthropic';
+import { AnthropicMessagesTool, ContextManagementResponse, CUSTOM_TOOL_SEARCH_NAME, getContextManagementFromConfig, isAnthropicContextEditingEnabled, isAnthropicCustomToolSearchEnabled, isAnthropicToolSearchEnabled, ServerToolUse, TOOL_SEARCH_TOOL_NAME, TOOL_SEARCH_TOOL_TYPE, ToolSearchToolResult } from '../../networking/common/anthropic';
 import { FinishedCallback, IIPCodeCitation, IResponseDelta } from '../../networking/common/fetch';
 import { IChatEndpoint, ICreateEndpointBodyOptions, IEndpointBody } from '../../networking/common/networking';
 import { ChatCompletion, FinishedCompletionReason, rawMessageToCAPI } from '../../networking/common/openai';
+import { IToolDeferralService } from '../../networking/common/toolDeferralService';
 import { sendEngineMessagesTelemetry } from '../../networking/node/chatStream';
 import { IExperimentationService } from '../../telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../telemetry/common/telemetry';
@@ -85,6 +86,7 @@ interface AnthropicStreamEvent {
 export function createMessagesRequestBody(accessor: ServicesAccessor, options: ICreateEndpointBodyOptions, model: string, endpoint: IChatEndpoint): IEndpointBody {
 	const configurationService = accessor.get(IConfigurationService);
 	const experimentationService = accessor.get(IExperimentationService);
+	const toolDeferralService = accessor.get(IToolDeferralService);
 
 	const toolSearchEnabled = isAnthropicToolSearchEnabled(endpoint, configurationService);
 	const customToolSearchEnabled = isAnthropicCustomToolSearchEnabled(endpoint, configurationService, experimentationService);
@@ -102,7 +104,7 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 			if (!tool.function.name || tool.function.name.length === 0) {
 				continue;
 			}
-			const isDeferred = toolSearchEnabled && isAllowedConversationAgent && !isSubagent && !nonDeferredToolNames.has(tool.function.name);
+			const isDeferred = toolSearchEnabled && isAllowedConversationAgent && !isSubagent && !toolDeferralService.isNonDeferredTool(tool.function.name);
 			const anthropicTool: AnthropicMessagesTool = {
 				name: tool.function.name,
 				description: tool.function.description || '',

--- a/src/platform/networking/common/anthropic.ts
+++ b/src/platform/networking/common/anthropic.ts
@@ -83,43 +83,6 @@ export const TOOL_SEARCH_SUPPORTED_MODELS = [
 	'claude-opus-4.6',
 ] as const;
 
-export const nonDeferredToolNames = new Set([
-	// Read/navigate
-	'read_file',
-	'list_dir',
-	// Search
-	'grep_search',
-	'semantic_search',
-	'file_search',
-	// Edit
-	'replace_string_in_file',
-	'multi_replace_string_in_file',
-	'insert_edit_into_file',
-	'apply_patch',
-	'create_file',
-	// Terminal
-	'run_in_terminal',
-	'get_terminal_output',
-	// Other high-usage tools
-	'get_errors',
-	'manage_todo_list',
-	// Subagent tools
-	'runSubagent',
-	'search_subagent',
-	'execution_subagent',
-	// Testing
-	'runTests',
-	// Misc
-	'ask_questions',
-	'switch_agent',
-	'memory',
-	'task_complete',
-	// Custom tool search (must always be available so the model can search for deferred tools)
-	CUSTOM_TOOL_SEARCH_NAME,
-	'view_image',
-	'fetch_webpage'
-]);
-
 /**
  * Context management types for Anthropic Messages API
  * Based on https://platform.claude.com/docs/en/build-with-claude/context-editing

--- a/src/platform/networking/common/toolDeferralService.ts
+++ b/src/platform/networking/common/toolDeferralService.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createServiceIdentifier } from '../../../util/common/services';
+
+export const IToolDeferralService = createServiceIdentifier<IToolDeferralService>('IToolDeferralService');
+
+export interface IToolDeferralService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Check whether a tool (by its API-facing name) should be non-deferred.
+	 * Returns true if the tool should always be immediately available when
+	 * tool search is enabled.
+	 */
+	isNonDeferredTool(name: string): boolean;
+}


### PR DESCRIPTION

## Changes

- Add `nonDeferred?: boolean` to `ICopilotToolCtor` interface
- Add `IToolDeferralService` (interface in `src/platform/`, implementation in `src/extension/`) with `isNonDeferredTool()`
- Mark all 18 frequently-used tools as `static readonly nonDeferred = true` at their declaration site
- Register `IToolDeferralService` in prod, unit test, and vscode-node test service containers
- Remove centralized `nonDeferredToolNames` set from `anthropic.ts`
- Fix latent bug: old `'ask_questions'` entry never matched the real `'vscode_askQuestions'` tool name; now correctly included via `ToolName.CoreAskQuestions`

Fixes microsoft/vscode#303545