### PR TITLE
Add internal reasoning effort settings for evals

### DIFF
--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -844,6 +844,10 @@ export namespace ConfigKey {
 		/** Enable WebSocket transport for Responses API requests. When enabled, uses a persistent WebSocket connection per conversation instead of individual HTTP requests. */
 		export const ResponsesApiWebSocketEnabled = defineTeamInternalSetting<boolean>('chat.advanced.responsesApi.webSocket.enabled', ConfigType.ExperimentBased, false);
 		export const DebugSimulateWebSocketResponse = defineTeamInternalSetting<string>('chat.advanced.debug.simulateWebSocketResponse', ConfigType.Simple, '');
+		/** Internal: configure reasoning effort for Responses API. Used by evals. */
+		export const ResponsesApiReasoningEffort = defineTeamInternalSetting<'low' | 'medium' | 'high' | 'xhigh' | undefined>('chat.advanced.responsesApiReasoningEffort', ConfigType.Simple, undefined);
+		/** Internal: configure reasoning effort for Anthropic thinking. Used by evals. */
+		export const AnthropicThinkingEffort = defineTeamInternalSetting<'low' | 'medium' | 'high' | undefined>('chat.advanced.anthropicThinkingEffort', ConfigType.Simple, undefined);
 	}
 
 	/**

--- a/src/platform/endpoint/node/messagesApi.ts
+++ b/src/platform/endpoint/node/messagesApi.ts
@@ -173,7 +173,7 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	// Build output config with effort level for thinking, validating reasoningEffort
 	let effort: 'low' | 'medium' | 'high' | undefined;
 	if (thinkingConfig) {
-		const candidateEffort = reasoningEffort;
+		const candidateEffort = configurationService.getConfig(ConfigKey.TeamInternal.AnthropicThinkingEffort) ?? reasoningEffort;
 		if (candidateEffort === 'low' || candidateEffort === 'medium' || candidateEffort === 'high') {
 			effort = candidateEffort;
 		}

--- a/src/platform/endpoint/node/responsesApi.ts
+++ b/src/platform/endpoint/node/responsesApi.ts
@@ -74,7 +74,8 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 		'disabled';
 	const summaryConfig = configService.getExperimentBasedConfig(ConfigKey.ResponsesApiReasoningSummary, expService);
 	const shouldDisableReasoningSummary = endpoint.family === 'gpt-5.3-codex-spark-preview';
-	const effort = options.reasoningEffort || 'medium';
+	const effortFromSetting = configService.getConfig(ConfigKey.TeamInternal.ResponsesApiReasoningEffort);
+	const effort = effortFromSetting || options.reasoningEffort || 'medium';
 	const summary = summaryConfig === 'off' || shouldDisableReasoningSummary ? undefined : summaryConfig;
 	if (effort || summary) {
 		body.reasoning = {


### PR DESCRIPTION
## Summary

Adds two hidden `TeamInternal` settings for configuring reasoning/thinking effort, intended for eval use:

- `github.copilot.chat.advanced.responsesApiReasoningEffort` — controls effort sent to the Responses API (`low`, `medium`, `high`, `xhigh`)
- `github.copilot.chat.advanced.anthropicThinkingEffort` — controls thinking effort for Anthropic models (`low`, `medium`, `high`)

Both default to `undefined` (no-op). When set, the setting takes priority over the per-request model picker value.

These settings are **not registered in package.json** so they don't appear in the Settings UI — they can only be configured via `settings.json` directly.
