### PR TITLE
Cache-friendly summarization: bake transcript hint into summary text

### DIFF
--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -499,6 +499,12 @@ export class SummarizedConversationHistory extends PromptElement<SummarizedAgent
 			return;
 		}
 
+		// Short-circuit if session already exists — avoids rebuilding
+		// the full IHistoricalTurn[] array on every render.
+		if (this.sessionTranscriptService.getTranscriptPath(sessionId)) {
+			return;
+		}
+
 		// Build IHistoricalTurn[] from the prompt context's Turn[] history
 		const history: IHistoricalTurn[] = this.props.promptContext.history.map(turn => ({
 			userMessage: turn.request.message,


### PR DESCRIPTION
At compaction time, append the transcript hint (path + frozen line count + `read_file` example) directly into `round.summary`. On subsequent renders the text is constant, preserving cache stability.

### Changes
- **Bake hint into summary string** in `SummarizedConversationHistory.render()` — transcript path, line count, and usage example are appended to the summary text once at compaction time
- **Remove `transcriptPath` prop** from `SummarizedAgentHistoryProps`, `ConversationHistory`, and `SummaryMessageElement`
- **Remove `transcriptLineCount` prop** and all freeze-on-round plumbing
- **Fix ordering bug**: move `ensureTranscriptSession()` before `getTranscriptPath()` so the session exists on first compaction

### Result
The compaction summary `UserMessage` is now byte-identical across turns → full prefix cache hits restored.