### PR TITLE
fix: preserve full MCP tool schemas for Anthropic API

### DIFF
--- a/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -9,6 +9,7 @@ import { CancellationToken, LanguageModelChatInformation, LanguageModelChatMessa
 import { ChatFetchResponseType, ChatLocation } from '../../../platform/chat/common/commonTypes';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { CustomDataPartMimeTypes } from '../../../platform/endpoint/common/endpointTypes';
+import { buildToolInputSchema } from '../../../platform/endpoint/node/messagesApi';
 import { ILogService } from '../../../platform/log/common/logService';
 import { ContextManagementResponse, getContextManagementFromConfig, isAnthropicContextEditingEnabled, isAnthropicMemoryToolEnabled, isAnthropicToolSearchEnabled, TOOL_SEARCH_TOOL_NAME, TOOL_SEARCH_TOOL_TYPE, ToolSearchToolResult, ToolSearchToolSearchResult } from '../../../platform/networking/common/anthropic';
 import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
@@ -189,12 +190,7 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 				tools.push({
 					name: tool.name,
 					description: tool.description,
-					input_schema: {
-						type: 'object',
-						properties: (tool.inputSchema as { properties?: Record<string, unknown> }).properties ?? {},
-						required: (tool.inputSchema as { required?: string[] }).required ?? [],
-						$schema: (tool.inputSchema as { $schema?: unknown }).$schema
-					},
+					input_schema: buildToolInputSchema(tool.inputSchema as Record<string, unknown>),
 					...(shouldDefer ? { defer_loading: shouldDefer } : {})
 				});
 			}

--- a/src/platform/endpoint/node/messagesApi.ts
+++ b/src/platform/endpoint/node/messagesApi.ts
@@ -23,6 +23,20 @@ import { IExperimentationService } from '../../telemetry/common/nullExperimentat
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { TelemetryData } from '../../telemetry/common/telemetryData';
 
+/**
+ * Build the `input_schema` for an Anthropic tool from an arbitrary JSON Schema
+ * object. Ensures `type: 'object'` and `properties` default, preserves extra
+ * keys like `$defs` and `additionalProperties`, and strips `$schema` which the
+ * Anthropic API rejects.
+ */
+export function buildToolInputSchema(schema: Record<string, unknown> | undefined): Record<string, unknown> & { type: 'object' } {
+	if (!schema) {
+		return { type: 'object', properties: {} };
+	}
+	const { $schema: _, ...rest } = schema;
+	return { type: 'object', properties: {}, ...rest };
+}
+
 /** IP Code Citation annotation from Messages API copilot_annotations */
 interface AnthropicIPCodeCitation {
 	id: number;
@@ -108,11 +122,7 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 			const anthropicTool: AnthropicMessagesTool = {
 				name: tool.function.name,
 				description: tool.function.description || '',
-				input_schema: {
-					type: 'object',
-					properties: (tool.function.parameters as { properties?: Record<string, unknown> })?.properties ?? {},
-					required: (tool.function.parameters as { required?: string[] })?.required ?? [],
-				},
+				input_schema: buildToolInputSchema(tool.function.parameters as Record<string, unknown> | undefined),
 				...(isDeferred ? { defer_loading: true } : {}),
 			};
 			(isDeferred ? deferredTools : nonDeferredTools).push(anthropicTool);

--- a/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -7,7 +7,7 @@ import type { ContentBlockParam, DocumentBlockParam, ImageBlockParam, MessagePar
 import { Raw } from '@vscode/prompt-tsx';
 import { expect, suite, test } from 'vitest';
 import { AnthropicMessagesTool, CUSTOM_TOOL_SEARCH_NAME } from '../../../networking/common/anthropic';
-import { addToolsAndSystemCacheControl, rawMessagesToMessagesAPI } from '../../node/messagesApi';
+import { addToolsAndSystemCacheControl, buildToolInputSchema, rawMessagesToMessagesAPI } from '../../node/messagesApi';
 
 function assertContentArray(content: MessageParam['content']): ContentBlockParam[] {
 	expect(Array.isArray(content)).toBe(true);
@@ -575,5 +575,61 @@ suite('addToolsAndSystemCacheControl', function () {
 		addToolsAndSystemCacheControl(tools, messagesResult);
 
 		expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
+	});
+});
+
+suite('buildToolInputSchema', function () {
+
+	test('returns default schema when input is undefined', function () {
+		const result = buildToolInputSchema(undefined);
+		expect(result).toEqual({ type: 'object', properties: {} });
+	});
+
+	test('strips $schema from the input', function () {
+		const result = buildToolInputSchema({
+			$schema: 'https://json-schema.org/draft/2020-12/schema',
+			type: 'object',
+			properties: { query: { type: 'string' } },
+			required: ['query'],
+		});
+		expect(result).toEqual({
+			type: 'object',
+			properties: { query: { type: 'string' } },
+			required: ['query'],
+		});
+		expect(result).not.toHaveProperty('$schema');
+	});
+
+	test('preserves $defs and additionalProperties', function () {
+		const defs = { Foo: { type: 'object', properties: { x: { type: 'number' } } } };
+		const result = buildToolInputSchema({
+			type: 'object',
+			properties: { foo: { $ref: '#/$defs/Foo' } },
+			$defs: defs,
+			additionalProperties: false,
+		});
+		expect(result.$defs).toEqual(defs);
+		expect(result.additionalProperties).toBe(false);
+	});
+
+	test('defaults properties to empty object when not provided', function () {
+		const result = buildToolInputSchema({ type: 'object' });
+		expect(result.properties).toEqual({});
+	});
+
+	test('overrides default properties when provided in schema', function () {
+		const props = { name: { type: 'string' } };
+		const result = buildToolInputSchema({ type: 'object', properties: props });
+		expect(result.properties).toEqual(props);
+	});
+
+	test('passes through a plain schema without $schema unchanged', function () {
+		const schema = {
+			type: 'object',
+			properties: { id: { type: 'number' } },
+			required: ['id'],
+		};
+		const result = buildToolInputSchema(schema);
+		expect(result).toEqual(schema);
 	});
 });


### PR DESCRIPTION
## Problem

MCP tools that use JSON Schema draft-2020-12 features (`$schema`, `$defs`, `$ref`, `additionalProperties`) cause errors with Claude models. The Anthropic API paths (CAPI and BYOK) were only extracting `properties` and `required` from tool schemas, dropping everything else.

This meant:
- `$defs` targets were lost, breaking any `$ref` references
- `additionalProperties` constraints were dropped
- `$schema` was passed through to the Anthropic API (BYOK path), which rejects it

## Fix

Extract a shared `buildToolInputSchema()` helper that:
- Defaults `type: 'object'` and `properties: {}`
- Spreads the full schema on top (preserving `$defs`, `additionalProperties`, `required`, etc.)
- Strips `$schema` which the Anthropic API rejects

Both the CAPI path (`messagesApi.ts`) and BYOK path (`anthropicProvider.ts`) now use this shared function.

Fixes microsoft/vscode#303990