### PR TITLE
NES: tweak cursor placement for xtab call after cursor prediction

### DIFF
--- a/src/extension/xtab/node/xtabProvider.ts
+++ b/src/extension/xtab/node/xtabProvider.ts
@@ -16,7 +16,7 @@ import { DocumentId } from '../../../platform/inlineEdits/common/dataTypes/docum
 import { Edits } from '../../../platform/inlineEdits/common/dataTypes/edit';
 import { LanguageContextEntry, LanguageContextResponse } from '../../../platform/inlineEdits/common/dataTypes/languageContext';
 import { LanguageId } from '../../../platform/inlineEdits/common/dataTypes/languageId';
-import { NextCursorLinePrediction } from '../../../platform/inlineEdits/common/dataTypes/nextCursorLinePrediction';
+import { NextCursorLinePrediction, NextCursorLinePredictionCursorPlacement } from '../../../platform/inlineEdits/common/dataTypes/nextCursorLinePrediction';
 import * as xtabPromptOptions from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { AggressivenessSetting, isAggressivenessStrategy, LanguageContextLanguages, LanguageContextOptions } from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { InlineEditRequestLogContext } from '../../../platform/inlineEdits/common/inlineEditLogContext';
@@ -1081,7 +1081,9 @@ export class XtabProvider implements IStatelessNextEditProvider {
 
 		const nextCursorLineOneBased = nextCursorLineZeroBased + 1;
 		const nextCursorLine = promptPieces.activeDoc.documentAfterEditsLines.at(nextCursorLineZeroBased);
-		const nextCursorColumn = (nextCursorLine?.length ?? 0) + 1;
+
+		const cursorPlacement = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsNextCursorPredictionCursorPlacement, this.expService);
+		const nextCursorColumn = XtabProvider.getNextCursorColumn(nextCursorLine, cursorPlacement);
 
 		switch (nextCursorLinePrediction) {
 			case NextCursorLinePrediction.Jump: {
@@ -1433,6 +1435,20 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		return filters.reduce((acc, filter) => filter(acc), edits);
 	}
 
+	public static getNextCursorColumn(nextCursorLine: string | undefined, cursorPlacement: NextCursorLinePredictionCursorPlacement): number {
+		let nextCursorColumn: number;
+		switch (cursorPlacement) {
+			case NextCursorLinePredictionCursorPlacement.BeforeLine:
+				nextCursorColumn = (nextCursorLine?.match(/^(\s*)/)?.at(1)?.length ?? 0) + 1;
+				break;
+			case NextCursorLinePredictionCursorPlacement.AfterLine:
+				nextCursorColumn = (nextCursorLine?.length ?? 0) + 1;
+				break;
+			default:
+				assertNever(cursorPlacement);
+		}
+		return nextCursorColumn;
+	}
 }
 
 export function filterOutEditsWithSubstrings(edits: readonly LineReplacement[], substringsToFilterOut: string[]): readonly LineReplacement[] {

--- a/src/extension/xtab/test/node/xtabProvider.spec.ts
+++ b/src/extension/xtab/test/node/xtabProvider.spec.ts
@@ -13,6 +13,7 @@ import { InMemoryConfigurationService } from '../../../../platform/configuration
 import { DocumentId } from '../../../../platform/inlineEdits/common/dataTypes/documentId';
 import { Edits } from '../../../../platform/inlineEdits/common/dataTypes/edit';
 import { LanguageId } from '../../../../platform/inlineEdits/common/dataTypes/languageId';
+import { NextCursorLinePredictionCursorPlacement } from '../../../../platform/inlineEdits/common/dataTypes/nextCursorLinePrediction';
 import { DEFAULT_OPTIONS, LanguageContextLanguages, LintOptionShowCode, LintOptionWarning, ModelConfiguration, PromptingStrategy, ResponseFormat } from '../../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { InlineEditRequestLogContext } from '../../../../platform/inlineEdits/common/inlineEditLogContext';
 import { IInlineEditsModelService } from '../../../../platform/inlineEdits/common/inlineEditsModelService';
@@ -2206,5 +2207,57 @@ suite('filterOutEditsWithSubstrings', () => {
 		const edit = makeEdit([]);
 		const result = filterOutEditsWithSubstrings([edit], ['<|diff_marker|>']);
 		expect(result).toEqual([edit]);
+	});
+});
+
+suite('getNextCursorColumn', () => {
+
+	const { BeforeLine, AfterLine } = NextCursorLinePredictionCursorPlacement;
+
+	/** Inserts a `|` cursor marker at the computed column position (1-based). */
+	function colWithMarker(line: string | undefined, placement: NextCursorLinePredictionCursorPlacement): string {
+		const column = XtabProvider.getNextCursorColumn(line, placement);
+		const s = line ?? '';
+		return s.slice(0, column - 1) + '|' + s.slice(column - 1);
+	}
+
+	test('BeforeLine: indented with spaces', () => {
+		expect(colWithMarker('    const x = 1;', BeforeLine)).toMatchInlineSnapshot(`"    |const x = 1;"`);
+	});
+
+	test('BeforeLine: indented with tabs', () => {
+		expect(colWithMarker('\t\treturn;', BeforeLine)).toMatchInlineSnapshot(`"		|return;"`);
+	});
+
+	test('BeforeLine: no leading whitespace', () => {
+		expect(colWithMarker('function foo() {', BeforeLine)).toMatchInlineSnapshot(`"|function foo() {"`);
+	});
+
+	test('BeforeLine: empty string', () => {
+		expect(colWithMarker('', BeforeLine)).toMatchInlineSnapshot(`"|"`);
+	});
+
+	test('BeforeLine: whitespace-only line', () => {
+		expect(colWithMarker('   ', BeforeLine)).toMatchInlineSnapshot(`"   |"`);
+	});
+
+	test('BeforeLine: undefined', () => {
+		expect(colWithMarker(undefined, BeforeLine)).toMatchInlineSnapshot(`"|"`);
+	});
+
+	test('AfterLine: normal line', () => {
+		expect(colWithMarker('const x = 1;', AfterLine)).toMatchInlineSnapshot(`"const x = 1;|"`);
+	});
+
+	test('AfterLine: empty string', () => {
+		expect(colWithMarker('', AfterLine)).toMatchInlineSnapshot(`"|"`);
+	});
+
+	test('AfterLine: undefined', () => {
+		expect(colWithMarker(undefined, AfterLine)).toMatchInlineSnapshot(`"|"`);
+	});
+
+	test('AfterLine: trailing whitespace', () => {
+		expect(colWithMarker('abc   ', AfterLine)).toMatchInlineSnapshot(`"abc   |"`);
 	});
 });

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -15,6 +15,7 @@ import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStor
 import { packageJson } from '../../env/common/packagejson';
 import { ImportChanges } from '../../inlineEdits/common/dataTypes/importFilteringOptions';
 import { JointCompletionsProviderStrategy, JointCompletionsProviderTriggerChangeStrategy } from '../../inlineEdits/common/dataTypes/jointCompletionsProviderOptions';
+import { NextCursorLinePredictionCursorPlacement } from '../../inlineEdits/common/dataTypes/nextCursorLinePrediction';
 import * as triggerOptions from '../../inlineEdits/common/dataTypes/triggerOptions';
 import * as xtabHistoryOptions from '../../inlineEdits/common/dataTypes/xtabHistoryOptions';
 import * as xtabPromptOptions from '../../inlineEdits/common/dataTypes/xtabPromptOptions';
@@ -784,6 +785,7 @@ export namespace ConfigKey {
 		export const InlineEditsXtabRecentlyViewedDocumentsMaxTokens = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.xtabProvider.recentlyViewedDocuments.maxTokens', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.recentlyViewedDocuments.maxTokens);
 		export const InlineEditsXtabRecentlyViewedIncludeLineNumbers = defineTeamInternalSetting<xtabPromptOptions.IncludeLineNumbersOption>('chat.advanced.inlineEdits.xtabProvider.recentlyViewedDocuments.includeLineNumbers', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.recentlyViewedDocuments.includeLineNumbers);
 		export const InlineEditsNextCursorPredictionRecentSnippetsIncludeLineNumbers = defineTeamInternalSetting<xtabPromptOptions.IncludeLineNumbersOption>('chat.advanced.inlineEdits.nextCursorPrediction.recentSnippets.includeLineNumbers', ConfigType.ExperimentBased, xtabPromptOptions.IncludeLineNumbersOption.None);
+		export const InlineEditsNextCursorPredictionCursorPlacement = defineTeamInternalSetting<NextCursorLinePredictionCursorPlacement>('chat.advanced.inlineEdits.nextCursorPrediction.cursorPlacement', ConfigType.ExperimentBased, NextCursorLinePredictionCursorPlacement.AfterLine, NextCursorLinePredictionCursorPlacement.VALIDATOR);
 		export const InlineEditsXtabDiffNEntries = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.xtabProvider.diffNEntries', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.diffHistory.nEntries);
 		export const InlineEditsXtabDiffMaxTokens = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.xtabProvider.diffMaxTokens', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.diffHistory.maxTokens);
 		export const InlineEditsXtabDiffMergeStrategy = defineTeamInternalSetting<xtabHistoryOptions.DiffHistoryMergeStrategy>('chat.advanced.inlineEdits.xtabProvider.diffMergeStrategy', ConfigType.ExperimentBased, xtabHistoryOptions.DiffHistoryMergeStrategy.SameStartLine, xtabHistoryOptions.DiffHistoryMergeStrategy.VALIDATOR);

--- a/src/platform/inlineEdits/common/dataTypes/nextCursorLinePrediction.ts
+++ b/src/platform/inlineEdits/common/dataTypes/nextCursorLinePrediction.ts
@@ -3,7 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { vEnum } from '../../../configuration/common/validator';
+
 export enum NextCursorLinePrediction {
 	Jump = 'jump',
 	OnlyWithEdit = 'onlyWithEdit',
+}
+
+export enum NextCursorLinePredictionCursorPlacement {
+	BeforeLine = 'beforeLine',
+	AfterLine = 'afterLine',
+}
+
+export namespace NextCursorLinePredictionCursorPlacement {
+	export const VALIDATOR = vEnum(NextCursorLinePredictionCursorPlacement.BeforeLine, NextCursorLinePredictionCursorPlacement.AfterLine);
 }


### PR DESCRIPTION
Adds a configurable cursor placement strategy for next-cursor-line predictions:

- **\`BeforeLine\`**: places cursor at the first non-whitespace column (after indentation)
- **\`AfterLine\`** (default): places cursor at the end of the line (existing behavior)

The placement strategy is experiment-based via \`InlineEditsNextCursorPredictionCursorPlacement\`.