### PR TITLE
Remove redundant quick pick titles from memory commands

### DIFF
--- a/src/extension/chatSessions/claude/vscode-node/slashCommands/memoryCommand.ts
+++ b/src/extension/chatSessions/claude/vscode-node/slashCommands/memoryCommand.ts
@@ -96,7 +96,6 @@ export class MemorySlashCommand implements IClaudeSlashCommandHandler {
 
 		// Show QuickPick
 		const selected = await vscode.window.showQuickPick(items, {
-			title: vscode.l10n.t('Claude Memory'),
 			placeHolder: vscode.l10n.t('Select memory file to edit'),
 			ignoreFocusOut: true,
 		});

--- a/src/extension/tools/vscode-node/tools.ts
+++ b/src/extension/tools/vscode-node/tools.ts
@@ -142,7 +142,6 @@ export class ToolsContribution extends Disposable {
 			}
 
 			const selected = await vscode.window.showQuickPick(items, {
-				title: l10n.t('Memory'),
 				placeHolder: l10n.t('Select a memory file to view'),
 			});
 


### PR DESCRIPTION
Per [VS Code UX guidelines](https://code.visualstudio.com/api/ux-guidelines/quick-picks), quick pick titles should not be used when the placeholder already describes the purpose.

Removes the `title` property from two memory-related quick picks:
- **Show Memory Files** command in `tools.ts` — had `title: 'Memory'` with placeholder `'Select a memory file to view'`
- **Claude /memory** slash command in `memoryCommand.ts` — had `title: 'Claude Memory'` with placeholder `'Select memory file to edit'`

Fixes microsoft/vscode#297325