### PR TITLE
fix: merge SDK anthropic-beta headers with base endpoint betas

### DIFF
--- a/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
+++ b/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
@@ -494,7 +494,17 @@ class ClaudeStreamingPassThroughEndpoint implements IChatEndpoint {
 		if (typeof this.requestHeaders['anthropic-beta'] === 'string') {
 			const filtered = filterSupportedBetas(this.requestHeaders['anthropic-beta']);
 			if (filtered) {
-				headers['anthropic-beta'] = filtered;
+				if (headers['anthropic-beta']) {
+					// Merge SDK's filtered betas with base endpoint's betas (e.g. config-driven
+					// context-management) instead of overwriting, deduplicating exact matches.
+					const allBetas = new Set([
+						...headers['anthropic-beta'].split(',').map(b => b.trim()),
+						...filtered.split(',').map(b => b.trim()),
+					]);
+					headers['anthropic-beta'] = [...allBetas].join(',');
+				} else {
+					headers['anthropic-beta'] = filtered;
+				}
 			}
 		}
 		return headers;


### PR DESCRIPTION
## Problem

When `contextEditing.mode` is enabled (e.g. `clear-tooluse`), the Claude agent fails with:

```
400 {"type":"error","error":{"type":"invalid_request_error","message":"context_management: Extra inputs are not permitted"}}
```

## Root Cause

In `ClaudeStreamingPassThroughEndpoint.getExtraHeaders()`, the SDK's `anthropic-beta` header was **overwriting** the base endpoint's beta headers instead of merging with them.

1. The base `chatEndpoint.getExtraHeaders()` adds `context-management-2025-06-27` to `anthropic-beta` (driven by the `contextEditing.mode` config)
2. `createMessagesRequestBody` adds `context_management` to the request body
3. Then the SDK's `anthropic-beta` header (which doesn't include `context-management`) **replaces** the base's value
4. CAPI receives `context_management` in the body without the required beta header → 400 error

## Fix

Merge the SDK's filtered betas with the base endpoint's betas using a `Set` to deduplicate, instead of overwriting.

Fixes microsoft/vscode#298471