### PR TITLE
Make vision permissions consistent

### DIFF
--- a/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/src/extension/prompts/node/panel/toolCalling.tsx
@@ -695,7 +695,7 @@ class PrimitiveToolResult<T extends IPrimitiveToolResultProps> extends PromptEle
 	}
 
 	protected async onImage(part: LanguageModelDataPart, _imageIndex?: number) {
-		if (!this.endpoint.supportsVision) {
+		if (!this.endpoint.supportsVision || !this.authService.copilotToken?.isEditorPreviewFeaturesEnabled()) {
 			return '[Image content is not available because vision is not supported by the current model or is disabled by your organization.]';
 		}
 


### PR DESCRIPTION
Currently we have inconsistent permissions. In the case where an endpoint supports Vision but the organization preview features disabled, image attachments will not work (because of the preview features disabled) but View Image Tool permissions will succeed because it doesn't check for preview features. This PR makes the two consistent by also checking for preview features for scenarios like the View Image Tool.

Here are some screenshots that show the different behaviors:
<img width="288" height="817" alt="image" src="https://github.com/user-attachments/assets/772cc094-1962-449c-bee5-8b9314bc7505" />

<img width="297" height="831" alt="image" src="https://github.com/user-attachments/assets/3ac72d4b-6e12-4cd4-b7d0-f41cf8ffc8ec" />

And a video from where the screenshots were taken:

https://github.com/user-attachments/assets/ab1774b7-f35a-4f64-862a-08194a2f2d6d

