### PR TITLE
Make vscode_renameSymbol and vscode_listCodeUsages non-deferred

### DIFF
--- a/src/extension/tools/common/toolDeferralService.ts
+++ b/src/extension/tools/common/toolDeferralService.ts
@@ -23,6 +23,9 @@ const additionalNonDeferredToolNames = new Set<string>([
 	ToolName.ToolSearch,
 	// Dynamically injected tools (no ToolName enum entry)
 	'task_complete',
+	// VS Code built-in language tools that should always be available
+	'vscode_renameSymbol',
+	'vscode_listCodeUsages',
 ]);
 
 /**


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/297586