### PR TITLE
Remove `forceExtendedThinking` experiment config

### DIFF
--- a/package.json
+++ b/package.json
@@ -3231,15 +3231,6 @@
 							"onExp"
 						]
 					},
-					"github.copilot.chat.anthropic.thinking.forceExtendedThinking": {
-						"type": "boolean",
-						"markdownDescription": "%github.copilot.config.anthropic.thinking.forceExtendedThinking%",
-						"default": false,
-						"tags": [
-							"preview",
-							"onExp"
-						]
-					},
 					"github.copilot.chat.backgroundCompaction": {
 						"type": "boolean",
 						"default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -346,7 +346,6 @@
 	"github.copilot.config.gpt54ConcisePrompt.enabled": "Enables the concise prompt experiment for gpt-5.4 model.",
 	"github.copilot.config.gpt54LargePrompt.enabled": "Enables the large prompt experiment for gpt-5.4 model.",
 	"github.copilot.config.anthropic.thinking.budgetTokens": "Maximum number of tokens to allocate for extended thinking in Anthropic models. Setting this value enables extended thinking. Valid range is `1,024` to `max_tokens-1`.",
-	"github.copilot.config.anthropic.thinking.forceExtendedThinking": "Force extended thinking for models that support adaptive thinking (e.g., Sonnet 4.6, Opus 4.6). When enabled, uses explicit token budgets instead of adaptive thinking.",
 	"github.copilot.config.anthropic.tools.websearch.enabled": "Enable Anthropic's native web search tool for BYOK Claude models. When enabled, allows Claude to search the web for current information. \n\n**Note**: This is an experimental feature only available for BYOK Anthropic Claude models.",
 	"github.copilot.config.anthropic.tools.websearch.maxUses": "Maximum number of web searches allowed per request. Valid range is 1 to 20. Prevents excessive API calls within a single interaction. If Claude exceeds this limit, the response returns an error.",
 	"github.copilot.config.anthropic.tools.websearch.allowedDomains": "List of domains to restrict web search results to (e.g., `[\"example.com\", \"docs.example.com\"]`). Domains should not include the HTTP/HTTPS scheme. Subdomains are automatically included. Cannot be used together with blocked domains.",

--- a/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -237,8 +237,7 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 
 			// Check if model supports adaptive thinking
 			const modelCapabilities = this._knownModels?.[model.id];
-			const forceNonAdaptive = this._configurationService.getExperimentBasedConfig(ConfigKey.AnthropicForceExtendedThinking, this._experimentationService);
-			const supportsAdaptiveThinking = (modelCapabilities?.adaptiveThinking ?? false) && !forceNonAdaptive;
+			const supportsAdaptiveThinking = modelCapabilities?.adaptiveThinking ?? false;
 
 			// Build context management configuration
 			const thinkingEnabled = supportsAdaptiveThinking || (thinkingBudget ?? 0) > 0;
@@ -251,8 +250,6 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 			// Build betas array for beta API features (adaptive thinking doesn't need interleaved-thinking beta)
 			const betas: string[] = [];
 			if (thinkingBudget && !supportsAdaptiveThinking) {
-				betas.push('interleaved-thinking-2025-05-14');
-			} else if (forceNonAdaptive && (modelCapabilities?.adaptiveThinking ?? false)) {
 				betas.push('interleaved-thinking-2025-05-14');
 			}
 			if (hasMemoryTool || contextManagement) {

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -899,8 +899,6 @@ export namespace ConfigKey {
 	export const EnableChatImageUpload = defineSetting<boolean>('chat.imageUpload.enabled', ConfigType.ExperimentBased, true);
 	/** Thinking token budget for Anthropic extended thinking. If set, enables extended thinking. */
 	export const AnthropicThinkingBudget = defineSetting<number>('chat.anthropic.thinking.budgetTokens', ConfigType.Simple, 16000);
-	/** Force extended thinking (with explicit token budgets) even on models that support adaptive thinking. */
-	export const AnthropicForceExtendedThinking = defineSetting<boolean>('chat.anthropic.thinking.forceExtendedThinking', ConfigType.ExperimentBased, false);
 	/** Enable Anthropic web search tool for BYOK Claude models */
 	export const AnthropicWebSearchToolEnabled = defineSetting<boolean>('chat.anthropic.tools.websearch.enabled', ConfigType.ExperimentBased, false);
 	/** Maximum number of web searches allowed per request */

--- a/src/platform/endpoint/node/chatEndpoint.ts
+++ b/src/platform/endpoint/node/chatEndpoint.ts
@@ -192,7 +192,7 @@ export class ChatEndpoint implements IChatEndpoint {
 
 			const betaFeatures: string[] = [];
 
-			if (!this.supportsAdaptiveThinking || this._configurationService.getExperimentBasedConfig(ConfigKey.AnthropicForceExtendedThinking, this._expService)) {
+			if (!this.supportsAdaptiveThinking) {
 				betaFeatures.push('interleaved-thinking-2025-05-14');
 			}
 

--- a/src/platform/endpoint/node/messagesApi.ts
+++ b/src/platform/endpoint/node/messagesApi.ts
@@ -149,8 +149,7 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	if (options.enableThinking) {
 		const configuredBudget = configurationService.getConfig(ConfigKey.AnthropicThinkingBudget);
 		const thinkingExplicitlyDisabled = configuredBudget === 0;
-		const forceExtendedThinking = configurationService.getExperimentBasedConfig(ConfigKey.AnthropicForceExtendedThinking, experimentationService);
-		if (endpoint.supportsAdaptiveThinking && !thinkingExplicitlyDisabled && !forceExtendedThinking) {
+		if (endpoint.supportsAdaptiveThinking && !thinkingExplicitlyDisabled) {
 			thinkingConfig = { type: 'adaptive' };
 		} else if (!thinkingExplicitlyDisabled && endpoint.maxThinkingBudget && endpoint.minThinkingBudget) {
 			const maxTokens = options.postOptions.max_tokens ?? 1024;


### PR DESCRIPTION
The `anthropic.thinking.forceExtendedThinking` experiment is done. This PR removes:

- The setting definition from `configurationService.ts`
- The `package.json` setting entry and `package.nls.json` description
- All usage sites in `messagesApi.ts`, `chatEndpoint.ts`, and `anthropicProvider.ts`

Since the default was `false`, the code now always uses adaptive thinking when supported by the model, which was already the non-experiment behavior.