### PR TITLE
Add reasoning effort level support for BYOK Anthropic models

### DIFF
--- a/src/extension/byok/common/byokProvider.ts
+++ b/src/extension/byok/common/byokProvider.ts
@@ -60,6 +60,7 @@ export interface BYOKModelCapabilities {
 	requestHeaders?: Record<string, string>;
 	supportedEndpoints?: ModelSupportedEndpoint[];
 	zeroDataRetentionEnabled?: boolean;
+	supportsReasoningEffort?: string[];
 }
 
 export interface BYOKModelRegistry {
@@ -149,7 +150,7 @@ export function byokKnownModelToAPIInfo(providerName: string, id: string, capabi
 		capabilities: {
 			toolCalling: capabilities.toolCalling,
 			imageInput: capabilities.vision
-		}
+		},
 	};
 }
 

--- a/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -24,8 +24,9 @@ import { toErrorMessage } from '../../../util/common/errorMessage';
 import { RecordedProgress } from '../../../util/common/progressRecorder';
 import { generateUuid } from '../../../util/vs/base/common/uuid';
 import { anthropicMessagesToRawMessagesForLogging, apiMessageToAnthropicMessage } from '../common/anthropicMessageConverter';
-import { BYOKKnownModels, byokKnownModelsToAPIInfo, BYOKModelCapabilities, LMResponsePart } from '../common/byokProvider';
+import { BYOKKnownModels, BYOKModelCapabilities, LMResponsePart } from '../common/byokProvider';
 import { AbstractLanguageModelChatProvider, ExtendedLanguageModelChatInformation, LanguageModelChatConfiguration } from './abstractLanguageModelChatProvider';
+import { byokKnownModelsToAPIInfoWithEffort } from './byokModelInfo';
 import { IBYOKStorageService } from './byokStorageService';
 
 export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
@@ -86,7 +87,7 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 					};
 				}
 			}
-			return byokKnownModelsToAPIInfo(this._name, modelList);
+			return byokKnownModelsToAPIInfoWithEffort(this._name, modelList);
 		} catch (error) {
 			this._logService.error(error, `Error fetching available ${AnthropicLMProvider.providerName} models`);
 			throw new Error(error.message ? error.message : error);
@@ -262,8 +263,9 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 			}
 
 			const rawEffort = options.modelConfiguration?.reasoningEffort;
-			const effort = supportsAdaptiveThinking && typeof rawEffort === 'string'
-				? rawEffort as 'low' | 'medium' | 'high'
+			const supportsEffort = modelCapabilities?.supportsReasoningEffort;
+			const effort = supportsEffort && typeof rawEffort === 'string' && supportsEffort.includes(rawEffort)
+				? rawEffort as 'low' | 'medium' | 'high' | 'max'
 				: undefined;
 
 			const params: Anthropic.Beta.Messages.MessageCreateParamsStreaming = {

--- a/src/extension/byok/vscode-node/byokModelInfo.ts
+++ b/src/extension/byok/vscode-node/byokModelInfo.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { l10n, type LanguageModelChatInformation, type LanguageModelConfigurationSchema } from 'vscode';
+import { BYOKKnownModels, byokKnownModelsToAPIInfo } from '../common/byokProvider';
+
+/**
+ * Wraps {@link byokKnownModelsToAPIInfo} and enriches each model entry with
+ * a localized configurationSchema for the "Thinking Effort" picker when the
+ * model's capabilities include `supportsReasoningEffort`.
+ */
+export function byokKnownModelsToAPIInfoWithEffort(providerName: string, knownModels: BYOKKnownModels | undefined): LanguageModelChatInformation[] {
+	const models = byokKnownModelsToAPIInfo(providerName, knownModels);
+	if (!knownModels) {
+		return models;
+	}
+
+	return models.map(model => {
+		const capabilities = knownModels[model.id];
+		const effortLevels = capabilities?.supportsReasoningEffort;
+		if (!effortLevels || effortLevels.length === 0) {
+			return model;
+		}
+		return {
+			...model,
+			...buildEffortConfigurationSchema(effortLevels, model.family),
+		};
+	});
+}
+
+function buildEffortConfigurationSchema(effortLevels: readonly string[], family: string): { configurationSchema?: LanguageModelConfigurationSchema } {
+	const lowerFamily = family.toLowerCase();
+	const preferred = lowerFamily.startsWith('claude') ? 'high' : 'medium';
+	const defaultEffort = effortLevels.includes(preferred) ? preferred : undefined;
+
+	return {
+		configurationSchema: {
+			properties: {
+				reasoningEffort: {
+					type: 'string',
+					title: l10n.t('Thinking Effort'),
+					enum: effortLevels,
+					enumItemLabels: effortLevels.map(level => level.charAt(0).toUpperCase() + level.slice(1)),
+					enumDescriptions: effortLevels.map(level => {
+						switch (level) {
+							case 'none': return l10n.t('No reasoning applied');
+							case 'low': return l10n.t('Faster responses with less reasoning');
+							case 'medium': return l10n.t('Balanced reasoning and speed');
+							case 'high': return l10n.t('Maximum reasoning depth');
+							case 'max': return l10n.t('Absolute maximum capability with no constraints');
+							default: return level;
+						}
+					}),
+					default: defaultEffort,
+					group: 'navigation',
+				}
+			}
+		}
+	};
+}


### PR DESCRIPTION
Adds a Thinking Effort picker for BYOK Anthropic models, gated by a `supportsReasoningEffort` capability array in copilotChat.json.

## Changes

### `src/extension/byok/common/byokProvider.ts`
- Added `supportsReasoningEffort?: string[]` to `BYOKModelCapabilities` interface
- Added `buildBYOKConfigurationSchema()` that builds a `configurationSchema` with effort picker UI (enum with descriptions for low/medium/high/max)
- Spreads the schema into `byokKnownModelToAPIInfo` return value

### `src/extension/byok/vscode-node/anthropicProvider.ts`
- Changed effort gate from `supportsAdaptiveThinking` to `supportsReasoningEffort` capability check
- Validates effort value against the model's allowed levels
- Supports `max` effort level (Opus 4.6 exclusive per Anthropic docs)

## Depends on
- microsoft/vscode-engineering#2309 (adds `supportsReasoningEffort` and `adaptiveThinking` to copilotChat.json)