### PR TITLE
Revert: Remove transcript line count from compaction summary

### DIFF
--- a/src/extension/chat/vscode-node/sessionTranscriptService.ts
+++ b/src/extension/chat/vscode-node/sessionTranscriptService.ts
@@ -38,8 +38,6 @@ interface IActiveSession {
 	readonly buffer: string[];
 	/** Chain of flush operations to serialize writes. */
 	flushPromise: Promise<void>;
-	/** Running count of lines in the transcript (flushed + buffered). */
-	lineCount: number;
 }
 
 export class SessionTranscriptService implements ISessionTranscriptService {
@@ -91,7 +89,6 @@ export class SessionTranscriptService implements ISessionTranscriptService {
 			lastEntryId: null,
 			buffer: [],
 			flushPromise: Promise.resolve(),
-			lineCount: 0,
 		};
 		this._activeSessions.set(sessionId, session);
 
@@ -105,12 +102,7 @@ export class SessionTranscriptService implements ISessionTranscriptService {
 		}
 
 		if (fileAlreadyExists) {
-			// Session file exists — we're resuming; count existing lines so getLineCount stays accurate
-			try {
-				const content = await fs.promises.readFile(fileUri.fsPath, 'utf-8');
-				session.lineCount = content.split('\n').filter(l => l.length > 0).length;
-			} catch {
-			}
+			// Session file exists — we're resuming; no need to replay history
 			return;
 		}
 
@@ -222,10 +214,6 @@ export class SessionTranscriptService implements ISessionTranscriptService {
 
 	getTranscriptPath(sessionId: string): URI | undefined {
 		return this._activeSessions.get(sessionId)?.uri;
-	}
-
-	getLineCount(sessionId: string): number | undefined {
-		return this._activeSessions.get(sessionId)?.lineCount;
 	}
 
 	isTranscriptUri(uri: URI): boolean {
@@ -364,7 +352,6 @@ export class SessionTranscriptService implements ISessionTranscriptService {
 		} as TranscriptEntry;
 
 		session.lastEntryId = id;
-		session.lineCount++;
 		session.buffer.push(JSON.stringify(fullEntry) + '\n');
 	}
 

--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -248,7 +248,7 @@ class ConversationHistory extends PromptElement<SummarizedAgentHistoryProps> {
 		}
 
 		if (summaryForCurrentTurn) {
-			history.push(<SummaryMessageElement endpoint={this.props.endpoint} summaryText={summaryForCurrentTurn} transcriptPath={this.props.transcriptPath} transcriptLineCount={this.props.transcriptLineCount} />);
+			history.push(<SummaryMessageElement endpoint={this.props.endpoint} summaryText={summaryForCurrentTurn} transcriptPath={this.props.transcriptPath} />);
 
 			return (<PrioritizedList priority={this.props.priority} descending={false} passPriority={true}>
 				{history.reverse()}
@@ -308,7 +308,7 @@ class ConversationHistory extends PromptElement<SummarizedAgentHistoryProps> {
 
 			if (summaryForTurn) {
 				// We have a summary for a tool call round that was part of this turn
-				turnComponents.push(<SummaryMessageElement endpoint={this.props.endpoint} summaryText={summaryForTurn.text} transcriptPath={this.props.transcriptPath} transcriptLineCount={this.props.transcriptLineCount} />);
+				turnComponents.push(<SummaryMessageElement endpoint={this.props.endpoint} summaryText={summaryForTurn.text} transcriptPath={this.props.transcriptPath} />);
 			} else if (!turn.isContinuation) {
 				turnComponents.push(<AgentUserMessage flexGrow={1} {...getUserMessagePropsFromTurn(turn, this.props.endpoint, {
 					userQueryTagName: this.props.userQueryTagName,
@@ -410,8 +410,6 @@ export interface SummarizedAgentHistoryProps extends BasePromptElementProps, Age
 	readonly summarizationSource?: 'background' | 'foreground';
 	/** Path to the conversation transcript JSONL file, used to inform the model after summarization */
 	readonly transcriptPath?: string;
-	/** Number of lines in the transcript at the time of compaction */
-	readonly transcriptLineCount?: number;
 }
 
 /**
@@ -460,7 +458,6 @@ export class SummarizedConversationHistory extends PromptElement<SummarizedAgent
 
 		// Resolve transcript path and flush to disk so the model can read the up-to-date file
 		let transcriptPath: string | undefined;
-		let transcriptLineCount: number | undefined;
 		if (transcriptLookupEnabled) {
 			const sessionId = this.props.promptContext.conversation?.sessionId;
 			if (sessionId) {
@@ -468,7 +465,6 @@ export class SummarizedConversationHistory extends PromptElement<SummarizedAgent
 				if (transcriptUri) {
 					await this.sessionTranscriptService.flush(sessionId);
 					transcriptPath = transcriptUri.fsPath;
-					transcriptLineCount = this.sessionTranscriptService.getLineCount(sessionId);
 				}
 			}
 		}
@@ -479,7 +475,6 @@ export class SummarizedConversationHistory extends PromptElement<SummarizedAgent
 				{...this.props}
 				promptContext={promptContext}
 				transcriptPath={transcriptPath}
-				transcriptLineCount={transcriptLineCount}
 				enableCacheBreakpoints={this.props.enableCacheBreakpoints} />
 		</>;
 	}
@@ -1007,7 +1002,6 @@ interface SummaryMessageProps extends BasePromptElementProps {
 	readonly summaryText: string;
 	readonly endpoint: IChatEndpoint;
 	readonly transcriptPath?: string;
-	readonly transcriptLineCount?: number;
 }
 
 class SummaryMessageElement extends PromptElement<SummaryMessageProps> {
@@ -1016,7 +1010,7 @@ class SummaryMessageElement extends PromptElement<SummaryMessageProps> {
 			<Tag name='conversation-summary'>
 				{this.props.summaryText}
 			</Tag>
-			{this.props.transcriptPath && <><br />If you need specific details from before compaction (such as exact code snippets, error messages, tool results, or content you previously generated), use the {ToolName.ReadFile} tool to look up the full uncompacted conversation transcript at: "{this.props.transcriptPath}"{this.props.transcriptLineCount !== undefined && <><br />At the time of this request, the transcript has {this.props.transcriptLineCount} lines.</>}<br />Example usage: {ToolName.ReadFile}(filePath: "{this.props.transcriptPath}")</>}
+			{this.props.transcriptPath && <><br />If you need specific details from before compaction (such as exact code snippets, error messages, tool results, or content you previously generated), use the {ToolName.ReadFile} tool to look up the full uncompacted conversation transcript at: {this.props.transcriptPath}</>}
 			{this.props.endpoint.family === 'gpt-4.1' && <Tag name='reminderInstructions'>
 				<DefaultOpenAIKeepGoingReminder />
 			</Tag>}

--- a/src/platform/chat/common/sessionTranscriptService.ts
+++ b/src/platform/chat/common/sessionTranscriptService.ts
@@ -238,12 +238,6 @@ export interface ISessionTranscriptService {
 	getTranscriptPath(sessionId: string): URI | undefined;
 
 	/**
-	 * Get the current number of lines in the transcript for a session.
-	 * Returns `undefined` if the session is not active.
-	 */
-	getLineCount(sessionId: string): number | undefined;
-
-	/**
 	 * Remove transcript files for sessions that are no longer active,
 	 * keeping at most `maxRetained` most-recent ended sessions.
 	 */
@@ -269,7 +263,6 @@ export class NullSessionTranscriptService implements ISessionTranscriptService {
 	async flush(): Promise<void> { }
 	async endSession(): Promise<void> { }
 	getTranscriptPath(): URI | undefined { return undefined; }
-	getLineCount(): number | undefined { return undefined; }
 	async cleanupOldTranscripts(): Promise<void> { }
 	isTranscriptUri(): boolean { return false; }
 }


### PR DESCRIPTION
Reverts #4811.

The transcript line count added to the compaction summary changes every turn (it's read live via `getLineCount()`), which invalidates the prompt cache.

Removing the line count restores cache stability. The transcript path hint remains so the model can still look up the full conversation.