### PR TITLE
chore: skip nuget MCP tests until less flaky

### DIFF
--- a/src/extension/mcp/test/vscode-node/nuget.integration.spec.ts
+++ b/src/extension/mcp/test/vscode-node/nuget.integration.spec.ts
@@ -15,7 +15,7 @@ import { FixtureFetcherService } from './util';
 
 const RUN_DOTNET_CLI_TESTS = !!process.env['CI'] && !process.env['BUILD_ARTIFACTSTAGINGDIRECTORY'];
 
-describe.runIf(RUN_DOTNET_CLI_TESTS)('get nuget MCP server info using dotnet CLI', { timeout: 30_000 }, () => {
+describe.runIf(RUN_DOTNET_CLI_TESTS).skip('get nuget MCP server info using dotnet CLI', { timeout: 30_000 }, () => {
 	let testingServiceCollection: TestingServiceCollection;
 	let accessor: ITestingServicesAccessor;
 	let logService: ILogService;


### PR DESCRIPTION
flaky CI failure with a timeout https://github.com/microsoft/vscode-copilot-chat/actions/runs/23746481256/job/69176381546?pr=4304