### PR TITLE
Use VS code org to determine team membership

### DIFF
--- a/src/platform/authentication/common/copilotToken.ts
+++ b/src/platform/authentication/common/copilotToken.ts
@@ -53,7 +53,7 @@ function containsMicrosoftOrg(orgList: string[]): boolean {
  * @param orgList The list of organizations the user is a member of
  * Whether or not it contains a VS Code org
  */
-function containsVSCodeOrg(orgList: string[]): boolean {
+export function containsVSCodeOrg(orgList: string[]): boolean {
 	const VSCODE_ORGANIZATIONS = ['551cca60ce19654d894e786220822482'];
 	// Check if the user is part of a VS Code organization.
 	for (const org of orgList) {

--- a/src/platform/authentication/node/copilotTokenManager.ts
+++ b/src/platform/authentication/node/copilotTokenManager.ts
@@ -11,13 +11,13 @@ import { IConfigurationService } from '../../configuration/common/configurationS
 import { ICAPIClientService } from '../../endpoint/common/capiClient';
 import { IDomainService } from '../../endpoint/common/domainService';
 import { IEnvService, isScenarioAutomation } from '../../env/common/envService';
-import { BaseOctoKitService, VSCodeTeamId } from '../../github/common/githubService';
+import { BaseOctoKitService } from '../../github/common/githubService';
 import { NullBaseOctoKitService } from '../../github/common/nullOctokitServiceImpl';
 import { ILogService } from '../../log/common/logService';
 import { FetchOptions, IFetcherService, Response, jsonVerboseError } from '../../networking/common/fetcherService';
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { TelemetryData } from '../../telemetry/common/telemetryData';
-import { CopilotToken, CopilotUserInfo, ErrorEnvelope, ExtendedTokenInfo, StandardErrorEnvelope, TokenEnvelope, TokenInfoOrError, TokenValidationResult, containsInternalOrg, createTestExtendedTokenInfo, isErrorEnvelope, isStandardErrorEnvelope, validateTokenEnvelope } from '../common/copilotToken';
+import { CopilotToken, CopilotUserInfo, ErrorEnvelope, ExtendedTokenInfo, StandardErrorEnvelope, TokenEnvelope, TokenInfoOrError, TokenValidationResult, containsVSCodeOrg, createTestExtendedTokenInfo, isErrorEnvelope, isStandardErrorEnvelope, validateTokenEnvelope } from '../common/copilotToken';
 import { CheckCopilotToken, ICopilotTokenManager, NotGitHubLoginFailed, nowSeconds } from '../common/copilotTokenManager';
 
 /**
@@ -229,11 +229,6 @@ export abstract class BaseCopilotTokenManager extends Disposable implements ICop
 
 		// extend the token envelope
 		const login = ghUsername ?? 'unknown';
-		let isVscodeTeamMember = false;
-		// VS Code team members are guaranteed to be a part of an internal org so we can check that first to minimize API calls
-		if (containsInternalOrg(tokenInfo.organization_list ?? []) && 'githubToken' in context) {
-			isVscodeTeamMember = !!(await this._baseOctokitservice.getTeamMembershipWithToken(VSCodeTeamId, context.githubToken, login));
-		}
 		const extendedInfo: ExtendedTokenInfo = {
 			...tokenInfo,
 			copilot_plan: userInfo?.copilot_plan ?? tokenInfo.sku ?? '',
@@ -242,7 +237,7 @@ export abstract class BaseCopilotTokenManager extends Disposable implements ICop
 			codex_agent_enabled: userInfo?.codex_agent_enabled,
 			organization_login_list: userInfo?.organization_login_list ?? [],
 			username: login,
-			isVscodeTeamMember,
+			isVscodeTeamMember: containsVSCodeOrg(tokenInfo.organization_list ?? []),
 		};
 		const telemetryData = TelemetryData.createAndMarkAsIssued(
 			{},

--- a/src/platform/github/common/githubService.ts
+++ b/src/platform/github/common/githubService.ts
@@ -466,10 +466,6 @@ export class BaseOctoKitService {
 		return this._makeGHAPIRequest('user', 'GET', token, undefined, undefined, 'github-rest-get-user');
 	}
 
-	async getTeamMembershipWithToken(teamId: number, token: string, username: string): Promise<any | undefined> {
-		return this._makeGHAPIRequest(`teams/${teamId}/memberships/${username}`, 'GET', token, undefined, undefined, 'github-rest-get-team-membership');
-	}
-
 	async getGitHubOutageStatus(): Promise<GitHubOutageStatus> {
 		const now = Date.now();
 		if (this._cachedOutageStatus && (now - this._cachedOutageStatus.timestamp) < BaseOctoKitService._outageStatusCacheTTL) {

--- a/src/platform/github/common/nullOctokitServiceImpl.ts
+++ b/src/platform/github/common/nullOctokitServiceImpl.ts
@@ -14,10 +14,6 @@ export class NullBaseOctoKitService extends BaseOctoKitService {
 		return { avatar_url: '', login: 'NullUser', name: 'Null User' };
 	}
 
-	override async getTeamMembershipWithToken(teamId: number, token: string, username: string): Promise<any | undefined> {
-		return undefined;
-	}
-
 	override async _makeGHAPIRequest(routeSlug: string, method: 'GET' | 'POST', token: string, body?: { [key: string]: any }, options?: { silent404?: boolean }, callSite?: string) {
 		return undefined;
 	}


### PR DESCRIPTION
This org controls ExP and other team features so we should just settle on that rather than wasting a network request on fetching the team