### PR TITLE
[Throwaway POC] Potential fix for `supportsVision` undefined

### DIFF
--- a/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/src/extension/prompts/node/panel/toolCalling.tsx
@@ -417,11 +417,15 @@ class ToolResultElement extends PromptElement<IToolResultElementActualProps & Ba
 }
 
 export function sendInvokedToolTelemetry(tokenizer: ITokenizer, telemetry: ITelemetryService, toolName: string, toolResult: LanguageModelToolResult2) {
+	// Filter out image data parts: this renderer has no IPromptEndpoint registered,
+	// so PrimitiveToolResult.onImage() would crash accessing endpoint.supportsVision.
+	// Image blobs don't contribute to meaningful token counts anyway.
+	const textContent = toolResult.content.filter(part => !isImageDataPart(part));
 	new BasePromptRenderer(
 		{ modelMaxPromptTokens: Infinity },
 		class extends PromptElement {
 			render() {
-				return <UserMessage><PrimitiveToolResult content={toolResult.content} /></UserMessage>;
+				return <UserMessage><PrimitiveToolResult content={textContent} /></UserMessage>;
 			}
 		},
 		{},


### PR DESCRIPTION
I was seeing issues like `TypeError: Cannot read properties of undefined (reading 'supportsVision')` in logs when running local evals, so I asked Copilot to investigate and it suggested this fix. I asked copilot to come up with a PR description, and this is what it said:

---

**Title:** Fix crash in sendInvokedToolTelemetry when tool result contains images

**Description:**

When a tool (e.g. `view_image`) returns an image in its result, `sendInvokedToolTelemetry` crashes with:

```
TypeError: Cannot read properties of undefined (reading 'supportsVision')
```

**Root cause:** `sendInvokedToolTelemetry` creates a bare `BasePromptRenderer` to count tokens, but does not register `IPromptEndpoint` in the DI container. When the tool result contains a `LanguageModelDataPart` image, `PrimitiveToolResult.render()` calls `onImage()`, which accesses `this.endpoint.supportsVision` — but `this.endpoint` is `undefined` because it was never injected.

**Fix:** Filter out image data parts before passing the tool result content to `PrimitiveToolResult`. Image blobs are binary data that don't contribute to meaningful token counts, so they should be excluded from this telemetry path.Continued with Autopilot

Provided the PR title and description as requested. 

