### PR TITLE
Fix whitespace-only text block from orphaned CacheBreakpoint

### DIFF
--- a/src/platform/endpoint/node/messagesApi.ts
+++ b/src/platform/endpoint/node/messagesApi.ts
@@ -381,6 +381,8 @@ function tryParseToolReferences(content: ContentBlockParam[], validToolNames?: S
 
 function rawContentToAnthropicContent(content: readonly Raw.ChatCompletionContentPart[]): ContentBlockParam[] {
 	const convertedContent: ContentBlockParam[] = [];
+	// Track pending cache_control that couldn't be attached to a preceding block
+	let pendingCacheControl = false;
 
 	for (const part of content) {
 		switch (part.type) {
@@ -419,12 +421,12 @@ function rawContentToAnthropicContent(content: readonly Raw.ChatCompletionConten
 				if (previousBlock && contentBlockSupportsCacheControl(previousBlock)) {
 					previousBlock.cache_control = { type: 'ephemeral' };
 				} else {
-					// Empty string is invalid
-					convertedContent.push({
-						type: 'text',
-						text: ' ',
-						cache_control: { type: 'ephemeral' }
-					});
+					// No preceding block to attach to — defer until the next
+					// cacheable content block is added, or silently drop it.
+					// Previously this created a whitespace-only text block which
+					// the Anthropic API rejects with "text content block must
+					// contain non-whitespace text".
+					pendingCacheControl = true;
 				}
 				break;
 			}
@@ -465,6 +467,15 @@ function rawContentToAnthropicContent(content: readonly Raw.ChatCompletionConten
 					}
 				}
 				break;
+			}
+		}
+
+		// Attach any pending cache_control to the block we just added
+		if (pendingCacheControl && convertedContent.length > 0) {
+			const lastBlock = convertedContent.at(-1)!;
+			if (contentBlockSupportsCacheControl(lastBlock)) {
+				lastBlock.cache_control = { type: 'ephemeral' };
+				pendingCacheControl = false;
 			}
 		}
 	}

--- a/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -370,9 +370,32 @@ suite('rawMessagesToMessagesAPI', function () {
 
 		const toolResult = findToolResult(result.messages);
 		expect(toolResult).toBeDefined();
-		expect(toolResult!.cache_control).toEqual({ type: 'ephemeral' });
-		// The dummy whitespace-only text block should be filtered out
+		// Orphaned cache breakpoint with no content to attach to is silently dropped
+		expect(toolResult!.cache_control).toBeUndefined();
 		expect(toolResult!.content).toBeUndefined();
+	});
+
+	test('cache breakpoint before content defers cache_control to next block', function () {
+		const messages: Raw.ChatMessage[] = [
+			{
+				role: Raw.ChatRole.User,
+				content: [
+					{ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint, cacheType: 'ephemeral' },
+					{ type: Raw.ChatCompletionContentPartKind.Text, text: 'hello world' },
+				],
+			},
+		];
+
+		const result = rawMessagesToMessagesAPI(messages);
+
+		expect(result.messages).toHaveLength(1);
+		const content = assertContentArray(result.messages[0].content);
+		expect(content).toHaveLength(1);
+		expect(content[0]).toEqual({
+			type: 'text',
+			text: 'hello world',
+			cache_control: { type: 'ephemeral' },
+		});
 	});
 });
 


### PR DESCRIPTION
## Problem

Fixes microsoft/vscode#305956

## Root Cause

In `rawContentToAnthropicContent()`, the `CacheBreakpoint` handler's `else` branch (when no preceding block exists):
```ts
// Old code
convertedContent.push({ type: 'text', text: ' ', cache_control: { type: 'ephemeral' } });
```

## Fix

Instead of creating an invalid placeholder, **defer** the `cache_control` to the next cacheable content block that gets added. If no subsequent block exists, silently drop it — there's nothing to cache anyway.

- `pendingCacheControl` flag tracks orphaned breakpoints internally
- After each content block is pushed, attach any pending `cache_control` to it
- No change to the function's return type or callers
- No prompt cache regression: the "defer forward" behavior actually improves cache placement (cache covers real content, not a useless space token)

## Test Coverage

- **New test**: `cache breakpoint before content defers cache_control to next block` — verified it fails on old code (2 blocks including whitespace placeholder) and passes on new code (1 block with correct `cache_control`)
- **Updated test**: `cache_control-only tool content` — orphaned breakpoint with no content is now silently dropped (impossible in practice since `addCacheBreakpoints` only targets messages with content)
- All 31 existing tests pass