### PR TITLE
Experiment: sort model picker by vendor (OpenAI, Anthropic, Gemini)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4586,6 +4586,15 @@
 							"advanced"
 						]
 					},
+					"github.copilot.chat.modelPickerVendorOrdering": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "%github.copilot.config.modelPickerVendorOrdering%",
+						"tags": [
+							"experimental",
+							"onExp"
+						]
+					},
 					"github.copilot.chat.searchSubagent.enabled": {
 						"type": "boolean",
 						"default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -474,6 +474,7 @@
 	"copilot.tools.runSubagent.description": "Runs a task within an isolated subagent context. Enables efficient organization of tasks and context window management.",
 	"copilot.tools.searchSubagent.name": "Search Subagent",
 	"copilot.tools.searchSubagent.description": "Launch an iterative search-focused subagent to find relevant code in your workspace.",
+	"github.copilot.config.modelPickerVendorOrdering": "Sort models in the model picker by vendor: OpenAI first, then Anthropic, then Gemini.",
 	"github.copilot.config.searchSubagent.enabled": "Enable the search subagent tool for iterative code exploration in the workspace.",
 	"github.copilot.config.searchSubagent.useAgenticProxy": "Use the agentic proxy for the search subagent tool.",
 	"github.copilot.config.searchSubagent.model": "Model to use for the search subagent. When useAgenticProxy is enabled, defaults to 'agentic-search-v3'. Otherwise defaults to the main agent model.",

--- a/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -11,7 +11,7 @@ import { CopilotToken } from '../../../platform/authentication/common/copilotTok
 import { IBlockedExtensionService } from '../../../platform/chat/common/blockedExtensionService';
 import { ChatFetchResponseType, ChatLocation, getErrorDetailsFromChatFetchError } from '../../../platform/chat/common/commonTypes';
 import { getTextPart } from '../../../platform/chat/common/globalStringUtils';
-import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
+import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { EmbeddingType, getWellKnownEmbeddingTypeInfo, IEmbeddingsComputer } from '../../../platform/embeddings/common/embeddingsComputer';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { CustomDataPartMimeTypes } from '../../../platform/endpoint/common/endpointTypes';
@@ -180,6 +180,7 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 		@IVSCodeExtensionContext private readonly _vsCodeExtensionContext: IVSCodeExtensionContext,
 		@IAutomodeService private readonly _automodeService: IAutomodeService,
 		@IExperimentationService private readonly _expService: IExperimentationService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 
@@ -243,7 +244,7 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 
 		// Experiment: sort endpoints by vendor priority (OpenAI, Anthropic, Gemini, others).
 		// Auto endpoint is always first via its category order.
-		if (this._expService.getTreatmentVariable<boolean>('chat.modelPickerVendorOrdering')) {
+		if (this._configurationService.getExperimentBasedConfig(ConfigKey.Shared.ModelPickerVendorOrdering, this._expService)) {
 			const getVendorPriority = (e: IChatEndpoint): number => {
 				if (e instanceof AutoChatEndpoint) { return -1; }
 				const provider = e.modelProvider.toLowerCase();

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -642,6 +642,7 @@ export namespace ConfigKey {
 		export const PromptFileContext = defineAndMigrateExpSetting<boolean>('chat.advanced.promptFileContextProvider.enabled', 'chat.promptFileContextProvider.enabled', true);
 		export const DefaultToolsGrouped = defineAndMigrateExpSetting<boolean>('chat.advanced.tools.defaultToolsGrouped', 'chat.tools.defaultToolsGrouped', false);
 		export const Gpt5AlternativePatch = defineAndMigrateExpSetting<boolean>('chat.advanced.gpt5AlternativePatch', 'chat.gpt5AlternativePatch', false);
+		export const ModelPickerVendorOrdering = defineSetting<boolean>('chat.modelPickerVendorOrdering', ConfigType.ExperimentBased, false);
 		export const SearchSubagentToolEnabled = defineSetting<boolean>('chat.searchSubagent.enabled', ConfigType.ExperimentBased, false);
 		/** Use the agentic proxy for the search subagent tool */
 		export const SearchSubagentUseAgenticProxy = defineSetting<boolean>('chat.searchSubagent.useAgenticProxy', ConfigType.ExperimentBased, false);


### PR DESCRIPTION
## Motivation

We want to A/B test whether reordering models in the chat model picker by vendor improves the user experience. Currently, models appear in whatever order the server returns them (roughly alphabetical), which surfaces Claude models before GPT models. This change lets us experiment with a vendor-prioritized ordering: OpenAI → Anthropic → Gemini → others.

## Approach

- **Sort logic in `languageModelAccess.ts`**: After assembling `chatEndpoints` from the server response, sort them by vendor using `endpoint.modelProvider`. The Auto endpoint is excluded from sorting (it's always first via its category order). Within each vendor group, the original server ordering is preserved (stable sort).
- **ExperimentBased setting**: Added `github.copilot.chat.modelPickerVendorOrdering` as an `ExperimentBased` boolean config (default `false`). This means:
  - It can be controlled via TAS for A/B testing
  - Users can manually toggle it in VS Code settings for local testing
  - Tagged `experimental` + `onExp` in `package.json`
- **No behavior change when disabled**: When the setting is `false` or unset, the model list is unchanged from the current server-driven order.

## Key files

- `src/extension/conversation/vscode-node/languageModelAccess.ts` — sort logic + config read
- `src/platform/configuration/common/configurationService.ts` — `ConfigKey.Shared.ModelPickerVendorOrdering` definition
- `package.json` / `package.nls.json` — setting registration and description