### PR TITLE
fix: guard MonacoPerformanceMarks against missing clearMarks method

### DIFF
--- a/src/util/common/performance.ts
+++ b/src/util/common/performance.ts
@@ -27,7 +27,20 @@ function _getNativePolyfill(): IMonacoPerformanceMarks {
 	};
 }
 
-const perf: IMonacoPerformanceMarks = (globalThis as { MonacoPerformanceMarks?: IMonacoPerformanceMarks }).MonacoPerformanceMarks ?? _getNativePolyfill();
+const perf: IMonacoPerformanceMarks = _getPerf();
+
+function _getPerf(): IMonacoPerformanceMarks {
+	const host = (globalThis as { MonacoPerformanceMarks?: Partial<IMonacoPerformanceMarks> }).MonacoPerformanceMarks;
+	if (!host) {
+		return _getNativePolyfill();
+	}
+	const polyfill = _getNativePolyfill();
+	return {
+		mark: host.mark?.bind(host) ?? polyfill.mark,
+		getMarks: host.getMarks?.bind(host) ?? polyfill.getMarks,
+		clearMarks: host.clearMarks?.bind(host) ?? polyfill.clearMarks,
+	};
+}
 
 const chatExtPrefix = 'code/chat/ext/';
 


### PR DESCRIPTION
## Problem

After #4673 ("Add chat perf markers"), calling `clearChatExtMarks()` throws:

```
cgt.clearMarks is not a function
```

This happens because the VS Code host provides `MonacoPerformanceMarks` on `globalThis`, but that object does not yet implement `clearMarks()`. The extension was assuming the host object satisfies the full `IMonacoPerformanceMarks` interface and using it directly — so the `clearMarks` call fails at runtime.

## Fix

Instead of consuming the host object as-is or falling back entirely to the native polyfill, we now compose a `perf` object that picks each method from the host if available, falling back to the polyfill per-method. This makes the extension resilient to partial `MonacoPerformanceMarks` implementations.

## Testing

- Existing `performance.spec.ts` tests all pass (5/5)
- Lint-staged (tsfmt + eslint) passes