### PR TITLE
Use selected model when starting Copilot coding agent task

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -2566,7 +2566,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			problem_statement: problemStatement,
 			event_type: 'visual_studio_code_remote_agent_tool_invoked',
 			...(customAgentName && customAgentName !== DEFAULT_CUSTOM_AGENT_ID && { custom_agent: customAgentName }),
-			...(modelName && modelName !== DEFAULT_MODEL_ID && { model_name: modelName }),
+			...(modelName && modelName !== DEFAULT_MODEL_ID && { model: modelName }),
 			...(resolvePartnerAgentName(partnerAgentName)),
 			pull_request: {
 				title,


### PR DESCRIPTION
When setting the session type to "Cloud", VS Code correctly lists models available for Copilot coding agent.

However, the selected model is not honored because it is sent in the `model_name` parameter instead of the expected `model` parameter.

This switches to using the expected `model` parameter, as expected by the `RemoteAgentJobPayload` type and the underlying API.

### Before

I select Opus 4.6, but my job uses Sonnet 4.5, the default model

<img width="935" height="193" alt="CleanShot 2026-03-30 at 12 45 03" src="https://github.com/user-attachments/assets/9d09081f-6742-42c5-baa4-f1c87afe1a1b" />

### After

I select Opus 4.6, and my job uses Opus 4.6

<img width="772" height="149" alt="CleanShot 2026-03-30 at 12 44 33" src="https://github.com/user-attachments/assets/99364a11-ab06-4301-92dd-c33272904b4a" />