### PR TITLE
Add skillContentRead telemetry event for skill provenance tracking

### DIFF
--- a/src/extension/tools/node/readFileTool.tsx
+++ b/src/extension/tools/node/readFileTool.tsx
@@ -8,11 +8,9 @@ import type * as vscode from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { ObjectJsonSchema } from '../../../platform/configuration/common/jsonSchema';
 import { ICustomInstructionsService } from '../../../platform/customInstructions/common/customInstructionsService';
-import { PERSONAL_SKILL_FOLDERS } from '../../../platform/customInstructions/common/promptTypes';
 import { NotebookDocumentSnapshot } from '../../../platform/editing/common/notebookDocumentSnapshot';
 import { TextDocumentSnapshot } from '../../../platform/editing/common/textDocumentSnapshot';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
-import { INativeEnvService } from '../../../platform/env/common/envService';
 import { IExtensionsService } from '../../../platform/extensions/common/extensionsService';
 import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
 import { IAlternativeNotebookContentService } from '../../../platform/notebook/common/alternativeContent';
@@ -132,7 +130,6 @@ export class ReadFileTool implements ICopilotTool<ReadFileParams> {
 		@ICustomInstructionsService private readonly customInstructionsService: ICustomInstructionsService,
 		@IFileSystemService private readonly fileSystemService: IFileSystemService,
 		@IExtensionsService private readonly extensionsService: IExtensionsService,
-		@INativeEnvService private readonly envService: INativeEnvService,
 	) { }
 
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<ReadFileParams>, token: vscode.CancellationToken) {
@@ -379,7 +376,7 @@ export class ReadFileTool implements ICopilotTool<ReadFileParams> {
 		// Reuses extensionSkillInfo/skillInfo already computed above.
 		// TODO: Add pluginNameHash and pluginVersion properties once vscode core's
 		// extensionPromptFileProvider command exposes IAgentPluginService metadata.
-		if (skillInfo && documentSnapshot) {
+		if (skillInfo && documentSnapshot && uri && this.customInstructionsService.isSkillMdFile(uri)) {
 			const content = documentSnapshot instanceof TextDocumentSnapshot ? documentSnapshot.getText() : '';
 			const extensionId = extensionSkillInfo?.extensionId ?? '';
 			const extensionVersion = extensionId ? this.extensionsService.getExtension(extensionId)?.packageJSON?.version ?? '' : '';
@@ -388,10 +385,10 @@ export class ReadFileTool implements ICopilotTool<ReadFileParams> {
 			// Plaintext properties shared by enhanced GH and internal MSFT events
 			const plaintextProps = {
 				skillName: skillInfo.skillName,
-				skillPath: uri!.toString(),
+				skillPath: uri.toString(),
 				extensionId,
 				extensionVersion,
-				skillStorage: this.getSkillStorage(uri!, extensionSkillInfo),
+				skillStorage: skillInfo.storage,
 				contentHash,
 			};
 
@@ -409,29 +406,6 @@ export class ReadFileTool implements ICopilotTool<ReadFileParams> {
 
 			this.telemetryService.sendInternalMSFTTelemetryEvent('skillContentRead', plaintextProps);
 		}
-	}
-
-	/**
-	 * Classifies skill storage provenance. Mirrors the discovery logic in
-	 * {@link CustomInstructionsService._matchInstructionLocationsFromSkills}
-	 * which uses the same {@link PERSONAL_SKILL_FOLDERS} + userHome check.
-	 *
-	 * Skills from config-based locations (`chat.skills.location` setting) fall
-	 * through to `'local'` since they are user-configured workspace-adjacent paths.
-	 */
-	private getSkillStorage(uri: URI, extensionSkillInfo: { extensionId?: string } | undefined): string {
-		if (extensionSkillInfo?.extensionId) {
-			return 'extension';
-		}
-		if (uri.scheme === 'vscode-chat-internal') {
-			return 'internal';
-		}
-		for (const folder of PERSONAL_SKILL_FOLDERS) {
-			if (extUriBiasedIgnorePathCase.isEqualOrParent(uri, extUriBiasedIgnorePathCase.joinPath(this.envService.userHome, folder))) {
-				return 'user';
-			}
-		}
-		return 'local';
 	}
 
 	async resolveInput(input: IReadFileParamsV1, promptContext: IBuildPromptContext): Promise<IReadFileParamsV1> {

--- a/src/extension/tools/node/test/readFile.spec.tsx
+++ b/src/extension/tools/node/test/readFile.spec.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { afterAll, beforeAll, expect, suite, test } from 'vitest';
-import { ICustomInstructionsService } from '../../../../platform/customInstructions/common/customInstructionsService';
+import { ICustomInstructionsService, SkillStorage } from '../../../../platform/customInstructions/common/customInstructionsService';
 import { IExtensionsService } from '../../../../platform/extensions/common/extensionsService';
 import { IFileSystemService } from '../../../../platform/filesystem/common/fileSystemService';
 import { MockFileSystemService } from '../../../../platform/filesystem/node/test/mockFileSystemService';
@@ -763,7 +763,7 @@ suite('ReadFile', () => {
 
 			const event = telemetry.events.find(e => e.eventName === 'skillContentRead');
 			expect(event).toBeDefined();
-			expect(event!.properties!.skillStorage).toBe('local');
+			expect(event!.properties!.skillStorage).toBe(SkillStorage.Workspace);
 			expect(event!.properties!.skillNameHash).not.toBe('');
 			expect(event!.properties!.extensionIdHash).toBe('');
 			expect(event!.properties!.extensionVersion).toBe('');
@@ -775,7 +775,7 @@ suite('ReadFile', () => {
 			expect(enhanced!.properties!.skillPath).toBe(skillUri.toString());
 			expect(enhanced!.properties!.extensionId).toBe('');
 			expect(enhanced!.properties!.extensionVersion).toBe('');
-			expect(enhanced!.properties!.skillStorage).toBe('local');
+			expect(enhanced!.properties!.skillStorage).toBe(SkillStorage.Workspace);
 			expect(enhanced!.properties!.contentHash).not.toBe('');
 
 			const internal = telemetry.internalEvents.find(e => e.eventName === 'skillContentRead');
@@ -783,7 +783,7 @@ suite('ReadFile', () => {
 			expect(internal!.properties!.skillName).toBe('my-skill');
 			expect(internal!.properties!.skillPath).toBe(skillUri.toString());
 			expect(internal!.properties!.extensionId).toBe('');
-			expect(internal!.properties!.skillStorage).toBe('local');
+			expect(internal!.properties!.skillStorage).toBe(SkillStorage.Workspace);
 			expect(internal!.properties!.contentHash).not.toBe('');
 
 			testAccessor.dispose();
@@ -802,7 +802,7 @@ suite('ReadFile', () => {
 			));
 
 			const mockCustomInstructions = new MockCustomInstructionsService();
-			mockCustomInstructions.setSkillFiles([skillUri]);
+			mockCustomInstructions.setSkillFiles([skillUri], SkillStorage.Personal);
 			services.define(ICustomInstructionsService, mockCustomInstructions);
 
 			const telemetry = new CapturingTelemetryService();
@@ -816,7 +816,7 @@ suite('ReadFile', () => {
 
 			const event = telemetry.events.find(e => e.eventName === 'skillContentRead');
 			expect(event).toBeDefined();
-			expect(event!.properties!.skillStorage).toBe('user');
+			expect(event!.properties!.skillStorage).toBe(SkillStorage.Personal);
 
 			testAccessor.dispose();
 		});
@@ -860,7 +860,7 @@ suite('ReadFile', () => {
 
 			const event = telemetry.events.find(e => e.eventName === 'skillContentRead');
 			expect(event).toBeDefined();
-			expect(event!.properties!.skillStorage).toBe('extension');
+			expect(event!.properties!.skillStorage).toBe(SkillStorage.Extension);
 			expect(event!.properties!.extensionIdHash).not.toBe('');
 			expect(event!.properties!.extensionVersion).toBe('1.2.3');
 			expect(event!.properties!.contentHash).not.toBe('');
@@ -871,7 +871,7 @@ suite('ReadFile', () => {
 			expect(enhanced!.properties!.skillPath).toBe(skillUri.toString());
 			expect(enhanced!.properties!.extensionId).toBe('publisher.my-ext');
 			expect(enhanced!.properties!.extensionVersion).toBe('1.2.3');
-			expect(enhanced!.properties!.skillStorage).toBe('extension');
+			expect(enhanced!.properties!.skillStorage).toBe(SkillStorage.Extension);
 			expect(enhanced!.properties!.contentHash).not.toBe('');
 
 			const internal = telemetry.internalEvents.find(e => e.eventName === 'skillContentRead');
@@ -879,7 +879,7 @@ suite('ReadFile', () => {
 			expect(internal!.properties!.skillName).toBe('ext-skill');
 			expect(internal!.properties!.extensionId).toBe('publisher.my-ext');
 			expect(internal!.properties!.extensionVersion).toBe('1.2.3');
-			expect(internal!.properties!.skillStorage).toBe('extension');
+			expect(internal!.properties!.skillStorage).toBe(SkillStorage.Extension);
 			expect(internal!.properties!.contentHash).not.toBe('');
 
 			testAccessor.dispose();
@@ -897,7 +897,7 @@ suite('ReadFile', () => {
 			));
 
 			const mockCustomInstructions = new MockCustomInstructionsService();
-			mockCustomInstructions.setSkillFiles([skillUri]);
+			mockCustomInstructions.setSkillFiles([skillUri], SkillStorage.Internal);
 			services.define(ICustomInstructionsService, mockCustomInstructions);
 
 			const telemetry = new CapturingTelemetryService();
@@ -911,7 +911,7 @@ suite('ReadFile', () => {
 
 			const event = telemetry.events.find(e => e.eventName === 'skillContentRead');
 			expect(event).toBeDefined();
-			expect(event!.properties!.skillStorage).toBe('internal');
+			expect(event!.properties!.skillStorage).toBe(SkillStorage.Internal);
 
 			testAccessor.dispose();
 		});

--- a/src/platform/customInstructions/common/customInstructionsService.ts
+++ b/src/platform/customInstructions/common/customInstructionsService.ts
@@ -55,6 +55,19 @@ export interface IExtensionPromptFile {
 	extensionId?: string;
 }
 
+export const enum SkillStorage {
+	Extension = 'extension',
+	Internal = 'internal',
+	Personal = 'personal',
+	Workspace = 'workspace',
+}
+
+export interface ISkillInfo {
+	readonly skillName: string;
+	readonly skillFolderUri: URI;
+	readonly storage: SkillStorage;
+}
+
 export interface ICustomInstructionsService {
 	readonly _serviceBrand: undefined;
 	fetchInstructionsFromSetting(configKey: Config<CodeGenerationInstruction[]>): Promise<ICustomInstructions[]>;
@@ -68,7 +81,7 @@ export interface ICustomInstructionsService {
 	isExternalInstructionsFolder(uri: URI): boolean;
 	isSkillFile(uri: URI): boolean;
 	isSkillMdFile(uri: URI): boolean;
-	getSkillInfo(uri: URI): { skillName: string; skillFolderUri: URI } | undefined;
+	getSkillInfo(uri: URI): ISkillInfo | undefined;
 
 	/**
 	 * Refreshes the cached extension prompt files by querying VS Code's extension prompt file provider.
@@ -78,7 +91,7 @@ export interface ICustomInstructionsService {
 	 */
 	refreshExtensionPromptFiles(): Promise<void>;
 	/** Gets skill info for extension-contributed skill files */
-	getExtensionSkillInfo(uri: URI): { skillName: string; skillFolderUri: URI; extensionId?: string } | undefined;
+	getExtensionSkillInfo(uri: URI): (ISkillInfo & { extensionId?: string }) | undefined;
 }
 
 export interface IInstructionIndexFile {
@@ -110,7 +123,7 @@ export class CustomInstructionsService extends Disposable implements ICustomInst
 
 	readonly _matchInstructionLocationsFromConfig: IObservable<(uri: URI) => boolean>;
 	readonly _matchInstructionLocationsFromExtensions: IObservable<(uri: URI) => boolean>;
-	readonly _matchInstructionLocationsFromSkills: IObservable<(uri: URI) => { skillName: string; skillFolderUri: URI } | undefined>;
+	readonly _matchInstructionLocationsFromSkills: IObservable<(uri: URI) => ISkillInfo | undefined>;
 
 	private _extensionPromptFilesCache: IExtensionPromptFile[] | undefined;
 	private readonly _onDidChangeExtensionPromptFilesCache = this._register(new Emitter<void>());
@@ -215,8 +228,11 @@ export class CustomInstructionsService extends Disposable implements ICustomInst
 					const workspaceSkillFolderUris = this.workspaceService.getWorkspaceFolders().flatMap(workspaceFolder =>
 						WORKSPACE_SKILL_FOLDERS.map(folder => extUriBiasedIgnorePathCase.joinPath(workspaceFolder, folder))
 					);
-					// List of **/skills folder URIs
-					const topLevelSkillsFolderUris = [...personalSkillFolderUris, ...workspaceSkillFolderUris];
+					// Tagged list preserving the storage provenance for each folder
+					const taggedSkillFolderUris: { uri: URI; storage: SkillStorage }[] = [
+						...personalSkillFolderUris.map(uri => ({ uri, storage: SkillStorage.Personal as const })),
+						...workspaceSkillFolderUris.map(uri => ({ uri, storage: SkillStorage.Workspace as const })),
+					];
 
 					// Get additional skill locations from config
 					const configSkillLocationUris: URI[] = [];
@@ -246,7 +262,7 @@ export class CustomInstructionsService extends Disposable implements ICustomInst
 
 					return ((uri: URI) => {
 						// Check workspace and personal skill folders
-						for (const topLevelSkillFolderUri of topLevelSkillsFolderUris) {
+						for (const { uri: topLevelSkillFolderUri, storage } of taggedSkillFolderUris) {
 							if (extUriBiasedIgnorePathCase.isEqualOrParent(uri, topLevelSkillFolderUri)) {
 								// Get the path segments relative to the skill folder
 								const relativePath = extUriBiasedIgnorePathCase.relativePath(topLevelSkillFolderUri, uri);
@@ -254,7 +270,7 @@ export class CustomInstructionsService extends Disposable implements ICustomInst
 									// The skill directory is the first path segment under the skill folder
 									const skillName = relativePath.split('/')[0];
 									const skillFolderUri = extUriBiasedIgnorePathCase.joinPath(topLevelSkillFolderUri, skillName);
-									return { skillName, skillFolderUri };
+									return { skillName, skillFolderUri, storage };
 								}
 							}
 						}
@@ -269,7 +285,7 @@ export class CustomInstructionsService extends Disposable implements ICustomInst
 										// The skill directory is the first path segment under the skill folder
 										const skillName = relativePath.split('/')[0];
 										const skillFolderUri = extUriBiasedIgnorePathCase.joinPath(locationUri, skillName);
-										return { skillName, skillFolderUri };
+										return { skillName, skillFolderUri, storage: SkillStorage.Workspace };
 									}
 								}
 							}
@@ -402,7 +418,7 @@ export class CustomInstructionsService extends Disposable implements ICustomInst
 		});
 	}
 
-	public getExtensionSkillInfo(uri: URI): { skillName: string; skillFolderUri: URI; extensionId?: string } | undefined {
+	public getExtensionSkillInfo(uri: URI): (ISkillInfo & { extensionId?: string }) | undefined {
 		if (!this._extensionPromptFilesCache) {
 			return undefined;
 		}
@@ -411,7 +427,7 @@ export class CustomInstructionsService extends Disposable implements ICustomInst
 				const skillFolderUri = extUriBiasedIgnorePathCase.dirname(file.uri);
 				if (extUriBiasedIgnorePathCase.isEqualOrParent(uri, skillFolderUri)) {
 					const skillName = extUriBiasedIgnorePathCase.basename(skillFolderUri);
-					return { skillName, skillFolderUri, extensionId: file.extensionId };
+					return { skillName, skillFolderUri, storage: SkillStorage.Extension, extensionId: file.extensionId };
 				}
 			}
 		}
@@ -473,11 +489,11 @@ export class CustomInstructionsService extends Disposable implements ICustomInst
 		return skillInfo.skillName;
 	}
 
-	public getSkillInfo(uri: URI): { skillName: string; skillFolderUri: URI } | undefined {
+	public getSkillInfo(uri: URI): ISkillInfo | undefined {
 		return this._matchInstructionLocationsFromSkills.get()(uri) || this.getChatInternalSkillInfo(uri);
 	}
 
-	private getChatInternalSkillInfo(uri: URI): { skillName: string; skillFolderUri: URI } | undefined {
+	private getChatInternalSkillInfo(uri: URI): ISkillInfo | undefined {
 		if (uri.scheme !== 'vscode-chat-internal') {
 			return undefined;
 		}
@@ -486,7 +502,7 @@ export class CustomInstructionsService extends Disposable implements ICustomInst
 		}
 		const skillFolderUri = extUriBiasedIgnorePathCase.dirname(uri);
 		const skillName = extUriBiasedIgnorePathCase.basename(skillFolderUri);
-		return { skillName, skillFolderUri };
+		return { skillName, skillFolderUri, storage: SkillStorage.Internal };
 	}
 }
 

--- a/src/platform/test/common/testCustomInstructionsService.ts
+++ b/src/platform/test/common/testCustomInstructionsService.ts
@@ -7,7 +7,7 @@ import { ResourceSet } from '../../../util/vs/base/common/map';
 import { URI } from '../../../util/vs/base/common/uri';
 import type { Uri } from '../../../vscodeTypes';
 import { Config } from '../../configuration/common/configurationService';
-import { CodeGenerationInstruction, ICustomInstructions, ICustomInstructionsService, IInstructionIndexFile } from '../../customInstructions/common/customInstructionsService';
+import { CodeGenerationInstruction, ICustomInstructions, ICustomInstructionsService, IInstructionIndexFile, ISkillInfo, SkillStorage } from '../../customInstructions/common/customInstructionsService';
 
 /**
  * A configurable mock implementation of ICustomInstructionsService for testing.
@@ -16,10 +16,10 @@ import { CodeGenerationInstruction, ICustomInstructions, ICustomInstructionsServ
 export class MockCustomInstructionsService implements ICustomInstructionsService {
 	declare readonly _serviceBrand: undefined;
 
-	private skillFiles = new Set<string>();
+	private skillFiles = new Map<string, SkillStorage>();
 	private externalFiles = new Set<string>();
 	private externalFolders = new Set<string>();
-	private extensionSkillInfos = new Map<string, { skillName: string; skillFolderUri: URI; extensionId: string }>();
+	private extensionSkillInfos = new Map<string, ISkillInfo & { extensionId: string }>();
 
 	parseInstructionIndexFile(promptFileIndexText: string): IInstructionIndexFile {
 		return {
@@ -33,9 +33,9 @@ export class MockCustomInstructionsService implements ICustomInstructionsService
 	/**
 	 * Set the URIs that should be recognized as skill files.
 	 */
-	setSkillFiles(uris: URI[]): void {
+	setSkillFiles(uris: URI[], storage: SkillStorage = SkillStorage.Workspace): void {
 		this.skillFiles.clear();
-		uris.forEach(uri => this.skillFiles.add(uri.toString()));
+		uris.forEach(uri => this.skillFiles.set(uri.toString(), storage));
 	}
 
 	/**
@@ -59,7 +59,7 @@ export class MockCustomInstructionsService implements ICustomInstructionsService
 	 */
 	setExtensionSkillInfos(infos: { uri: URI; skillName: string; skillFolderUri: URI; extensionId: string }[]): void {
 		this.extensionSkillInfos.clear();
-		infos.forEach(info => this.extensionSkillInfos.set(info.uri.toString(), { skillName: info.skillName, skillFolderUri: info.skillFolderUri, extensionId: info.extensionId }));
+		infos.forEach(info => this.extensionSkillInfos.set(info.uri.toString(), { skillName: info.skillName, skillFolderUri: info.skillFolderUri, storage: SkillStorage.Extension, extensionId: info.extensionId }));
 	}
 
 	isSkillFile(uri: URI): boolean {
@@ -89,13 +89,14 @@ export class MockCustomInstructionsService implements ICustomInstructionsService
 		return URI.joinPath(skillDir, 'SKILL.md');
 	}
 
-	getSkillInfo(uri: URI): { skillName: string; skillFolderUri: URI } | undefined {
+	getSkillInfo(uri: URI): ISkillInfo | undefined {
 		if (!this.isSkillFile(uri)) {
 			return undefined;
 		}
 		const skillFolderUri = this.getSkillDirectory(uri);
 		const skillName = this.getSkillName(uri);
-		return { skillName, skillFolderUri };
+		const storage = this.skillFiles.get(uri.toString()) ?? SkillStorage.Workspace;
+		return { skillName, skillFolderUri, storage };
 	}
 
 	isExternalInstructionsFile(uri: URI): Promise<boolean> {
@@ -122,7 +123,7 @@ export class MockCustomInstructionsService implements ICustomInstructionsService
 		return Promise.resolve();
 	}
 
-	getExtensionSkillInfo(uri: URI): { skillName: string; skillFolderUri: URI; extensionId: string } | undefined {
+	getExtensionSkillInfo(uri: URI): (ISkillInfo & { extensionId: string }) | undefined {
 		return this.extensionSkillInfos.get(uri.toString());
 	}
 }


### PR DESCRIPTION
Adds a new `skillContentRead` telemetry event fired when the `read_file` tool successfully reads a skill file. This is separate from the existing `readFileToolInvoked` event and runs off the critical path via `queueMicrotask`.

Addresses https://github.com/microsoft/vscode/pull/306520#issuecomment-4160588650 — moves skill content telemetry from vscode core into the extension.

## What's captured

**GH telemetry event** (`sendGHTelemetryEvent`) — hashed values:
| Property | Description |
|---|---|
| `skillNameHash` | SHA-256 hash of the skill name |
| `skillStorage` | Storage provenance: `extension`, `internal`, `user`, or `local` |
| `extensionIdHash` | SHA-256 hash of the contributing extension ID (empty if not extension-sourced) |
| `extensionVersion` | Semver version of the contributing extension |
| `contentHash` | SHA-256 hash of the full skill file content |

**Enhanced GH telemetry event** (`sendEnhancedGHTelemetryEvent`) — plaintext, opt-in only:
| Property | Description |
|---|---|
| `skillName` | Skill name in plaintext |
| `skillPath` | Full URI of the skill file |
| `extensionId` | Contributing extension ID |
| `extensionVersion` | Extension version |
| `skillStorage` | Same provenance classification |

## Storage classification (`getSkillStorage`)
- **`extension`** — contributed by a VS Code extension via `extensionPromptFileProvider`
- **`internal`** — built-in skill using `vscode-chat-internal` URI scheme
- **`user`** — personal skill under `userHome` + `PERSONAL_SKILL_FOLDERS` (e.g. `~/.copilot/skills/`)
- **`local`** — workspace-level skill (e.g. `.github/skills/`)

## Design decisions
- Separate event from `readFileToolInvoked` to keep concerns clean
- Deferred via `queueMicrotask` so hashing/lookups don't block the tool response
- Snapshot text captured synchronously before deferring (snapshot may not be valid later)
- `pluginNameHash`/`pluginVersion` deferred until vscode core exposes `IAgentPluginService` metadata (TODO in code)