### PR TITLE
chatSessions: add backward compat guards for hooks and plugins APIs

### DIFF
--- a/src/extension/chatSessions/vscode-node/chatPromptFileService.ts
+++ b/src/extension/chatSessions/vscode-node/chatPromptFileService.ts
@@ -48,13 +48,17 @@ export class ChatPromptFileService extends Disposable implements IChatPromptFile
 			this._onDidChangeSkills.fire();
 		}));
 
-		this._register(vscode.chat.onDidChangeHooks(() => {
-			this._onDidChangeHooks.fire();
-		}));
+		if (vscode.chat.onDidChangeHooks) {
+			this._register(vscode.chat.onDidChangeHooks(() => {
+				this._onDidChangeHooks.fire();
+			}));
+		}
 
-		this._register(vscode.chat.onDidChangePlugins(() => {
-			this._onDidChangePlugins.fire();
-		}));
+		if (vscode.chat.onDidChangePlugins) {
+			this._register(vscode.chat.onDidChangePlugins(() => {
+				this._onDidChangePlugins.fire();
+			}));
+		}
 		this.triggerRefreshCustomAgents();
 	}
 
@@ -75,11 +79,11 @@ export class ChatPromptFileService extends Disposable implements IChatPromptFile
 	}
 
 	get hooks(): readonly vscode.ChatResource[] {
-		return vscode.chat.hooks;
+		return vscode.chat.hooks ?? [];
 	}
 
 	get plugins(): readonly vscode.ChatResource[] {
-		return vscode.chat.plugins;
+		return vscode.chat.plugins ?? [];
 	}
 
 	override dispose(): void {

--- a/src/extension/chatSessions/vscode-node/copilotCLICustomizationProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLICustomizationProvider.ts
@@ -27,7 +27,7 @@ export class CopilotCLICustomizationProvider extends Disposable implements vscod
 				vscode.ChatSessionCustomizationType.Instructions,
 				vscode.ChatSessionCustomizationType.Hook,
 				vscode.ChatSessionCustomizationType.Plugins,
-			],
+			].filter((t): t is vscode.ChatSessionCustomizationType => t !== undefined),
 		};
 	}
 


### PR DESCRIPTION
## Summary

Adds availability guards for the recently-added `vscode.chat.hooks` and `vscode.chat.plugins` proposed APIs so the extension doesn't crash on older VS Code builds that don't yet expose them.

## Changes

### `chatPromptFileService.ts`
- **Event subscriptions**: Wrapped `onDidChangeHooks` and `onDidChangePlugins` in `if (vscode.chat.onDidChangeHooks)` / `if (vscode.chat.onDidChangePlugins)` guards
- **Property getters**: Added `?? []` fallback on `hooks` and `plugins` getters so they return empty arrays when the API is absent

### `copilotCLICustomizationProvider.ts`
- **`supportedTypes`**: Added `.filter(t => t !== undefined)` to strip out `Hook`/`Plugins` enum values that may not exist on older VS Code

## Context

PRs #4952 and #4962 wired hooks and plugins through the CopilotCLI customization provider. The hooks PR initially had backward compat guards but they were removed in a follow-up commit. This restores those guards (and adds equivalent ones for plugins) to ensure users on older VS Code versions aren't broken.