### PR TITLE
feat(auth): Enhance GitHub session handling with detailed prompts

### DIFF
--- a/src/extension/agents/vscode-node/githubOrgChatResourcesService.ts
+++ b/src/extension/agents/vscode-node/githubOrgChatResourcesService.ts
@@ -153,7 +153,7 @@ export class GitHubOrgChatResourcesService extends Disposable implements IGitHub
 		// Get the organizations the user is a member of
 		let userOrganizations: string[];
 		try {
-			userOrganizations = await this.octoKitService.getUserOrganizations({ createIfNone: false }, 1);
+			userOrganizations = await this.octoKitService.getUserOrganizations({}, 1);
 			this.logService.trace(`[GitHubOrgChatResourcesService] User organizations: ${JSON.stringify(userOrganizations)}`);
 			if (userOrganizations.length === 0) {
 				this.logService.trace('[GitHubOrgChatResourcesService] No organizations found for user');

--- a/src/extension/agents/vscode-node/githubOrgCustomAgentProvider.ts
+++ b/src/extension/agents/vscode-node/githubOrgCustomAgentProvider.ts
@@ -59,7 +59,7 @@ export class GitHubOrgCustomAgentProvider extends Disposable implements vscode.C
 			const internalOptions = { includeSources: ['org', 'enterprise'] } satisfies CustomAgentListOptions;
 
 			// Note: we need to fetch an arbitrary visible/accessible repository, in case user does not have access to .github-private
-			const repos = await this.octoKitService.getOrganizationRepositories(orgId, { createIfNone: false }, 1);
+			const repos = await this.octoKitService.getOrganizationRepositories(orgId, {}, 1);
 			if (repos.length === 0) {
 				this.logService.trace(`[GitHubOrgCustomAgentProvider] No repositories found for org ${orgId}`);
 				return;
@@ -68,7 +68,7 @@ export class GitHubOrgCustomAgentProvider extends Disposable implements vscode.C
 			// Fetch custom agents from GitHub and compare with existing agents in cache
 			const repoName = repos[0];
 			const [agents, existingAgents] = await Promise.all([
-				this.octoKitService.getCustomAgents(orgId, repoName, internalOptions, { createIfNone: false }),
+				this.octoKitService.getCustomAgents(orgId, repoName, internalOptions, {}),
 				this.githubOrgChatResourcesService.listCachedFiles(PromptsType.agent, orgId)
 			]);
 
@@ -81,7 +81,7 @@ export class GitHubOrgCustomAgentProvider extends Disposable implements vscode.C
 					agent.repo_name,
 					agent.name,
 					agent.version,
-					{ createIfNone: false },
+					{},
 				);
 
 				// Generate agent markdown file content

--- a/src/extension/agents/vscode-node/githubOrgInstructionsProvider.ts
+++ b/src/extension/agents/vscode-node/githubOrgInstructionsProvider.ts
@@ -54,7 +54,7 @@ export class GitHubOrgInstructionsProvider extends Disposable implements vscode.
 
 	private async pollInstructions(orgId: string): Promise<void> {
 		try {
-			const instructions = await this.octoKitService.getOrgCustomInstructions(orgId, { createIfNone: false });
+			const instructions = await this.octoKitService.getOrgCustomInstructions(orgId, {});
 			if (!instructions) {
 				await this.githubOrgChatResourcesService.clearCache(PromptsType.instructions, orgId);
 				this.logService.trace(`[GitHubOrgInstructionsProvider] No custom instructions found for org ${orgId}`);

--- a/src/extension/agents/vscode-node/test/githubOrgCustomAgentProvider.spec.ts
+++ b/src/extension/agents/vscode-node/test/githubOrgCustomAgentProvider.spec.ts
@@ -953,7 +953,7 @@ Test prompt
 				// Sign out user after first call
 				mockOctoKitService.getCurrentAuthedUser = async () => undefined as any;
 			}
-			return originalGetCustomAgents.call(mockOctoKitService, owner, repo, options, { createIfNone: false });
+			return originalGetCustomAgents.call(mockOctoKitService, owner, repo, options, {});
 		};
 
 		await provider.provideCustomAgents({}, {} as any);

--- a/src/extension/agents/vscode-node/test/mockOctoKitService.ts
+++ b/src/extension/agents/vscode-node/test/mockOctoKitService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CCAEnabledResult, CustomAgentDetails, CustomAgentListItem, CustomAgentListOptions, GitHubOutageStatus, IOctoKitService, PermissiveAuthRequiredError } from '../../../../platform/github/common/githubService';
+import { AuthOptions, CCAEnabledResult, CustomAgentDetails, CustomAgentListItem, CustomAgentListOptions, GitHubOutageStatus, IOctoKitService, PermissiveAuthRequiredError } from '../../../../platform/github/common/githubService';
 
 /**
  * Mock implementation of IOctoKitService for testing
@@ -40,22 +40,22 @@ export class MockOctoKitService implements IOctoKitService {
 	getAssignableActors = async () => [];
 	isCCAEnabled = async (): Promise<CCAEnabledResult> => ({ enabled: true });
 
-	getUserOrganizations = async (_authOptions?: { createIfNone?: boolean }, _pageSize?: number) => this.userOrganizations;
-	isUserMemberOfOrg = async (org: string, _authOptions?: { createIfNone?: boolean }) => this.userOrganizations.includes(org);
-	getOrganizationRepositories = async (org: string, _authOptions?: { createIfNone?: boolean }, _pageSize?: number) => [org === 'testorg' ? 'testrepo' : 'repo'];
+	getUserOrganizations = async (_authOptions?: AuthOptions, _pageSize?: number) => this.userOrganizations;
+	isUserMemberOfOrg = async (org: string, _authOptions?: AuthOptions) => this.userOrganizations.includes(org);
+	getOrganizationRepositories = async (org: string, _authOptions?: AuthOptions, _pageSize?: number) => [org === 'testorg' ? 'testrepo' : 'repo'];
 
-	async getOrgCustomInstructions(orgLogin: string, _authOptions?: { createIfNone?: boolean }): Promise<string | undefined> {
+	async getOrgCustomInstructions(orgLogin: string, _authOptions?: AuthOptions): Promise<string | undefined> {
 		return this.orgInstructions.get(orgLogin);
 	}
 
-	async getCustomAgents(_owner: string, _repo: string, _options: CustomAgentListOptions, _authOptions: { createIfNone?: boolean }): Promise<CustomAgentListItem[]> {
+	async getCustomAgents(_owner: string, _repo: string, _options: CustomAgentListOptions, _authOptions: AuthOptions): Promise<CustomAgentListItem[]> {
 		if (!(await this.getCurrentAuthedUser())) {
 			throw new PermissiveAuthRequiredError();
 		}
 		return this.customAgents;
 	}
 
-	async getCustomAgentDetails(_owner: string, _repo: string, agentName: string, _version: string, _authOptions: { createIfNone?: boolean }): Promise<CustomAgentDetails | undefined> {
+	async getCustomAgentDetails(_owner: string, _repo: string, agentName: string, _version: string, _authOptions: AuthOptions): Promise<CustomAgentDetails | undefined> {
 		return this.agentDetails.get(agentName);
 	}
 

--- a/src/extension/chatSessions/vscode-node/chatSessions.ts
+++ b/src/extension/chatSessions/vscode-node/chatSessions.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IEnvService, INativeEnvService } from '../../../platform/env/common/envService';
@@ -311,7 +312,7 @@ export class ChatSessionsContrib extends Disposable implements IExtensionContrib
 						ctx.pullRequestDetails.repository.owner.login,
 						ctx.pullRequestDetails.repository.name,
 						ctx.pullRequestDetails.number,
-						{ createIfNone: true });
+						{ createIfNone: { detail: l10n.t('Sign in to GitHub to access Copilot cloud sessions.') } });
 					if (!success) {
 						this.logService.error(`${CLOSE_SESSION_PR_CMD}: Failed to close PR #${ctx.pullRequestDetails.number}`);
 					}

--- a/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
@@ -2581,7 +2581,7 @@ async function detectPullRequestFromGitHubAPI(
 		repoInfo.id.org,
 		repoInfo.id.repo,
 		branchName,
-		{ createIfNone: false },
+		{},
 	);
 
 	if (pr?.url) {

--- a/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
@@ -2632,7 +2632,7 @@ async function detectPullRequestFromGitHubAPI(
 		repoInfo.id.org,
 		repoInfo.id.repo,
 		branchName,
-		{ createIfNone: false },
+		{},
 	);
 
 	if (pr?.url) {

--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -13,7 +13,7 @@ import { IVSCodeExtensionContext } from '../../../platform/extContext/common/ext
 import { IGitExtensionService } from '../../../platform/git/common/gitExtensionService';
 import { GithubRepoId, IGitService } from '../../../platform/git/common/gitService';
 import { derivePullRequestState, PullRequestSearchItem, SessionInfo } from '../../../platform/github/common/githubAPI';
-import { CCAEnabledResult, IGithubRepositoryService, IOctoKitService, JobInfo, RemoteAgentJobResponse } from '../../../platform/github/common/githubService';
+import { AuthOptions, CCAEnabledResult, IGithubRepositoryService, IOctoKitService, JobInfo, RemoteAgentJobResponse } from '../../../platform/github/common/githubService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
@@ -30,6 +30,8 @@ import { CopilotCloudGitOperationsManager } from './copilotCloudGitOperationsMan
 import { ChatSessionContentBuilder } from './copilotCloudSessionContentBuilder';
 import { IPullRequestFileChangesService } from './pullRequestFileChangesService';
 import MarkdownIt = require('markdown-it');
+
+const CLOUD_SESSIONS_AUTH_OPTIONS: AuthOptions = { createIfNone: { detail: l10n.t('Sign in to GitHub to access Copilot cloud sessions.') } };
 
 interface ConfirmationMetadata {
 	prompt: string;
@@ -252,7 +254,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 				let intervalMs: number;
 				let hasHistoricalSessions: boolean;
 				try {
-					const sessions = await Promise.all(repoIds.map(repoId => this._octoKitService.getAllSessions(`${repoId.org}/${repoId.repo}`, false, { createIfNone: false })));
+					const sessions = await Promise.all(repoIds.map(repoId => this._octoKitService.getAllSessions(`${repoId.org}/${repoId.repo}`, false, {})));
 					hasHistoricalSessions = sessions.some(s => s.length > 0);
 					intervalMs = this.getRefreshIntervalTime(hasHistoricalSessions);
 				} catch (e) {
@@ -266,7 +268,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 				const schedulerCallback = async () => {
 					let sessions = [];
 					try {
-						sessions = await Promise.all(repoIds.map(repoId => this._octoKitService.getAllSessions(`${repoId.org}/${repoId.repo}`, true, { createIfNone: false })));
+						sessions = await Promise.all(repoIds.map(repoId => this._octoKitService.getAllSessions(`${repoId.org}/${repoId.repo}`, true, {})));
 						sessions = sessions.flat();
 						if (this.cachedSessionsSize !== sessions.length) {
 							this.refresh();
@@ -524,7 +526,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			return cached;
 		}
 
-		const result = await this._octoKitService.isCCAEnabled(owner, repo, { createIfNone: false });
+		const result = await this._octoKitService.isCCAEnabled(owner, repo, {});
 
 		// Only cache enabled=true results with a TTL; disabled results should always re-fetch
 		if (result.enabled === true) {
@@ -592,7 +594,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			// Fetch only the active sessions using allSettled to handle individual failures
 			const sessionResults = await Promise.allSettled(
 				Array.from(this.activeSessionIds).map(sessionId =>
-					this._octoKitService.getSessionInfo(sessionId, { createIfNone: true })
+					this._octoKitService.getSessionInfo(sessionId, CLOUD_SESSIONS_AUTH_OPTIONS)
 				)
 			);
 
@@ -644,7 +646,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 	private async getAvailablePartnerAgents(owner: string, repo: string): Promise<{ id: string; name: string; at?: string; codiconId?: string }[]> {
 		try {
 			// Fetch assignable actors for the repository
-			const assignableActors = await this._octoKitService.getAssignableActors(owner, repo, { createIfNone: false });
+			const assignableActors = await this._octoKitService.getAssignableActors(owner, repo, {});
 
 			// Check which agents from HARDCODED_PARTNER_AGENTS are assignable
 			const availableAgents: { id: string; name: string; at?: string; codiconId?: string }[] = [];
@@ -756,8 +758,8 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		try {
 			// Fetch agents (requires repo), models (global), and partner agents in parallel
 			const [customAgents, models, partnerAgents] = await Promise.allSettled([
-				repoId && repoIds?.length === 1 ? this._octoKitService.getCustomAgents(repoId.org, repoId.repo, { excludeInvalidConfig: true }, { createIfNone: false }) : Promise.resolve([]),
-				this._octoKitService.getCopilotAgentModels({ createIfNone: false }),
+				repoId && repoIds?.length === 1 ? this._octoKitService.getCustomAgents(repoId.org, repoId.repo, { excludeInvalidConfig: true }, {}) : Promise.resolve([]),
+				this._octoKitService.getCopilotAgentModels({}),
 				repoId ? this.getAvailablePartnerAgents(repoId.org, repoId.repo) : Promise.resolve([])
 			]);
 
@@ -880,7 +882,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			} else {
 				// Fetch repos from recent push events (repos user has recently committed to)
 				try {
-					const recentlyCommittedRepos = await this._octoKitService.getRecentlyCommittedRepositories({ createIfNone: false });
+					const recentlyCommittedRepos = await this._octoKitService.getRecentlyCommittedRepositories({});
 					for (const repo of recentlyCommittedRepos) {
 						const nwo = `${repo.owner}/${repo.name}`;
 						items.push({
@@ -916,7 +918,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 	private async fetchAllRepositoriesFromGitHub(query?: string): Promise<vscode.ChatSessionProviderOptionItem[]> {
 		try {
 			// Fetch repos user has access to, optionally filtered by search query
-			const repos = await this._octoKitService.getUserRepositories({ createIfNone: false }, query);
+			const repos = await this._octoKitService.getUserRepositories({}, query);
 
 			// Sort alphabetically and convert to option items
 			return repos
@@ -988,9 +990,9 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			}
 			let sessions = [];
 			if (vscode.workspace.isAgentSessionsWorkspace || !repoIds || repoIds.length === 0) {
-				sessions = await this._octoKitService.getAllSessions(undefined, true, { createIfNone: false });
+				sessions = await this._octoKitService.getAllSessions(undefined, true, {});
 			} else {
-				sessions = (await Promise.all(repoIds.map(repo => this._octoKitService.getAllSessions(`${repo.org}/${repo.repo}`, true, { createIfNone: false })))).flat();
+				sessions = (await Promise.all(repoIds.map(repo => this._octoKitService.getAllSessions(`${repo.org}/${repo.repo}`, true, {})))).flat();
 			}
 			this.logService.debug(`copilotCloudSessionsProvider#provideChatSessionItems: fetched ${sessions.length} sessions`);
 			this.cachedSessionsSize = sessions.length;
@@ -1024,7 +1026,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			const uniqueGlobalIds = new Set(Array.from(latestSessionsMap.values()).map(s => s.resource_global_id));
 			const prFetches = Array.from(uniqueGlobalIds).map(async globalId => {
 				try {
-					const pr = await this._octoKitService.getPullRequestFromGlobalId(globalId, { createIfNone: false });
+					const pr = await this._octoKitService.getPullRequestFromGlobalId(globalId, {});
 					return { globalId, pr };
 				} catch (e) {
 					this.logService.warn(`Failed to fetch PR for global ID ${globalId}: ${e instanceof Error ? e.message : String(e)}`);
@@ -1161,7 +1163,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 				summaryReference.complete(undefined);
 				return undefined;
 			}
-			const jobInfo = await this._octoKitService.getJobBySessionId(repoOwner, repoName, sessions[0].id, 'vscode-copilot-chat', { createIfNone: true });
+			const jobInfo = await this._octoKitService.getJobBySessionId(repoOwner, repoName, sessions[0].id, 'vscode-copilot-chat', CLOUD_SESSIONS_AUTH_OPTIONS);
 			let prompt = jobInfo?.problem_statement || 'Initial Implementation';
 			// When delegating, we append the summary to the prompt, & that can be very large and doesn't look great.
 			// Turn the summary into a reference instead.
@@ -1202,7 +1204,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			return match ?? getDefault();
 		};
 
-		const sessions = await this._octoKitService.getCopilotSessionsForPR(pr.fullDatabaseId.toString(), { createIfNone: true });
+		const sessions = await this._octoKitService.getCopilotSessionsForPR(pr.fullDatabaseId.toString(), CLOUD_SESSIONS_AUTH_OPTIONS);
 		const sortedSessions = sessions
 			.filter((session, index, array) =>
 				array.findIndex(s => s.id === session.id) === index
@@ -1217,7 +1219,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		});
 
 		const sessionContentBuilder = new ChatSessionContentBuilder(CopilotCloudSessionsProvider.TYPE, this._gitService);
-		const history = await sessionContentBuilder.buildSessionHistory(getProblemStatement(pr.repository.owner.login, pr.repository.name, sortedSessions), sortedSessions, pr, (sessionId: string) => this._octoKitService.getSessionLogs(sessionId, { createIfNone: true }), storedReferences);
+		const history = await sessionContentBuilder.buildSessionHistory(getProblemStatement(pr.repository.owner.login, pr.repository.name, sortedSessions), sortedSessions, pr, (sessionId: string) => this._octoKitService.getSessionLogs(sessionId, CLOUD_SESSIONS_AUTH_OPTIONS), storedReferences);
 
 		// const selectedCustomAgent = undefined; /* TODO: Needs API to support this. */
 		// const selectedModel = undefined; /* TODO: Needs API to support this. */
@@ -1334,7 +1336,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		}
 		try {
 			pr = await retry(async () => {
-				const pullRequests = await this._octoKitService.getOpenPullRequestsForUser(repoOwner, repoName, { createIfNone: true });
+				const pullRequests = await this._octoKitService.getOpenPullRequestsForUser(repoOwner, repoName, CLOUD_SESSIONS_AUTH_OPTIONS);
 				const found = pullRequests.find(p => p.number === prNumber);
 				if (!found) {
 					this.logService.warn(`Pull request ${prNumber} is not visible yet, retrying...`);
@@ -1594,7 +1596,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		if (selection.includes(this.AUTHORIZE.toUpperCase())) {
 			stream.progress(vscode.l10n.t('Authorizing'));
 			try {
-				await this._authenticationService.getGitHubSession('permissive', { createIfNone: true });
+				await this._authenticationService.getGitHubSession('permissive', { createIfNone: { detail: l10n.t('Sign in to GitHub with additional permissions to use Copilot cloud sessions.') } });
 				if (!this._authenticationService.permissiveGitHubSession) {
 					throw new Error('Failed to obtain permissive GitHub session');
 				}
@@ -2074,14 +2076,14 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 					}
 
 					// Get the specific session info
-					const sessionInfo = await this._octoKitService.getSessionInfo(sessionId, { createIfNone: true });
+					const sessionInfo = await this._octoKitService.getSessionInfo(sessionId, CLOUD_SESSIONS_AUTH_OPTIONS);
 					if (!sessionInfo || token.isCancellationRequested) {
 						complete();
 						return;
 					}
 
 					// Get session logs
-					const logs = await this._octoKitService.getSessionLogs(sessionId, { createIfNone: true });
+					const logs = await this._octoKitService.getSessionLogs(sessionId, CLOUD_SESSIONS_AUTH_OPTIONS);
 
 					// Check if session is still in progress
 					if (sessionInfo.state !== 'in_progress') {
@@ -2241,7 +2243,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		// Allow for a short delay before the session is marked as 'queued'
 		let waitForQueuedCount = 0;
 		do {
-			sessionInfo = await this._octoKitService.getSessionInfo(sessionId, { createIfNone: true });
+			sessionInfo = await this._octoKitService.getSessionInfo(sessionId, CLOUD_SESSIONS_AUTH_OPTIONS);
 			if (sessionInfo && sessionInfo.state === 'queued') {
 				this.logService.trace('Queued session found');
 				break;
@@ -2270,7 +2272,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 
 		this.logService.trace(`Session ${sessionInfo.id} is queued, waiting for transition to in_progress...`);
 		while (Date.now() - startTime < maxWaitTime && (!token || !token.isCancellationRequested)) {
-			const sessionInfo = await this._octoKitService.getSessionInfo(sessionId, { createIfNone: true });
+			const sessionInfo = await this._octoKitService.getSessionInfo(sessionId, CLOUD_SESSIONS_AUTH_OPTIONS);
 			if (sessionInfo?.state === 'in_progress') {
 				this.logService.trace(`Session ${sessionInfo.id} now in progress.`);
 				this.refresh();
@@ -2288,7 +2290,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		waitForTransitionToInProgress: boolean = false
 	): Promise<SessionInfo | undefined> {
 		// Get the current number of sessions
-		const initialSessions = await this._octoKitService.getCopilotSessionsForPR(pullRequest.fullDatabaseId.toString(), { createIfNone: true });
+		const initialSessions = await this._octoKitService.getCopilotSessionsForPR(pullRequest.fullDatabaseId.toString(), CLOUD_SESSIONS_AUTH_OPTIONS);
 		const initialSessionCount = initialSessions.length;
 
 		// Poll for a new session to start
@@ -2297,7 +2299,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		const startTime = Date.now();
 
 		while (Date.now() - startTime < maxWaitTime && !token.isCancellationRequested) {
-			const currentSessions = await this._octoKitService.getCopilotSessionsForPR(pullRequest.fullDatabaseId.toString(), { createIfNone: true });
+			const currentSessions = await this._octoKitService.getCopilotSessionsForPR(pullRequest.fullDatabaseId.toString(), CLOUD_SESSIONS_AUTH_OPTIONS);
 
 			// Check if a new session has started
 			if (currentSessions.length > initialSessionCount) {
@@ -2341,7 +2343,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			}
 			const commentBody = `@${targetAgent} ${userPrompt} ${summary ? '\n\n' + summary : ''}`;
 
-			const commentResult = await this._octoKitService.addPullRequestComment(pr.id, commentBody, { createIfNone: true });
+			const commentResult = await this._octoKitService.addPullRequestComment(pr.id, commentBody, CLOUD_SESSIONS_AUTH_OPTIONS);
 			if (!commentResult) {
 				this.logService.error(`Failed to add comment to PR #${pullRequestNumber}`);
 				return;
@@ -2372,7 +2374,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		this.logService.trace(`Waiting for job ${jobId} to have pull request information...`);
 
 		while (Date.now() - startTime < maxWaitTime && (!token || !token.isCancellationRequested)) {
-			const jobInfo = await this._octoKitService.getJobByJobId(owner, repo, jobId, 'vscode-copilot-chat', { createIfNone: true });
+			const jobInfo = await this._octoKitService.getJobByJobId(owner, repo, jobId, 'vscode-copilot-chat', CLOUD_SESSIONS_AUTH_OPTIONS);
 			if (jobInfo && jobInfo.pull_request && jobInfo.pull_request.number) {
 				/* __GDPR__
 					"copilotcloud.chat.remoteAgentJobPullRequestReady" : {
@@ -2484,7 +2486,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 
 		stream?.progress(vscode.l10n.t('Delegating to cloud agent'));
 		this.logService.debug(`[postCopilotAgentJob] Invoking cloud agent job with payload: ${JSON.stringify(payload)}`);
-		const response = await this._octoKitService.postCopilotAgentJob(repoOwner, repoName, JOBS_API_VERSION, payload, { createIfNone: true });
+		const response = await this._octoKitService.postCopilotAgentJob(repoOwner, repoName, JOBS_API_VERSION, payload, CLOUD_SESSIONS_AUTH_OPTIONS);
 		this.logService.debug(`[postCopilotAgentJob] Received response from cloud agent job invocation: ${JSON.stringify(response)}`);
 		if (!this.validateRemoteAgentJobResponse(response)) {
 			const statusCode = response?.status;

--- a/src/extension/chatSessions/vscode-node/prContentProvider.ts
+++ b/src/extension/chatSessions/vscode-node/prContentProvider.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
 import { IOctoKitService, PullRequestFile } from '../../../platform/github/common/githubService';
 import { ILogService } from '../../../platform/log/common/logService';
@@ -114,7 +115,7 @@ export class PRContentProvider extends Disposable implements vscode.TextDocument
 				params.repo,
 				params.commitSha,
 				params.fileName,
-				{ createIfNone: true }
+				{ createIfNone: { detail: l10n.t('Sign in to GitHub to access Copilot cloud sessions.') } }
 			);
 
 			return content;

--- a/src/extension/chatSessions/vscode-node/pullRequestFileChangesService.ts
+++ b/src/extension/chatSessions/vscode-node/pullRequestFileChangesService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
 import { PullRequestSearchItem } from '../../../platform/github/common/githubAPI';
 import { IOctoKitService } from '../../../platform/github/common/githubService';
@@ -37,7 +38,7 @@ export class PullRequestFileChangesService implements IPullRequestFileChangesSer
 			}
 
 			this.logService.trace(`Fetching PR files from ${repoOwner}/${repoName} for PR #${pullRequest.number}`);
-			const files = await this._octoKitService.getPullRequestFiles(repoOwner, repoName, pullRequest.number, { createIfNone: true });
+			const files = await this._octoKitService.getPullRequestFiles(repoOwner, repoName, pullRequest.number, { createIfNone: { detail: l10n.t('Sign in to GitHub to view pull request file changes.') } });
 			this.logService.trace(`Got ${files?.length || 0} files from API`);
 
 			if (!files || files.length === 0) {

--- a/src/extension/chatSessions/vscode/chatSessionsUriHandler.ts
+++ b/src/extension/chatSessions/vscode/chatSessionsUriHandler.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
 import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
 import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
@@ -236,7 +237,7 @@ export class ChatSessionsUriHandler extends Disposable implements CustomUriHandl
 		if (!repoId || repoId.length === 0) {
 			return;
 		}
-		const pullRequests = await this._octoKitService.getOpenPullRequestsForUser(repoId[0].org, repoId[0].repo, { createIfNone: true });
+		const pullRequests = await this._octoKitService.getOpenPullRequestsForUser(repoId[0].org, repoId[0].repo, { createIfNone: { detail: l10n.t('Sign in to GitHub to access Copilot cloud sessions.') } });
 		const pullRequest = pullRequests.find(pr => pr.id === prId);
 		if (!pullRequest) {
 			return;

--- a/src/extension/githubMcp/common/githubMcpDefinitionProvider.ts
+++ b/src/extension/githubMcp/common/githubMcpDefinitionProvider.ts
@@ -17,6 +17,8 @@ export class GitHubMcpDefinitionProvider implements McpServerDefinitionProvider<
 
 	readonly onDidChangeMcpServerDefinitions: Event<void>;
 
+	private _askedForAuth = false;
+
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IAuthenticationService private readonly authenticationService: IAuthenticationService,
@@ -135,15 +137,26 @@ export class GitHubMcpDefinitionProvider implements McpServerDefinitionProvider<
 	}
 
 	async resolveMcpServerDefinition(server: McpHttpServerDefinition, token: CancellationToken): Promise<McpHttpServerDefinition> {
-		const session = await this.authenticationService.getGitHubSession('permissive', {
-			createIfNone: {
-				detail: l10n.t('Additional permissions are required to use GitHub MCP Server'),
-			},
-		});
-		if (!session) {
-			throw new Error('Authentication required');
+		const accessToken = this.authenticationService.permissiveGitHubSession?.accessToken;
+		if (accessToken) {
+			server.headers['Authorization'] = `Bearer ${accessToken}`;
+			return server;
 		}
-		server.headers['Authorization'] = `Bearer ${session.accessToken}`;
-		return server;
+
+		if (this._askedForAuth) {
+			throw new Error('User denied authentication. Cannot connect to GitHub MCP Server.');
+		}
+
+		try {
+			const session = await this.authenticationService.getGitHubSession('permissive', {
+				createIfNone: {
+					detail: l10n.t('Additional permissions are required to use GitHub MCP Server'),
+				},
+			});
+			server.headers['Authorization'] = `Bearer ${session.accessToken}`;
+			return server;
+		} finally {
+			this._askedForAuth = true;
+		}
 	}
 }

--- a/src/extension/githubMcp/test/node/githubMcpDefinitionProvider.spec.ts
+++ b/src/extension/githubMcp/test/node/githubMcpDefinitionProvider.spec.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { beforeEach, describe, expect, test } from 'vitest';
-import type { AuthenticationGetSessionOptions, AuthenticationGetSessionPresentationOptions, AuthenticationSession } from 'vscode';
-import { BaseAuthenticationService, IAuthenticationService } from '../../../../platform/authentication/common/authentication';
+import type { AuthenticationGetSessionOptions, AuthenticationSession } from 'vscode';
+import { BaseAuthenticationService, IAuthenticationService, StrictAuthenticationPresentationOptions } from '../../../../platform/authentication/common/authentication';
 import { CopilotToken } from '../../../../platform/authentication/common/copilotToken';
 import { ICopilotTokenManager } from '../../../../platform/authentication/common/copilotTokenManager';
 import { CopilotTokenStore, ICopilotTokenStore } from '../../../../platform/authentication/common/copilotTokenStore';
@@ -42,8 +42,8 @@ class TestAuthenticationService extends BaseAuthenticationService {
 		this.fireAuthenticationChange('setPermissiveGitHubSession');
 	}
 
-	override getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { createIfNone: boolean | AuthenticationGetSessionPresentationOptions }): Promise<AuthenticationSession>;
-	override getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { forceNewSession: boolean | AuthenticationGetSessionPresentationOptions }): Promise<AuthenticationSession>;
+	override getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { createIfNone: StrictAuthenticationPresentationOptions }): Promise<AuthenticationSession>;
+	override getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { forceNewSession: StrictAuthenticationPresentationOptions }): Promise<AuthenticationSession>;
 	override getGitHubSession(kind: 'permissive' | 'any', options?: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined> {
 		if (kind === 'permissive') {
 			if (options?.createIfNone && !this._permissiveGitHubSession) {

--- a/src/extension/inlineEdits/vscode-node/components/nesFeedbackSubmitter.ts
+++ b/src/extension/inlineEdits/vscode-node/components/nesFeedbackSubmitter.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as l10n from '@vscode/l10n';
 import { env, Uri, window, workspace } from 'vscode';
 import { IAuthenticationService } from '../../../../platform/authentication/common/authentication';
 import { ILogger, ILogService } from '../../../../platform/log/common/logService';
@@ -91,7 +92,7 @@ export class NesFeedbackSubmitter {
 			}
 
 			// Get GitHub auth token - need permissive session for repo access
-			const session = await this._authenticationService.getGitHubSession('permissive', { createIfNone: true });
+			const session = await this._authenticationService.getGitHubSession('permissive', { createIfNone: { detail: l10n.t('Sign in to GitHub to submit feedback.') } });
 			if (!session) {
 				window.showErrorMessage('GitHub authentication required with repo access. Please sign in to GitHub.');
 				return;

--- a/src/extension/onboardDebug/vscode-node/copilotDebugCommandContribution.ts
+++ b/src/extension/onboardDebug/vscode-node/copilotDebugCommandContribution.ts
@@ -160,7 +160,7 @@ export class CopilotDebugCommandContribution extends Disposable implements vscod
 
 			rpc.registerMethod('start', async function start(opts: IStartOptions): Promise<void> {
 				if (!authService.copilotToken) {
-					await authService.getGitHubSession('any', { createIfNone: true });
+					await authService.getGitHubSession('any', { createIfNone: { detail: l10n.t('Sign in to GitHub to use Copilot debug.') } });
 				}
 				const result = await factory.start(opts, cts.token);
 

--- a/src/platform/authentication/common/AGENTS.md
+++ b/src/platform/authentication/common/AGENTS.md
@@ -1,0 +1,87 @@
+# Authentication Service Usage Guide
+
+## Overview
+
+`IAuthenticationService` manages GitHub and Copilot authentication. It provides GitHub sessions (OAuth tokens) and Copilot tokens (CAPI tokens).
+
+## Choosing a Session Kind
+
+`getGitHubSession` requires a `kind` parameter. Choose thoughtfully:
+
+- **`'any'`** — Accepts whatever GitHub session is available, even one with minimal scopes (e.g., just `user:email`). Use this when you only need basic access and don't require repo or write permissions.
+- **`'permissive'`** — Requires a session with broader scopes (`read:user`, `user:email`, `repo`, `workflow`). Use when you need private repo access or write permissions.
+
+## The Three Overloads of `getGitHubSession`
+
+### 1. Interactive — prompt user to sign in
+
+Returns `AuthenticationSession` (never `undefined`). Throws if the user cancels.
+
+Requires `createIfNone` with a `StrictAuthenticationPresentationOptions` containing a **localized `detail` string** explaining why auth is needed:
+
+```ts
+const session = await authService.getGitHubSession('any', {
+  createIfNone: { detail: l10n.t('Sign in to GitHub to use feature X.') }
+});
+```
+
+### 2. Interactive — force a new session
+
+Same as above but forces re-authentication even if a session exists. Use when the current token has lost authorization:
+
+```ts
+const session = await authService.getGitHubSession('any', {
+  forceNewSession: { detail: l10n.t('Sign in again to restore access.') }
+});
+```
+
+### 3. Silent — no user prompt
+
+Returns `AuthenticationSession | undefined`. Never shows UI. Use when auth is optional:
+
+```ts
+const session = await authService.getGitHubSession('any', { silent: true });
+if (!session) {
+  // No session available, handle gracefully
+}
+```
+
+## Important Constraints
+
+- **`createIfNone` and `forceNewSession` do NOT accept `boolean`**. You must pass a `StrictAuthenticationPresentationOptions` with a required `detail` string.  Passing `true`, `false`, or `{}` will not compile.
+- **The `detail` string must be localized** using `l10n.t('...')`.
+- The silent overload's options type is `Omit<AuthenticationGetSessionOptions, 'createIfNone' | 'forceNewSession'>` — you cannot sneak a boolean `createIfNone` through it.
+
+## Synchronous Cache Properties
+
+For non-blocking checks (no network, no UI), use the cached properties:
+
+- `authService.anyGitHubSession` — cached `'any'` session or `undefined`
+- `authService.permissiveGitHubSession` — cached `'permissive'` session or `undefined`
+- `authService.copilotToken` — cached Copilot token (without the raw token string) or `undefined`
+
+React to `onDidAuthenticationChange` to stay up to date.
+
+## Copilot Tokens
+
+Most callers just need a valid CAPI token. `getCopilotToken()` handles refresh automatically:
+
+```ts
+const token = await authService.getCopilotToken();
+```
+
+## Minimal Mode
+
+When `authService.isMinimalMode` is `true`, the service will not fetch permissive tokens:
+- Interactive `'permissive'` calls throw `MinimalModeError`
+- Silent `'permissive'` calls return `undefined`
+
+## Auth State Flows
+
+There are three states a user can be in:
+
+1. **Not signed in** — No `'any'` session exists. The user has no GitHub session at all. An interactive `createIfNone` call will show VS Code's built-in sign-in dialog.
+
+2. **Signed in from VS Code** — The user explicitly signed in through VS Code (e.g., via Accounts menu or a `createIfNone` prompt). In this case, VS Code automatically acquires the permissive token since it requests the broader scopes upfront. Both `'any'` and `'permissive'` sessions are available.
+
+3. **Signed in passively** (e.g., via Settings Sync) — The user is signed into GitHub through a passive mechanism that only grants minimal scopes. Copilot Chat works with the `'any'` token, but no `'permissive'` token is available. A `'permissive'` call with `createIfNone` will prompt the user to grant additional permissions.

--- a/src/platform/authentication/common/authentication.ts
+++ b/src/platform/authentication/common/authentication.ts
@@ -4,6 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 import type { AuthenticationGetSessionOptions, AuthenticationGetSessionPresentationOptions, AuthenticationSession } from 'vscode';
 import { createServiceIdentifier } from '../../../util/common/services';
+
+/**
+ * A stricter version of {@link AuthenticationGetSessionPresentationOptions} that requires
+ * a `detail` message explaining why authentication is needed. This forces callers to provide
+ * meaningful context to the user instead of passing a bare `true` or `{}`.
+ */
+export type StrictAuthenticationPresentationOptions = AuthenticationGetSessionPresentationOptions & { detail: string };
 import { Emitter, Event } from '../../../util/vs/base/common/event';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { derived } from '../../../util/vs/base/common/observableInternal';
@@ -85,7 +92,7 @@ export interface IAuthenticationService {
 	 * @throws MinimalModeError - If kind is 'permissive' and the authentication service is in minimal mode.
 	 * @throws Error - If no session is acquired (user cancels).
 	 */
-	getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { createIfNone: boolean | AuthenticationGetSessionPresentationOptions }): Promise<AuthenticationSession>;
+	getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { createIfNone: StrictAuthenticationPresentationOptions }): Promise<AuthenticationSession>;
 
 	/**
 	 * Gets a GitHub session capable of calling GitHub APIs.
@@ -97,7 +104,7 @@ export interface IAuthenticationService {
 	 * @throws MinimalModeError - If kind is 'permissive' and the authentication service is in minimal mode.
 	 * @throws Error - If no session is acquired (user cancels).
 	 */
-	getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { forceNewSession: boolean | AuthenticationGetSessionPresentationOptions }): Promise<AuthenticationSession>;
+	getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { forceNewSession: StrictAuthenticationPresentationOptions }): Promise<AuthenticationSession>;
 
 	/**
 	 * Gets a GitHub session capable of calling GitHub APIs.
@@ -109,7 +116,7 @@ export interface IAuthenticationService {
 	 * @returns Promise<undefined> - If no session is available or kind is 'permissive' and the authentication service is in minimal mode.
 	 * @see {@link isMinimalMode} for more information about minimal mode.
 	 */
-	getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined>;
+	getGitHubSession(kind: 'permissive' | 'any', options: Omit<AuthenticationGetSessionOptions, 'createIfNone' | 'forceNewSession'>): Promise<AuthenticationSession | undefined>;
 
 	/**
 	 * Checks if there is currently a Copilot token available in the cache. Does not make any network requests.
@@ -215,9 +222,9 @@ export abstract class BaseAuthenticationService extends Disposable implements IA
 
 	//#region GitHub Session
 
-	abstract getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { createIfNone: boolean | AuthenticationGetSessionPresentationOptions }): Promise<AuthenticationSession>;
-	abstract getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { forceNewSession: boolean | AuthenticationGetSessionPresentationOptions }): Promise<AuthenticationSession>;
-	abstract getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined>;
+	abstract getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { createIfNone: StrictAuthenticationPresentationOptions }): Promise<AuthenticationSession>;
+	abstract getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { forceNewSession: StrictAuthenticationPresentationOptions }): Promise<AuthenticationSession>;
+	abstract getGitHubSession(kind: 'permissive' | 'any', options: Omit<AuthenticationGetSessionOptions, 'createIfNone' | 'forceNewSession'>): Promise<AuthenticationSession | undefined>;
 
 	//#endregion
 

--- a/src/platform/authentication/common/authenticationUpgradeService.ts
+++ b/src/platform/authentication/common/authenticationUpgradeService.ts
@@ -137,7 +137,7 @@ export class AuthenticationChatUpgradeService extends Disposable implements IAut
 			case `${this._permissionRequestGrant}: "${this._permissionRequest}"`:
 				this.logService.trace('User granted permission');
 				try {
-					await this._authenticationService.getGitHubSession('permissive', { createIfNone: true });
+					await this._authenticationService.getGitHubSession('permissive', { createIfNone: { detail: l10n.t('Sign in to GitHub with additional permissions for enhanced features.') } });
 					this._onDidGrantAuthUpgrade.fire();
 				} catch (e) {
 					// User cancelled so show the badge

--- a/src/platform/authentication/common/staticGitHubAuthenticationService.ts
+++ b/src/platform/authentication/common/staticGitHubAuthenticationService.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { AuthenticationGetSessionOptions, AuthenticationGetSessionPresentationOptions, AuthenticationSession } from 'vscode';
+import type { AuthenticationGetSessionOptions, AuthenticationSession } from 'vscode';
 import { IConfigurationService } from '../../configuration/common/configurationService';
 import { ILogService } from '../../log/common/logService';
-import { BaseAuthenticationService, GITHUB_SCOPE_ALIGNED, GITHUB_SCOPE_USER_EMAIL, IAuthenticationService, MinimalModeError } from './authentication';
+import { BaseAuthenticationService, GITHUB_SCOPE_ALIGNED, GITHUB_SCOPE_USER_EMAIL, IAuthenticationService, MinimalModeError, StrictAuthenticationPresentationOptions } from './authentication';
 import { CopilotToken } from './copilotToken';
 import { ICopilotTokenManager } from './copilotTokenManager';
 import { ICopilotTokenStore } from './copilotTokenStore';
@@ -43,8 +43,8 @@ export class StaticGitHubAuthenticationService extends BaseAuthenticationService
 		} : undefined;
 	}
 
-	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { createIfNone: boolean | AuthenticationGetSessionPresentationOptions }): Promise<AuthenticationSession>;
-	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { forceNewSession: boolean | AuthenticationGetSessionPresentationOptions }): Promise<AuthenticationSession>;
+	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { createIfNone: StrictAuthenticationPresentationOptions }): Promise<AuthenticationSession>;
+	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { forceNewSession: StrictAuthenticationPresentationOptions }): Promise<AuthenticationSession>;
 	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined>;
 	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined> {
 		if (kind === 'permissive') {

--- a/src/platform/authentication/vscode-node/authenticationService.ts
+++ b/src/platform/authentication/vscode-node/authenticationService.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { authentication, AuthenticationGetSessionOptions, AuthenticationGetSessionPresentationOptions, AuthenticationSession } from 'vscode';
+import { authentication, AuthenticationGetSessionOptions, AuthenticationSession } from 'vscode';
 import { TaskSingler } from '../../../util/common/taskSingler';
 import { AuthProviderId, IConfigurationService } from '../../configuration/common/configurationService';
 import { IDomainService } from '../../endpoint/common/domainService';
 import { ILogService } from '../../log/common/logService';
-import { authProviderId, BaseAuthenticationService } from '../common/authentication';
+import { authProviderId, BaseAuthenticationService, StrictAuthenticationPresentationOptions } from '../common/authentication';
 import { ICopilotTokenManager } from '../common/copilotTokenManager';
 import { ICopilotTokenStore } from '../common/copilotTokenStore';
 import { getAlignedSession, getAnyAuthSession } from './session';
@@ -40,8 +40,8 @@ export class AuthenticationService extends BaseAuthenticationService {
 		void this._handleAuthChangeEvent();
 	}
 
-	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { createIfNone: boolean | AuthenticationGetSessionPresentationOptions }): Promise<AuthenticationSession>;
-	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { forceNewSession: boolean | AuthenticationGetSessionPresentationOptions }): Promise<AuthenticationSession>;
+	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { createIfNone: StrictAuthenticationPresentationOptions }): Promise<AuthenticationSession>;
+	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { forceNewSession: StrictAuthenticationPresentationOptions }): Promise<AuthenticationSession>;
 	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined> {
 		if (kind === 'permissive') {
 			const func = () => getAlignedSession(this._configurationService, options);

--- a/src/platform/authentication/vscode-node/session.ts
+++ b/src/platform/authentication/vscode-node/session.ts
@@ -47,7 +47,7 @@ async function getAuthSession(providerId: string, defaultScopes: string[], getSi
 		// This will force GitHub auth to present a picker to choose which account you want to log in to if there
 		// are multiple accounts.
 		// When GitHub becomes a true multi-account provider, we can change this to just createIfNone: true.
-		const session = await authentication.getSession(providerId, defaultScopes, { forceNewSession: { learnMore: URI.parse('https://aka.ms/copilotRepoScope') }, clearSessionPreference: true });
+		const session = await authentication.getSession(providerId, defaultScopes, options);
 		return session;
 	}
 	// Pass the options in as they are

--- a/src/platform/github/common/githubService.ts
+++ b/src/platform/github/common/githubService.ts
@@ -18,11 +18,11 @@ import { addPullRequestCommentGraphQLRequest, AssignableActor, closePullRequest,
  */
 export interface AuthOptions {
 	/**
-	 * If true, prompts the user to sign in if no authentication token is available.
-	 * If false or undefined, fails silently without prompting.
-	 * @default false
+	 * If provided, prompts the user to sign in if no authentication token is available,
+	 * displaying the given detail message to explain why authentication is needed.
+	 * If undefined, fails silently without prompting.
 	 */
-	readonly createIfNone?: boolean;
+	readonly createIfNone?: { readonly detail: string };
 }
 
 export type IGetRepositoryInfoResponseData = Endpoints['GET /repos/{owner}/{repo}']['response']['data'];

--- a/src/platform/github/common/octoKitServiceImpl.ts
+++ b/src/platform/github/common/octoKitServiceImpl.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { CCAModel, RemoteAgentJobPayload, RequestType } from '@vscode/copilot-api';
+import type { AuthenticationSession } from 'vscode';
 import { IAuthenticationService } from '../../authentication/common/authentication';
 import { ICAPIClientService } from '../../endpoint/common/capiClient';
 import { ILogService } from '../../log/common/logService';
@@ -24,6 +25,13 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		super(capiClientService, fetcherService, logService, telemetryService);
 	}
 
+	private _getPermissiveSession(authOptions: AuthOptions): Promise<AuthenticationSession | undefined> {
+		if (authOptions.createIfNone) {
+			return this._authService.getGitHubSession('permissive', { createIfNone: authOptions.createIfNone });
+		}
+		return this._authService.getGitHubSession('permissive', { silent: true });
+	}
+
 	async getCurrentAuthedUser(): Promise<IOctoKitUser | undefined> {
 		const authToken = (await this._authService.getGitHubSession('any', { silent: true }))?.accessToken;
 		if (!authToken) {
@@ -33,8 +41,8 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		return await this.getCurrentAuthedUserWithToken(authToken);
 	}
 
-	async getOpenPullRequestsForUser(owner: string, repo: string, authOptions: { createIfNone?: boolean }): Promise<PullRequestSearchItem[]> {
-		const auth = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }));
+	async getOpenPullRequestsForUser(owner: string, repo: string, authOptions: AuthOptions): Promise<PullRequestSearchItem[]> {
+		const auth = (await this._getPermissiveSession(authOptions));
 		if (!auth?.accessToken) {
 			this._logService.trace('No authentication token available for getOpenPullRequestsForUser');
 			return [];
@@ -48,9 +56,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		return response;
 	}
 
-	async getCopilotSessionsForPR(prId: string, authOptions: { createIfNone?: boolean }): Promise<SessionInfo[]> {
+	async getCopilotSessionsForPR(prId: string, authOptions: AuthOptions): Promise<SessionInfo[]> {
 		try {
-			const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+			const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 			if (!authToken) {
 				this._logService.trace('No authentication token available for getCopilotSessionsForPR');
 				throw new PermissiveAuthRequiredError();
@@ -75,9 +83,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		}
 	}
 
-	async getSessionLogs(sessionId: string, authOptions: { createIfNone?: boolean }): Promise<string> {
+	async getSessionLogs(sessionId: string, authOptions: AuthOptions): Promise<string> {
 		try {
-			const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+			const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 			if (!authToken) {
 				this._logService.trace('No authentication token available for getSessionLogs');
 				throw new PermissiveAuthRequiredError();
@@ -98,9 +106,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		}
 	}
 
-	async getSessionInfo(sessionId: string, authOptions: { createIfNone?: boolean }): Promise<SessionInfo | undefined> {
+	async getSessionInfo(sessionId: string, authOptions: AuthOptions): Promise<SessionInfo | undefined> {
 		try {
-			const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+			const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 			if (!authToken) {
 				this._logService.trace('No authentication token available for getSessionInfo');
 				throw new PermissiveAuthRequiredError();
@@ -125,9 +133,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		}
 	}
 
-	async postCopilotAgentJob(owner: string, name: string, apiVersion: string, payload: RemoteAgentJobPayload, authOptions: { createIfNone?: boolean }): Promise<RemoteAgentJobResponse | ErrorResponseWithStatusCode | undefined> {
+	async postCopilotAgentJob(owner: string, name: string, apiVersion: string, payload: RemoteAgentJobPayload, authOptions: AuthOptions): Promise<RemoteAgentJobResponse | ErrorResponseWithStatusCode | undefined> {
 		try {
-			const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+			const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 			if (!authToken) {
 				this._logService.trace('No authentication token available for postCopilotAgentJob');
 				throw new PermissiveAuthRequiredError();
@@ -151,9 +159,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		}
 	}
 
-	async getJobByJobId(owner: string, repo: string, jobId: string, userAgent: string, authOptions: { createIfNone?: boolean }): Promise<JobInfo | undefined> {
+	async getJobByJobId(owner: string, repo: string, jobId: string, userAgent: string, authOptions: AuthOptions): Promise<JobInfo | undefined> {
 		try {
-			const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+			const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 			if (!authToken) {
 				this._logService.trace('No authentication token available for getJobByJobId');
 				throw new PermissiveAuthRequiredError();
@@ -174,9 +182,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		}
 	}
 
-	async getJobBySessionId(owner: string, repo: string, sessionId: string, userAgent: string, authOptions: { createIfNone?: boolean }): Promise<JobInfo | undefined> {
+	async getJobBySessionId(owner: string, repo: string, sessionId: string, userAgent: string, authOptions: AuthOptions): Promise<JobInfo | undefined> {
 		try {
-			const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+			const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 			if (!authToken) {
 				this._logService.trace('No authentication token available for getJobBySessionId');
 				throw new PermissiveAuthRequiredError();
@@ -197,8 +205,8 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		}
 	}
 
-	async addPullRequestComment(pullRequestId: string, commentBody: string, authOptions: { createIfNone?: boolean }): Promise<PullRequestComment | null> {
-		const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+	async addPullRequestComment(pullRequestId: string, commentBody: string, authOptions: AuthOptions): Promise<PullRequestComment | null> {
+		const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 		if (!authToken) {
 			this._logService.trace('No authentication token available for addPullRequestComment');
 			throw new PermissiveAuthRequiredError();
@@ -206,9 +214,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		return this.addPullRequestCommentWithToken(pullRequestId, commentBody, authToken);
 	}
 
-	async getAllSessions(nwo: string | undefined, open: boolean, authOptions: { createIfNone?: boolean }): Promise<SessionInfo[]> {
+	async getAllSessions(nwo: string | undefined, open: boolean, authOptions: AuthOptions): Promise<SessionInfo[]> {
 		try {
-			const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+			const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 			if (!authToken) {
 				this._logService.debug(`[getAllSessions] No authentication token available (nwo=${nwo})`);
 				throw new PermissiveAuthRequiredError();
@@ -234,8 +242,8 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		}
 	}
 
-	async getPullRequestFromGlobalId(globalId: string, authOptions: { createIfNone?: boolean }): Promise<PullRequestSearchItem | null> {
-		const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+	async getPullRequestFromGlobalId(globalId: string, authOptions: AuthOptions): Promise<PullRequestSearchItem | null> {
+		const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 		if (!authToken) {
 			this._logService.trace('No authentication token available for getPullRequestFromGlobalId');
 			throw new PermissiveAuthRequiredError();
@@ -243,9 +251,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		return this.getPullRequestFromSessionWithToken(globalId, authToken);
 	}
 
-	async getCustomAgents(owner: string, repo: string, options: CustomAgentListOptions, authOptions: { createIfNone?: boolean }): Promise<CustomAgentListItem[]> {
+	async getCustomAgents(owner: string, repo: string, options: CustomAgentListOptions, authOptions: AuthOptions): Promise<CustomAgentListItem[]> {
 		try {
-			const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+			const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 			if (!authToken) {
 				this._logService.trace('No authentication token available for getCustomAgents');
 				throw new PermissiveAuthRequiredError();
@@ -280,9 +288,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		}
 	}
 
-	async getCustomAgentDetails(owner: string, repo: string, agentName: string, version: string, authOptions: { createIfNone?: boolean }): Promise<CustomAgentDetails | undefined> {
+	async getCustomAgentDetails(owner: string, repo: string, agentName: string, version: string, authOptions: AuthOptions): Promise<CustomAgentDetails | undefined> {
 		try {
-			const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+			const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 			if (!authToken) {
 				this._logService.trace('No authentication token available for getCustomAgentDetails');
 				throw new PermissiveAuthRequiredError();
@@ -311,8 +319,8 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		}
 	}
 
-	async getPullRequestFiles(owner: string, repo: string, pullNumber: number, authOptions: { createIfNone?: boolean }): Promise<PullRequestFile[]> {
-		const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+	async getPullRequestFiles(owner: string, repo: string, pullNumber: number, authOptions: AuthOptions): Promise<PullRequestFile[]> {
+		const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 		if (!authToken) {
 			this._logService.trace('No authentication token available for getPullRequestFiles');
 			return [];
@@ -320,8 +328,8 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		return this.getPullRequestFilesWithToken(owner, repo, pullNumber, authToken);
 	}
 
-	async closePullRequest(owner: string, repo: string, pullNumber: number, authOptions: { createIfNone?: boolean }): Promise<boolean> {
-		const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+	async closePullRequest(owner: string, repo: string, pullNumber: number, authOptions: AuthOptions): Promise<boolean> {
+		const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 		if (!authToken) {
 			this._logService.trace('No authentication token available for closePullRequest');
 			return false;
@@ -330,7 +338,7 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 	}
 
 	async findPullRequestByHeadBranch(owner: string, repo: string, headBranch: string, authOptions: AuthOptions): Promise<PullRequestSearchItem | undefined> {
-		const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+		const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 		if (!authToken) {
 			this._logService.trace('No authentication token available for findPullRequestByHeadBranch');
 			return undefined;
@@ -338,8 +346,8 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		return this.findPullRequestByHeadBranchWithToken(owner, repo, headBranch, authToken);
 	}
 
-	async getFileContent(owner: string, repo: string, ref: string, path: string, authOptions: { createIfNone?: boolean }): Promise<string> {
-		const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+	async getFileContent(owner: string, repo: string, ref: string, path: string, authOptions: AuthOptions): Promise<string> {
+		const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 		if (!authToken) {
 			this._logService.trace('No authentication token available for getFileContent');
 			throw new PermissiveAuthRequiredError();
@@ -347,8 +355,8 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		return this.getFileContentWithToken(owner, repo, ref, path, authToken);
 	}
 
-	async getUserOrganizations(authOptions: { createIfNone?: boolean }, pageSize?: number): Promise<string[]> {
-		const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+	async getUserOrganizations(authOptions: AuthOptions, pageSize?: number): Promise<string[]> {
+		const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 		if (!authToken) {
 			this._logService.trace('No authentication token available for getUserOrganizations');
 			throw new PermissiveAuthRequiredError();
@@ -356,8 +364,8 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		return this.getUserOrganizationsWithToken(authToken, pageSize);
 	}
 
-	async isUserMemberOfOrg(org: string, authOptions: { createIfNone?: boolean }): Promise<boolean> {
-		const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+	async isUserMemberOfOrg(org: string, authOptions: AuthOptions): Promise<boolean> {
+		const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 		if (!authToken) {
 			this._logService.trace('No authentication token available for isUserMemberOfOrg');
 			return false;
@@ -365,8 +373,8 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		return this.isUserMemberOfOrgWithToken(org, authToken);
 	}
 
-	async getOrganizationRepositories(org: string, authOptions: { createIfNone?: boolean }, pageSize?: number): Promise<string[]> {
-		const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+	async getOrganizationRepositories(org: string, authOptions: AuthOptions, pageSize?: number): Promise<string[]> {
+		const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 		if (!authToken) {
 			this._logService.trace('No authentication token available for getOrganizationRepositories');
 			throw new PermissiveAuthRequiredError();
@@ -374,9 +382,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		return this.getOrganizationRepositoriesWithToken(org, authToken, pageSize);
 	}
 
-	async getOrgCustomInstructions(orgLogin: string, authOptions: { createIfNone?: boolean }): Promise<string | undefined> {
+	async getOrgCustomInstructions(orgLogin: string, authOptions: AuthOptions): Promise<string | undefined> {
 		try {
-			const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+			const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 			if (!authToken) {
 				throw new Error('No authentication token available');
 			}
@@ -403,9 +411,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		}
 	}
 
-	async getUserRepositories(authOptions: { createIfNone?: boolean }, query?: string): Promise<{ owner: string; name: string }[]> {
+	async getUserRepositories(authOptions: AuthOptions, query?: string): Promise<{ owner: string; name: string }[]> {
 		// Use 'permissive' auth to ensure we have the 'repo' scope needed to list private repositories
-		const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+		const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 		if (!authToken) {
 			this._logService.trace('No authentication token available for getUserRepositories');
 			throw new PermissiveAuthRequiredError();
@@ -413,9 +421,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		return this.getUserRepositoriesWithToken(authToken, query);
 	}
 
-	async getRecentlyCommittedRepositories(authOptions: { createIfNone?: boolean }): Promise<{ owner: string; name: string }[]> {
+	async getRecentlyCommittedRepositories(authOptions: AuthOptions): Promise<{ owner: string; name: string }[]> {
 		// Use 'permissive' auth to ensure we have access to private repository events
-		const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+		const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 		if (!authToken) {
 			this._logService.trace('No authentication token available for getRecentlyCommittedRepositories');
 			throw new PermissiveAuthRequiredError();
@@ -423,9 +431,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		return this.getRecentlyCommittedReposWithToken(authToken);
 	}
 
-	async getCopilotAgentModels(authOptions: { createIfNone?: boolean }): Promise<CCAModel[]> {
+	async getCopilotAgentModels(authOptions: AuthOptions): Promise<CCAModel[]> {
 		try {
-			const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+			const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 			if (!authToken) {
 				this._logService.trace('No authentication token available for getCopilotAgentModels');
 				throw new PermissiveAuthRequiredError();
@@ -451,8 +459,8 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		}
 	}
 
-	async getAssignableActors(owner: string, repo: string, authOptions: { createIfNone?: boolean }): Promise<AssignableActor[]> {
-		const auth = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }));
+	async getAssignableActors(owner: string, repo: string, authOptions: AuthOptions): Promise<AssignableActor[]> {
+		const auth = (await this._getPermissiveSession(authOptions));
 		if (!auth?.accessToken) {
 			this._logService.trace('No authentication token available for getAssignableActors');
 			throw new PermissiveAuthRequiredError();
@@ -491,9 +499,9 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 		}
 	}
 
-	async isCCAEnabled(owner: string, repo: string, authOptions: { createIfNone?: boolean }): Promise<CCAEnabledResult> {
+	async isCCAEnabled(owner: string, repo: string, authOptions: AuthOptions): Promise<CCAEnabledResult> {
 		try {
-			const authToken = (await this._authService.getGitHubSession('permissive', authOptions.createIfNone ? { createIfNone: true } : { silent: true }))?.accessToken;
+			const authToken = (await this._getPermissiveSession(authOptions))?.accessToken;
 			if (!authToken) {
 				this._logService.trace('No authentication token available for isCCAEnabled');
 				return { enabled: undefined };

--- a/src/platform/remoteCodeSearch/node/codeSearchRepoAuth.ts
+++ b/src/platform/remoteCodeSearch/node/codeSearchRepoAuth.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as l10n from '@vscode/l10n';
 import { createDecorator as createServiceIdentifier } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { IAuthenticationService } from '../../authentication/common/authentication';
 import { ResolvedRepoRemoteInfo } from '../../git/common/gitService';
@@ -32,7 +33,7 @@ export class BasicCodeSearchAuthenticationService implements ICodeSearchAuthenti
 			return;
 		}
 
-		await this._authenticationService.getGitHubSession('any', { createIfNone: true });
+		await this._authenticationService.getGitHubSession('any', { createIfNone: { detail: l10n.t('Sign in to GitHub to use remote code search.') } });
 	}
 
 	async tryReauthenticating(remoteInfo: ResolvedRepoRemoteInfo | undefined): Promise<void> {
@@ -41,7 +42,7 @@ export class BasicCodeSearchAuthenticationService implements ICodeSearchAuthenti
 			return;
 		}
 
-		await this._authenticationService.getGitHubSession('permissive', { createIfNone: true });
+		await this._authenticationService.getGitHubSession('permissive', { createIfNone: { detail: l10n.t('Sign in to GitHub with additional permissions for remote code search.') } });
 	}
 
 	async promptForExpandedLocalIndexing(fileCount: number): Promise<boolean> {

--- a/src/platform/remoteCodeSearch/vscode-node/codeSearchRepoAuth.ts
+++ b/src/platform/remoteCodeSearch/vscode-node/codeSearchRepoAuth.ts
@@ -52,7 +52,7 @@ export class VsCodeCodeSearchAuthenticationService implements ICodeSearchAuthent
 			}, signInButton, cancelButton);
 
 			if (result === signInButton) {
-				await this._authService.getGitHubSession('any', { createIfNone: true });
+				await this._authService.getGitHubSession('any', { createIfNone: { detail: t('Sign in to GitHub to use remote workspace index.') } });
 				return;
 			}
 		}

--- a/src/platform/urlChunkSearch/node/urlChunkEmbeddingsIndex.ts
+++ b/src/platform/urlChunkSearch/node/urlChunkEmbeddingsIndex.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as l10n from '@vscode/l10n';
 import { createSha256Hash } from '../../../util/common/crypto';
 import { CallTracker, TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
 import { raceCancellationError } from '../../../util/vs/base/common/async';
@@ -128,8 +129,8 @@ export class UrlChunkEmbeddingsIndex extends Disposable {
 		return chunksAndEmbeddings;
 	}
 
-	private async tryGetAuthToken(createIfNone = true): Promise<string | undefined> {
-		return (await this._authService.getGitHubSession('any', { createIfNone }))?.accessToken;
+	private async tryGetAuthToken(): Promise<string | undefined> {
+		return (await this._authService.getGitHubSession('any', { createIfNone: { detail: l10n.t('Sign in to GitHub to access URL chunk embeddings.') } }))?.accessToken;
 	}
 }
 

--- a/src/platform/workspaceChunkSearch/common/githubAvailableEmbeddingTypes.ts
+++ b/src/platform/workspaceChunkSearch/common/githubAvailableEmbeddingTypes.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RequestType } from '@vscode/copilot-api';
+import * as l10n from '@vscode/l10n';
 import { Result } from '../../../util/common/result';
 import { createServiceIdentifier } from '../../../util/common/services';
 import { CallTracker } from '../../../util/common/telemetryCorrelationId';
@@ -99,7 +100,9 @@ export class GithubAvailableEmbeddingTypesService implements IGithubAvailableEmb
 				return initialResult;
 			}
 
-			const permissiveSession = await this._authService.getGitHubSession('permissive', { silent, createIfNone: !silent ? true : undefined });
+			const permissiveSession = silent
+				? await this._authService.getGitHubSession('permissive', { silent })
+				: await this._authService.getGitHubSession('permissive', { createIfNone: { detail: l10n.t('Sign in to GitHub with additional permissions to use workspace embeddings.') } });
 			if (!permissiveSession) {
 				return initialResult;
 			}

--- a/src/platform/workspaceChunkSearch/node/workspaceChunkEmbeddingsIndex.ts
+++ b/src/platform/workspaceChunkSearch/node/workspaceChunkEmbeddingsIndex.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import type { AuthenticationGetSessionOptions } from 'vscode';
+import * as l10n from '@vscode/l10n';
 import { GlobIncludeOptions, shouldInclude } from '../../../util/common/glob';
 import { CallTracker, TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
 import { coalesce } from '../../../util/vs/base/common/arrays';
@@ -171,7 +171,7 @@ export class WorkspaceChunkEmbeddingsIndex extends Disposable {
 			return;
 		}
 
-		const authToken = await this.tryGetAuthToken({ createIfNone: false });
+		const authToken = (await this._authService.getGitHubSession('any', { silent: true }))?.accessToken;
 		if (authToken) {
 			await this.getChunksAndEmbeddings(authToken, file, new ComputeBatchInfo(), EmbeddingsComputeQos.Batch, telemetryInfo.callTracker.add('WorkspaceChunkEmbeddingsIndex::triggerIndexingOfFile'), token);
 		}
@@ -351,7 +351,9 @@ export class WorkspaceChunkEmbeddingsIndex extends Disposable {
 
 		// Telemetry event name kept as 'getAllWorkspaceEmbeddings' for dashboard backward compatibility
 		return logExecTime(this._logService, 'WorkspaceChunkEmbeddingIndex.indexAllWorkspaceFiles', async () => {
-			const authToken = await this.tryGetAuthToken({ createIfNone: true, silent: trigger === 'auto' });
+			const authToken = trigger === 'auto'
+				? (await this._authService.getGitHubSession('any', { silent: true }))?.accessToken
+				: (await this._authService.getGitHubSession('any', { createIfNone: { detail: l10n.t('Sign in to GitHub to index workspace files.') } }))?.accessToken;
 			if (!authToken) {
 				throw new Error('Unable to get auth token');
 			}
@@ -504,7 +506,7 @@ export class WorkspaceChunkEmbeddingsIndex extends Disposable {
 		return this._chunkingEndpointClient.computeChunks(authToken, this._embeddingType, file, batchInfo, qos, cachedChunks, telemetryInfo, token);
 	}
 
-	private async tryGetAuthToken(options: AuthenticationGetSessionOptions = { createIfNone: true }): Promise<string | undefined> {
-		return (await this._authService.getGitHubSession('any', options))?.accessToken;
+	private async tryGetAuthToken(): Promise<string | undefined> {
+		return (await this._authService.getGitHubSession('any', { createIfNone: { detail: l10n.t('Sign in to GitHub to index workspace files.') } }))?.accessToken;
 	}
 }


### PR DESCRIPTION
- Updated `getGitHubSession` method to require `StrictAuthenticationPresentationOptions` for `createIfNone` and `forceNewSession` parameters, ensuring meaningful context is provided to users.
- Modified various service implementations to include localized detail messages for authentication prompts, improving user experience during sign-in.
- Added a comprehensive usage guide for the `IAuthenticationService`, detailing session types, overloads, and constraints.
- GH MCP Feature doesn't bother user over and over for auth
- Introduced a new `AGENTS.md` file to document authentication service usage and best practices.