### PR TITLE
Add prompt file support to Copilot CLI chatSessionCustomizationsProvider

### DIFF
--- a/src/extension/chatSessions/common/chatPromptFileService.ts
+++ b/src/extension/chatSessions/common/chatPromptFileService.ts
@@ -72,4 +72,15 @@ export interface IChatPromptFileService extends IDisposable {
 	 * The list of currently installed agent plugins.
 	 */
 	readonly plugins: readonly ChatResource[];
+
+	/**
+	 * An event that fires when the list of {@link promptFiles prompt files} changes.
+	 */
+	readonly onDidChangePromptFiles: Event<void>;
+
+	/**
+	 * The list of currently available prompt files. These are `.prompt.md` files
+	 * from all sources (workspace, user, and extension-provided).
+	 */
+	readonly promptFiles: readonly ChatResource[];
 }

--- a/src/extension/chatSessions/copilotcli/node/test/copilotCLISkills.spec.ts
+++ b/src/extension/chatSessions/copilotcli/node/test/copilotCLISkills.spec.ts
@@ -36,9 +36,11 @@ class TestChatPromptFileService extends Disposable implements IChatPromptFileSer
 	readonly onDidChangeSkills: Event<void> = Event.None;
 	readonly onDidChangeHooks: Event<void> = Event.None;
 	readonly onDidChangePlugins: Event<void> = Event.None;
+	readonly onDidChangePromptFiles: Event<void> = Event.None;
 	readonly customAgents: readonly ChatResource[] = [];
 	readonly customAgentPromptFiles: readonly ParsedPromptFile[] = [];
 	readonly instructions: readonly ChatResource[] = [];
+	readonly promptFiles: readonly ChatResource[] = [];
 	skills: readonly ChatResource[] = [];
 	readonly hooks: readonly ChatResource[] = [];
 	readonly plugins: readonly ChatResource[] = [];

--- a/src/extension/chatSessions/copilotcli/node/test/copilotCliAgents.spec.ts
+++ b/src/extension/chatSessions/copilotcli/node/test/copilotCliAgents.spec.ts
@@ -51,11 +51,13 @@ class TestChatPromptFileService extends Disposable implements IChatPromptFileSer
 	readonly onDidChangeSkills: Event<void> = Event.None;
 	readonly onDidChangeHooks: Event<void> = Event.None;
 	readonly onDidChangePlugins: Event<void> = Event.None;
+	readonly onDidChangePromptFiles: Event<void> = Event.None;
 	readonly customAgents: readonly import('vscode').ChatResource[] = [];
 	readonly instructions: readonly import('vscode').ChatResource[] = [];
 	readonly skills: readonly import('vscode').ChatResource[] = [];
 	readonly hooks: readonly import('vscode').ChatResource[] = [];
 	readonly plugins: readonly import('vscode').ChatResource[] = [];
+	readonly promptFiles: readonly import('vscode').ChatResource[] = [];
 
 	constructor(private _customAgentPromptFiles: ParsedPromptFile[] = []) {
 		super();

--- a/src/extension/chatSessions/copilotcli/vscode-node/test/testHelpers.ts
+++ b/src/extension/chatSessions/copilotcli/vscode-node/test/testHelpers.ts
@@ -239,11 +239,13 @@ export class MockChatPromptFileService extends Disposable implements IChatPrompt
 	skills: ChatResource[] = [];
 	hooks: ChatResource[] = [];
 	plugins: ChatResource[] = [];
+	promptFiles: ChatResource[] = [];
 	private readonly _onDidChangeCustomAgents = this._register(new Emitter<void>());
 	private readonly _onDidChangeInstructions = this._register(new Emitter<void>());
 	private readonly _onDidChangeSkills = this._register(new Emitter<void>());
 	private readonly _onDidChangeHooks = this._register(new Emitter<void>());
 	private readonly _onDidChangePlugins = this._register(new Emitter<void>());
+	private readonly _onDidChangePromptFiles = this._register(new Emitter<void>());
 
 	get onDidChangeCustomAgents() {
 		return this._onDidChangeCustomAgents.event;
@@ -263,6 +265,10 @@ export class MockChatPromptFileService extends Disposable implements IChatPrompt
 
 	get onDidChangePlugins() {
 		return this._onDidChangePlugins.event;
+	}
+
+	get onDidChangePromptFiles() {
+		return this._onDidChangePromptFiles.event;
 	}
 	get customAgentPromptFiles() {
 		return [];

--- a/src/extension/chatSessions/vscode-node/chatPromptFileService.ts
+++ b/src/extension/chatSessions/vscode-node/chatPromptFileService.ts
@@ -26,6 +26,8 @@ export class ChatPromptFileService extends Disposable implements IChatPromptFile
 	readonly onDidChangeHooks: Event<void> = this._onDidChangeHooks.event;
 	private readonly _onDidChangePlugins = this._register(new Emitter<void>());
 	readonly onDidChangePlugins: Event<void> = this._onDidChangePlugins.event;
+	private readonly _onDidChangePromptFiles = this._register(new Emitter<void>());
+	readonly onDidChangePromptFiles: Event<void> = this._onDidChangePromptFiles.event;
 
 	private _customAgents: ParsedPromptFile[] = [];
 	private refreshCts: CancellationTokenSource | undefined;
@@ -55,6 +57,12 @@ export class ChatPromptFileService extends Disposable implements IChatPromptFile
 		this._register(vscode.chat.onDidChangePlugins(() => {
 			this._onDidChangePlugins.fire();
 		}));
+
+		if (vscode.chat.onDidChangePromptFiles) {
+			this._register(vscode.chat.onDidChangePromptFiles(() => {
+				this._onDidChangePromptFiles.fire();
+			}));
+		}
 		this.triggerRefreshCustomAgents();
 	}
 
@@ -80,6 +88,10 @@ export class ChatPromptFileService extends Disposable implements IChatPromptFile
 
 	get plugins(): readonly vscode.ChatResource[] {
 		return vscode.chat.plugins;
+	}
+
+	get promptFiles(): readonly vscode.ChatResource[] {
+		return vscode.chat.promptFiles ?? [];
 	}
 
 	override dispose(): void {

--- a/src/extension/chatSessions/vscode-node/copilotCLICustomizationProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLICustomizationProvider.ts
@@ -6,7 +6,7 @@
 import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
 import { ICustomInstructionsService } from '../../../platform/customInstructions/common/customInstructionsService';
-import { INSTRUCTION_FILE_EXTENSION, SKILL_FILENAME } from '../../../platform/customInstructions/common/promptTypes';
+import { INSTRUCTION_FILE_EXTENSION, PROMPT_FILE_EXTENSION, SKILL_FILENAME } from '../../../platform/customInstructions/common/promptTypes';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IPromptsService } from '../../../platform/promptFiles/common/promptsService';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
@@ -32,6 +32,7 @@ export class CopilotCLICustomizationProvider extends Disposable implements vscod
 				vscode.ChatSessionCustomizationType.Instructions,
 				vscode.ChatSessionCustomizationType.Hook,
 				vscode.ChatSessionCustomizationType.Plugins,
+				vscode.ChatSessionCustomizationType.Prompt,
 			],
 		};
 	}
@@ -50,6 +51,7 @@ export class CopilotCLICustomizationProvider extends Disposable implements vscod
 		this._register(this.chatPromptFileService.onDidChangeSkills(() => this._onDidChange.fire()));
 		this._register(this.chatPromptFileService.onDidChangeHooks(() => this._onDidChange.fire()));
 		this._register(this.chatPromptFileService.onDidChangePlugins(() => this._onDidChange.fire()));
+		this._register(this.chatPromptFileService.onDidChangePromptFiles(() => this._onDidChange.fire()));
 		this._register(this.copilotCLIAgents.onDidChangeAgents(() => this._onDidChange.fire()));
 	}
 
@@ -59,6 +61,7 @@ export class CopilotCLICustomizationProvider extends Disposable implements vscod
 		const skills = this.getSkillItems();
 		const hooks = this.getHookItems();
 		const plugins = this.getPluginItems();
+		const prompts = this.getPromptFileItems();
 
 		this.logService.debug(`[CopilotCLICustomizationProvider] agents (${agents.length}): ${agents.map(a => a.name).join(', ') || '(none)'}`);
 		this.logService.debug(`[CopilotCLICustomizationProvider] instructions (${instructions.length}): ${instructions.map(i => i.name).join(', ') || '(none)'}`);
@@ -66,8 +69,9 @@ export class CopilotCLICustomizationProvider extends Disposable implements vscod
 		this.logService.debug(`[CopilotCLICustomizationProvider] hooks (${hooks.length}): ${hooks.map(h => h.name).join(', ') || '(none)'}`);
 
 		this.logService.debug(`[CopilotCLICustomizationProvider] plugins (${plugins.length}): ${plugins.map(p => p.name).join(', ') || '(none)'}`);
+		this.logService.debug(`[CopilotCLICustomizationProvider] prompts (${prompts.length}): ${prompts.map(p => p.name).join(', ') || '(none)'}`);
 
-		const items = [...agents, ...instructions, ...skills, ...hooks, ...plugins];
+		const items = [...agents, ...instructions, ...skills, ...hooks, ...plugins, ...prompts];
 		this.logService.debug(`[CopilotCLICustomizationProvider] total: ${items.length} items`);
 		return items;
 	}
@@ -190,6 +194,17 @@ export class CopilotCLICustomizationProvider extends Disposable implements vscod
 			name: basename(p.uri),
 		}));
 	}
+
+	/**
+	 * Collects all prompt file items from the prompt file service.
+	 */
+	private getPromptFileItems(): vscode.ChatSessionCustomizationItem[] {
+		return this.chatPromptFileService.promptFiles.map(p => ({
+			uri: p.uri,
+			type: vscode.ChatSessionCustomizationType.Prompt,
+			name: deriveNameFromUri(p.uri, PROMPT_FILE_EXTENSION),
+		}));
+	}
 }
 
 function deriveNameFromUri(uri: vscode.Uri, extensionOrFilename: string): string {
@@ -199,7 +214,7 @@ function deriveNameFromUri(uri: vscode.Uri, extensionOrFilename: string): string
 		const parts = uri.path.split('/');
 		return parts.length >= 2 ? parts[parts.length - 2] : filename;
 	}
-	if (filename.endsWith(extensionOrFilename)) {
+	if (filename.toLowerCase().endsWith(extensionOrFilename.toLowerCase())) {
 		return filename.slice(0, -extensionOrFilename.length);
 	}
 	return filename;

--- a/src/extension/chatSessions/vscode-node/test/copilotCLICustomizationProvider.spec.ts
+++ b/src/extension/chatSessions/vscode-node/test/copilotCLICustomizationProvider.spec.ts
@@ -66,30 +66,36 @@ class MockChatPromptFileService extends mock<IChatPromptFileService>() {
 	override readonly onDidChangeHooks = this._onDidChangeHooks.event;
 	private readonly _onDidChangePlugins = new Emitter<void>();
 	override readonly onDidChangePlugins = this._onDidChangePlugins.event;
+	private readonly _onDidChangePromptFiles = new Emitter<void>();
+	override readonly onDidChangePromptFiles = this._onDidChangePromptFiles.event;
 
 	private _customAgents: vscode.ChatResource[] = [];
 	private _instructions: vscode.ChatResource[] = [];
 	private _skills: vscode.ChatResource[] = [];
 	private _hooks: vscode.ChatResource[] = [];
 	private _plugins: vscode.ChatResource[] = [];
+	private _promptFiles: vscode.ChatResource[] = [];
 
 	override get customAgents(): readonly vscode.ChatResource[] { return this._customAgents; }
 	override get instructions(): readonly vscode.ChatResource[] { return this._instructions; }
 	override get skills(): readonly vscode.ChatResource[] { return this._skills; }
 	override get hooks(): readonly vscode.ChatResource[] { return this._hooks; }
 	override get plugins(): readonly vscode.ChatResource[] { return this._plugins; }
+	override get promptFiles(): readonly vscode.ChatResource[] { return this._promptFiles; }
 
 	setCustomAgents(agents: vscode.ChatResource[]) { this._customAgents = agents; }
 	setInstructions(instructions: vscode.ChatResource[]) { this._instructions = instructions; }
 	setSkills(skills: vscode.ChatResource[]) { this._skills = skills; }
 	setHooks(hooks: vscode.ChatResource[]) { this._hooks = hooks; }
 	setPlugins(plugins: vscode.ChatResource[]) { this._plugins = plugins; }
+	setPromptFiles(promptFiles: vscode.ChatResource[]) { this._promptFiles = promptFiles; }
 
 	fireCustomAgentsChanged() { this._onDidChangeCustomAgents.fire(); }
 	fireInstructionsChanged() { this._onDidChangeInstructions.fire(); }
 	fireSkillsChanged() { this._onDidChangeSkills.fire(); }
 	fireHooksChanged() { this._onDidChangeHooks.fire(); }
 	firePluginsChanged() { this._onDidChangePlugins.fire(); }
+	firePromptFilesChanged() { this._onDidChangePromptFiles.fire(); }
 
 	override dispose() {
 		this._onDidChangeCustomAgents.dispose();
@@ -97,6 +103,7 @@ class MockChatPromptFileService extends mock<IChatPromptFileService>() {
 		this._onDidChangeSkills.dispose();
 		this._onDidChangeHooks.dispose();
 		this._onDidChangePlugins.dispose();
+		this._onDidChangePromptFiles.dispose();
 	}
 }
 
@@ -174,15 +181,16 @@ describe('CopilotCLICustomizationProvider', () => {
 			expect(CopilotCLICustomizationProvider.metadata.iconId).toBe('worktree');
 		});
 
-		it('supports Agent, Skill, Instructions, Hook, and Plugins types', () => {
+		it('supports Agent, Skill, Instructions, Hook, Plugins, and Prompt types', () => {
 			const supported = CopilotCLICustomizationProvider.metadata.supportedTypes;
 			expect(supported).toBeDefined();
-			expect(supported).toHaveLength(5);
+			expect(supported).toHaveLength(6);
 			expect(supported).toContain(FakeChatSessionCustomizationType.Agent);
 			expect(supported).toContain(FakeChatSessionCustomizationType.Skill);
 			expect(supported).toContain(FakeChatSessionCustomizationType.Instructions);
 			expect(supported).toContain(FakeChatSessionCustomizationType.Hook);
 			expect(supported).toContain(FakeChatSessionCustomizationType.Plugins);
+			expect(supported).toContain(FakeChatSessionCustomizationType.Prompt);
 		});
 
 		it('only returns items whose type is in supportedTypes', async () => {
@@ -289,9 +297,10 @@ describe('CopilotCLICustomizationProvider', () => {
 			mockPromptFileService.setSkills([{ uri: URI.file('/workspace/.github/skills/c/SKILL.md') }]);
 			mockPromptFileService.setHooks([{ uri: URI.file('/workspace/.copilot/hooks/pre-commit.json') }]);
 			mockPromptFileService.setPlugins([{ uri: URI.file('/workspace/.copilot/plugins/my-plugin') }]);
+			mockPromptFileService.setPromptFiles([{ uri: URI.file('/workspace/.github/prompts/d.prompt.md') }]);
 
 			const items = await provider.provideChatSessionCustomizations(undefined!);
-			expect(items).toHaveLength(5);
+			expect(items).toHaveLength(6);
 		});
 
 		it('returns hooks with correct type and name', async () => {
@@ -332,6 +341,35 @@ describe('CopilotCLICustomizationProvider', () => {
 			expect(items[0].uri).toEqual(uri);
 			expect(items[0].type).toBe(FakeChatSessionCustomizationType.Plugins);
 			expect(items[0].name).toBe('lint-rules');
+		});
+
+		it('returns prompt files with correct type and name', async () => {
+			const uri = URI.file('/workspace/.github/prompts/summarize.prompt.md');
+			mockPromptFileService.setPromptFiles([{ uri }]);
+
+			const items = await provider.provideChatSessionCustomizations(undefined!);
+			expect(items).toHaveLength(1);
+			expect(items[0].uri).toBe(uri);
+			expect(items[0].type).toBe(FakeChatSessionCustomizationType.Prompt);
+			expect(items[0].name).toBe('summarize');
+		});
+
+		it('derives prompt file name by stripping .prompt.md extension', async () => {
+			const uri = URI.file('/workspace/.github/prompts/code-review.prompt.md');
+			mockPromptFileService.setPromptFiles([{ uri }]);
+
+			const items = await provider.provideChatSessionCustomizations(undefined!);
+			expect(items).toHaveLength(1);
+			expect(items[0].name).toBe('code-review');
+		});
+
+		it('handles case-insensitive extension stripping for prompt files', async () => {
+			const uri = URI.file('/workspace/.github/prompts/summarize.Prompt.MD');
+			mockPromptFileService.setPromptFiles([{ uri }]);
+
+			const items = await provider.provideChatSessionCustomizations(undefined!);
+			expect(items).toHaveLength(1);
+			expect(items[0].name).toBe('summarize');
 		});
 	});
 
@@ -498,6 +536,14 @@ describe('CopilotCLICustomizationProvider', () => {
 			disposables.add(provider.onDidChange(() => { fired = true; }));
 
 			mockPromptFileService.firePluginsChanged();
+			expect(fired).toBe(true);
+		});
+
+		it('fires when prompt files change', () => {
+			let fired = false;
+			disposables.add(provider.onDidChange(() => { fired = true; }));
+
+			mockPromptFileService.firePromptFilesChanged();
 			expect(fired).toBe(true);
 		});
 

--- a/src/extension/vscode.proposed.chatPromptFiles.d.ts
+++ b/src/extension/vscode.proposed.chatPromptFiles.d.ts
@@ -181,6 +181,17 @@ declare module 'vscode' {
 		export const plugins: readonly ChatResource[];
 
 		/**
+		 * An event that fires when the list of {@link promptFiles prompt files} changes.
+		 */
+		export const onDidChangePromptFiles: Event<void>;
+
+		/**
+		 * The list of currently available prompt files. These are `.prompt.md` files
+		 * from all sources (workspace, user, and extension-provided).
+		 */
+		export const promptFiles: readonly ChatResource[];
+
+		/**
 		 * Register a provider for custom agents.
 		 * @param provider The custom agent provider.
 		 * @returns A disposable that unregisters the provider when disposed.


### PR DESCRIPTION
## Summary

Wire `.prompt.md` files through the `ChatPromptFileService` and `CopilotCLICustomizationProvider` so they appear in the session customizations management UI.

## Dependencies

Depends on [microsoft/vscode#307722](https://github.com/microsoft/vscode/pull/307722) which adds `chat.promptFiles` and `chat.onDidChangePromptFiles` to the VS Code proposed API namespace. The `vscode-dts:check` CI step will fail until that PR lands and we run `vscode-dts:update`.

## Changes

- **Proposed d.ts** (`vscode.proposed.chatPromptFiles.d.ts`): Add `chat.promptFiles` and `chat.onDidChangePromptFiles` to the namespace (matching the pattern of all other resource types)
- **Service interface** (`IChatPromptFileService`): Add `promptFiles` getter and `onDidChangePromptFiles` event
- **Service implementation** (`ChatPromptFileService`): Forward from `vscode.chat.promptFiles` with backcompat guards (`?? []`, conditional event registration)
- **Customization provider** (`CopilotCLICustomizationProvider`): Add `Prompt` to `supportedTypes`, new `getPromptFileItems()` method, change event wiring, debug logging
- **Case-insensitive fix**: Make `deriveNameFromUri` extension stripping case-insensitive
- **Tests**: 4 new test cases (prompt files, name derivation, case-insensitivity, change event) + updated combined types test + mock implementations

## Backcompat

Uses the same pattern as #4968 — backcompat guards so the extension works on VS Code versions where `chat.promptFiles` doesn't exist yet:
- `vscode.chat.promptFiles ?? []` for the getter
- `if (vscode.chat.onDidChangePromptFiles)` before event registration