### PR TITLE
chatSessionsProvider: add groupKeys and badges for instructions in CLI customization provider

### DIFF
--- a/src/extension/chatSessions/vscode-node/copilotCLICustomizationProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLICustomizationProvider.ts
@@ -3,9 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
+import { ICustomInstructionsService } from '../../../platform/customInstructions/common/customInstructionsService';
 import { INSTRUCTION_FILE_EXTENSION, SKILL_FILENAME } from '../../../platform/customInstructions/common/promptTypes';
 import { ILogService } from '../../../platform/log/common/logService';
+import { IPromptsService } from '../../../platform/promptFiles/common/promptsService';
+import { CancellationToken } from '../../../util/vs/base/common/cancellation';
+import { isCancellationError } from '../../../util/vs/base/common/errors';
 import { Emitter } from '../../../util/vs/base/common/event';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { basename } from '../../../util/vs/base/common/resources';
@@ -33,6 +38,8 @@ export class CopilotCLICustomizationProvider extends Disposable implements vscod
 	constructor(
 		@IChatPromptFileService private readonly chatPromptFileService: IChatPromptFileService,
 		@ICopilotCLIAgents private readonly copilotCLIAgents: ICopilotCLIAgents,
+		@ICustomInstructionsService private readonly customInstructionsService: ICustomInstructionsService,
+		@IPromptsService private readonly promptsService: IPromptsService,
 		@ILogService private readonly logService: ILogService,
 	) {
 		super();
@@ -44,9 +51,9 @@ export class CopilotCLICustomizationProvider extends Disposable implements vscod
 		this._register(this.copilotCLIAgents.onDidChangeAgents(() => this._onDidChange.fire()));
 	}
 
-	async provideChatSessionCustomizations(_token: vscode.CancellationToken): Promise<vscode.ChatSessionCustomizationItem[]> {
+	async provideChatSessionCustomizations(token: vscode.CancellationToken): Promise<vscode.ChatSessionCustomizationItem[]> {
 		const agents = await this.getAgentItems();
-		const instructions = this.getInstructionItems();
+		const instructions = await this.getInstructionItems(token);
 		const skills = this.getSkillItems();
 		const hooks = this.getHookItems();
 
@@ -75,14 +82,75 @@ export class CopilotCLICustomizationProvider extends Disposable implements vscod
 	}
 
 	/**
-	 * Collects all instruction items from the prompt file service.
+	 * Collects all instruction items from the prompt file service,
+	 * categorizing them with groupKeys and badges matching the core
+	 * implementation:
+	 * - agent-instructions: copilot-instructions.md files
+	 * - context-instructions: files with an applyTo pattern (badge = pattern)
+	 * - on-demand-instructions: files without an applyTo pattern
 	 */
-	private getInstructionItems(): vscode.ChatSessionCustomizationItem[] {
-		return this.chatPromptFileService.instructions.map(i => ({
-			uri: i.uri,
-			type: vscode.ChatSessionCustomizationType.Instructions,
-			name: deriveNameFromUri(i.uri, INSTRUCTION_FILE_EXTENSION),
-		}));
+	private async getInstructionItems(token: CancellationToken): Promise<vscode.ChatSessionCustomizationItem[]> {
+		const agentInstructionUris = new Set(
+			(await this.customInstructionsService.getAgentInstructions()).map(uri => uri.toString())
+		);
+
+		const items: vscode.ChatSessionCustomizationItem[] = [];
+
+		for (const instruction of this.chatPromptFileService.instructions) {
+			const uri = instruction.uri;
+			const name = deriveNameFromUri(uri, INSTRUCTION_FILE_EXTENSION);
+
+			if (agentInstructionUris.has(uri.toString())) {
+				items.push({
+					uri,
+					type: vscode.ChatSessionCustomizationType.Instructions,
+					name,
+					groupKey: 'agent-instructions',
+				});
+				continue;
+			}
+
+			let pattern: string | undefined;
+			let description: string | undefined;
+			try {
+				const parsed = await this.promptsService.parseFile(uri, token);
+				pattern = parsed.header?.applyTo;
+				description = parsed.header?.description;
+			} catch (err) {
+				if (isCancellationError(err) || token.isCancellationRequested) {
+					throw err;
+				}
+				this.logService.debug(`[CopilotCLICustomizationProvider] failed to parse ${uri.toString()}: ${err}`);
+			}
+
+			if (pattern !== undefined) {
+				const badge = pattern === '**'
+					? l10n.t('always added')
+					: pattern;
+				const badgeTooltip = pattern === '**'
+					? l10n.t('This instruction is automatically included in every interaction.')
+					: l10n.t('This instruction is automatically included when files matching \'{0}\' are in context.', pattern);
+				items.push({
+					uri,
+					type: vscode.ChatSessionCustomizationType.Instructions,
+					name,
+					description,
+					groupKey: 'context-instructions',
+					badge,
+					badgeTooltip,
+				});
+			} else {
+				items.push({
+					uri,
+					type: vscode.ChatSessionCustomizationType.Instructions,
+					name,
+					description,
+					groupKey: 'on-demand-instructions',
+				});
+			}
+		}
+
+		return items;
 	}
 
 	/**

--- a/src/extension/chatSessions/vscode-node/test/copilotCLICustomizationProvider.spec.ts
+++ b/src/extension/chatSessions/vscode-node/test/copilotCLICustomizationProvider.spec.ts
@@ -7,7 +7,10 @@ import type { SweCustomAgent } from '@github/copilot/sdk';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import * as vscode from 'vscode';
 import { ILogService } from '../../../../platform/log/common/logService';
+import { IPromptsService, ParsedPromptFile, PromptFileParser } from '../../../../platform/promptFiles/common/promptsService';
+import { MockCustomInstructionsService } from '../../../../platform/test/common/testCustomInstructionsService';
 import { mock } from '../../../../util/common/test/simpleMock';
+import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
 import { Emitter } from '../../../../util/vs/base/common/event';
 import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { URI } from '../../../../util/vs/base/common/uri';
@@ -105,10 +108,32 @@ class TestLogService extends mock<ILogService>() {
 	override debug() { }
 }
 
+class TestCustomInstructionsService extends MockCustomInstructionsService {
+	private _agentInstructions: URI[] = [];
+
+	setAgentInstructionUris(uris: URI[]) { this._agentInstructions = uris; }
+	override getAgentInstructions(): Promise<URI[]> { return Promise.resolve(this._agentInstructions); }
+}
+
+class TestPromptsService extends mock<IPromptsService>() {
+	private readonly parser = new PromptFileParser();
+	private _fileContents = new Map<string, string>();
+
+	/** Register content so parseFile returns a parsed result for the given URI. */
+	setFileContent(uri: URI, content: string) { this._fileContents.set(uri.toString(), content); }
+
+	override async parseFile(uri: URI, _token: CancellationToken): Promise<ParsedPromptFile> {
+		const content = this._fileContents.get(uri.toString()) ?? '';
+		return this.parser.parse(uri, content);
+	}
+}
+
 describe('CopilotCLICustomizationProvider', () => {
 	let disposables: DisposableStore;
 	let mockPromptFileService: MockChatPromptFileService;
 	let mockCopilotCLIAgents: MockCopilotCLIAgents;
+	let mockCustomInstructionsService: TestCustomInstructionsService;
+	let mockPromptsService: TestPromptsService;
 	let provider: CopilotCLICustomizationProvider;
 
 	let originalChatSessionCustomizationType: unknown;
@@ -119,9 +144,13 @@ describe('CopilotCLICustomizationProvider', () => {
 		disposables = new DisposableStore();
 		mockPromptFileService = disposables.add(new MockChatPromptFileService());
 		mockCopilotCLIAgents = disposables.add(new MockCopilotCLIAgents());
+		mockCustomInstructionsService = new TestCustomInstructionsService();
+		mockPromptsService = new TestPromptsService();
 		provider = disposables.add(new CopilotCLICustomizationProvider(
 			mockPromptFileService,
 			mockCopilotCLIAgents,
+			mockCustomInstructionsService,
+			mockPromptsService,
 			new TestLogService(),
 		));
 	});
@@ -214,7 +243,7 @@ describe('CopilotCLICustomizationProvider', () => {
 			expect(items[0].name).toBe('Code Review');
 		});
 
-		it('returns instructions', async () => {
+		it('returns instructions with on-demand groupKey when no applyTo pattern', async () => {
 			const uri = URI.file('/workspace/.github/copilot-instructions.md');
 			mockPromptFileService.setInstructions([{ uri }]);
 
@@ -222,6 +251,7 @@ describe('CopilotCLICustomizationProvider', () => {
 			expect(items).toHaveLength(1);
 			expect(items[0].uri).toBe(uri);
 			expect(items[0].type).toBe(FakeChatSessionCustomizationType.Instructions);
+			expect(items[0].groupKey).toBe('on-demand-instructions');
 		});
 
 		it('returns skills', async () => {
@@ -281,6 +311,131 @@ describe('CopilotCLICustomizationProvider', () => {
 			const items = await provider.provideChatSessionCustomizations(undefined!);
 			const hookItems = items.filter((i: vscode.ChatSessionCustomizationItem) => i.type === FakeChatSessionCustomizationType.Hook);
 			expect(hookItems).toHaveLength(2);
+		});
+	});
+
+	describe('instruction groupKeys and badges', () => {
+		it('uses agent-instructions groupKey for copilot-instructions.md files', async () => {
+			const uri = URI.file('/workspace/.github/copilot-instructions.md');
+			mockPromptFileService.setInstructions([{ uri }]);
+			mockCustomInstructionsService.setAgentInstructionUris([uri]);
+
+			const items = await provider.provideChatSessionCustomizations(undefined!);
+			const instrItems = items.filter(i => i.type === FakeChatSessionCustomizationType.Instructions);
+			expect(instrItems).toHaveLength(1);
+			expect(instrItems[0].groupKey).toBe('agent-instructions');
+			expect(instrItems[0].badge).toBeUndefined();
+		});
+
+		it('uses context-instructions groupKey with badge for instructions with applyTo pattern', async () => {
+			const uri = URI.file('/workspace/.github/style.instructions.md');
+			mockPromptFileService.setInstructions([{ uri }]);
+			mockPromptsService.setFileContent(uri, [
+				'---',
+				'applyTo: \'src/**/*.ts\'',
+				'---',
+				'Use TypeScript best practices.',
+			].join('\n'));
+
+			const items = await provider.provideChatSessionCustomizations(undefined!);
+			const instrItems = items.filter(i => i.type === FakeChatSessionCustomizationType.Instructions);
+			expect(instrItems).toHaveLength(1);
+			expect(instrItems[0].groupKey).toBe('context-instructions');
+			expect(instrItems[0].badge).toBe('src/**/*.ts');
+			expect(instrItems[0].badgeTooltip).toContain('src/**/*.ts');
+		});
+
+		it('uses "always added" badge when applyTo is **', async () => {
+			const uri = URI.file('/workspace/.github/global.instructions.md');
+			mockPromptFileService.setInstructions([{ uri }]);
+			mockPromptsService.setFileContent(uri, [
+				'---',
+				'applyTo: \'**\'',
+				'---',
+				'Global rules.',
+			].join('\n'));
+
+			const items = await provider.provideChatSessionCustomizations(undefined!);
+			const instrItems = items.filter(i => i.type === FakeChatSessionCustomizationType.Instructions);
+			expect(instrItems).toHaveLength(1);
+			expect(instrItems[0].groupKey).toBe('context-instructions');
+			expect(instrItems[0].badge).toBe('always added');
+			expect(instrItems[0].badgeTooltip).toContain('every interaction');
+		});
+
+		it('uses on-demand-instructions groupKey for instructions without applyTo', async () => {
+			const uri = URI.file('/workspace/.github/refactor.instructions.md');
+			mockPromptFileService.setInstructions([{ uri }]);
+			mockPromptsService.setFileContent(uri, [
+				'---',
+				'description: \'Refactoring guidelines\'',
+				'---',
+				'Prefer small functions.',
+			].join('\n'));
+
+			const items = await provider.provideChatSessionCustomizations(undefined!);
+			const instrItems = items.filter(i => i.type === FakeChatSessionCustomizationType.Instructions);
+			expect(instrItems).toHaveLength(1);
+			expect(instrItems[0].groupKey).toBe('on-demand-instructions');
+			expect(instrItems[0].badge).toBeUndefined();
+			expect(instrItems[0].description).toBe('Refactoring guidelines');
+		});
+
+		it('includes description from parsed header', async () => {
+			const uri = URI.file('/workspace/.github/testing.instructions.md');
+			mockPromptFileService.setInstructions([{ uri }]);
+			mockPromptsService.setFileContent(uri, [
+				'---',
+				'applyTo: \'**/*.spec.ts\'',
+				'description: \'Testing standards\'',
+				'---',
+				'Write unit tests with vitest.',
+			].join('\n'));
+
+			const items = await provider.provideChatSessionCustomizations(undefined!);
+			const instrItems = items.filter(i => i.type === FakeChatSessionCustomizationType.Instructions);
+			expect(instrItems).toHaveLength(1);
+			expect(instrItems[0].description).toBe('Testing standards');
+			expect(instrItems[0].badge).toBe('**/*.spec.ts');
+		});
+
+		it('categorizes mixed instructions correctly', async () => {
+			const agentUri = URI.file('/workspace/.github/copilot-instructions.md');
+			const contextUri = URI.file('/workspace/.github/style.instructions.md');
+			const onDemandUri = URI.file('/workspace/.github/refactor.instructions.md');
+			mockPromptFileService.setInstructions([{ uri: agentUri }, { uri: contextUri }, { uri: onDemandUri }]);
+			mockCustomInstructionsService.setAgentInstructionUris([agentUri]);
+			mockPromptsService.setFileContent(contextUri, '---\napplyTo: \'src/**\'\n---\nStyle rules.');
+			mockPromptsService.setFileContent(onDemandUri, '---\ndescription: Refactoring\n---\nRefactor tips.');
+
+			const items = await provider.provideChatSessionCustomizations(undefined!);
+			const instrItems = items.filter(i => i.type === FakeChatSessionCustomizationType.Instructions);
+			expect(instrItems).toHaveLength(3);
+
+			const agent = instrItems.find(i => i.groupKey === 'agent-instructions');
+			const context = instrItems.find(i => i.groupKey === 'context-instructions');
+			const onDemand = instrItems.find(i => i.groupKey === 'on-demand-instructions');
+
+			expect(agent).toBeDefined();
+			expect(agent!.uri).toBe(agentUri);
+
+			expect(context).toBeDefined();
+			expect(context!.badge).toBe('src/**');
+
+			expect(onDemand).toBeDefined();
+			expect(onDemand!.badge).toBeUndefined();
+		});
+
+		it('falls back to on-demand-instructions when file has no YAML header', async () => {
+			const uri = URI.file('/workspace/.github/plain.instructions.md');
+			mockPromptFileService.setInstructions([{ uri }]);
+			mockPromptsService.setFileContent(uri, 'Just plain text, no frontmatter.');
+
+			const items = await provider.provideChatSessionCustomizations(undefined!);
+			const instrItems = items.filter(i => i.type === FakeChatSessionCustomizationType.Instructions);
+			expect(instrItems).toHaveLength(1);
+			expect(instrItems[0].groupKey).toBe('on-demand-instructions');
+			expect(instrItems[0].badge).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## Summary

Add `groupKey`, `badge`, and `badgeTooltip` properties to instruction items returned by `CopilotCLICustomizationProvider`, matching the core implementation when `chat.customizations.providerApi.enabled` is disabled.

## Changes

### Instruction categorization via groupKeys

Instructions are now categorized into three groups (matching core):

| groupKey | Description | Badge |
|---|---|---|
| `agent-instructions` | `copilot-instructions.md` files (from `getAgentInstructions()`) | — |
| `context-instructions` | Files with an `applyTo` YAML frontmatter pattern | The pattern (e.g. `src/**/*.ts`) or localized `"always added"` for `**` |
| `on-demand-instructions` | Files without an `applyTo` pattern | — |

### New dependencies injected

- **`ICustomInstructionsService`** — identifies agent instruction files (`copilot-instructions.md`)
- **`IPromptsService`** — parses YAML frontmatter to extract `applyTo` and `description`

### Badge behavior

- Context instructions show their `applyTo` glob pattern as a badge
- The `**` pattern displays as localized `"always added"` with a tooltip explaining it's included in every interaction
- Other patterns show the raw glob with a tooltip explaining when it triggers
- `description` from YAML frontmatter is now included on instruction items

## Tests

7 new tests covering all groupKey/badge scenarios. All 24 tests pass.