### PR TITLE
sessions: extend delegated PR lookup retry window

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -1522,7 +1522,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		}
 
 		stream.progress(vscode.l10n.t('Fetching pull request details'));
-		const pullRequest = await this.findPR(number, { retries: 5, repository: selectedRepository });
+		const pullRequest = await this.findPR(number, { retries: 7, repository: selectedRepository });
 		if (!pullRequest) {
 			throw new Error(`Failed to find pull request #${number} after delegation.`);
 		}


### PR DESCRIPTION
## Summary

Increase the delegated cloud-agent pull request lookup retry count from `5` to `7` in `CopilotCloudSessionsProvider`.

Because `findPR` waits `1500ms` between failed attempts, this extends the retry window from about `7.5s` to about `10.5s` before giving up.

## Why

After delegation, the PR can take a little longer to become visible via GitHub APIs. This small increase makes post-delegation PR detection more reliable without changing the lookup behavior itself.

## Validation

- `npm run compile`
- `npm run lint`