### PR TITLE
Add new CAPI standard header for assignment context

### DIFF
--- a/src/platform/endpoint/common/capiClient.ts
+++ b/src/platform/endpoint/common/capiClient.ts
@@ -39,7 +39,7 @@ export abstract class BaseCAPIClientService extends CAPIClient implements ICAPIC
 	}
 
 	override makeRequest<T>(request: MakeRequestOptions, requestMetadata: RequestMetadata): Promise<T> {
-		// Inject AB Exp Context header if available
+		// Inject AB Exp Context headers (legacy VScode-ABExpContext and new standardized X-Copilot-Client-Exp-Assignment-Context) if available
 		if (this.abExpContext) {
 			if (!request.headers) {
 				request.headers = {};


### PR DESCRIPTION
Include the `X-Copilot-Client-Exp-Assignment-Context` header in requests  as new, standardized path for integrators to send this context. Since there is code using the old header, `VScode-ABExpContext` should be removed in a future PR after cleanup.