### PR TITLE
feat: support additionalContext in PreCompact hook

### DIFF
--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -8,7 +8,7 @@ import { BasePromptElementProps, PrioritizedList, PromptElement, PromptMetadata,
 import { BudgetExceededError } from '@vscode/prompt-tsx/dist/base/materialized';
 import { ChatMessage } from '@vscode/prompt-tsx/dist/base/output/rawTypes';
 import type { ChatResponsePart, ChatResultPromptTokenDetail, LanguageModelToolInformation, NotebookDocument, Progress } from 'vscode';
-import { IChatHookService, PreCompactHookInput } from '../../../../platform/chat/common/chatHookService';
+import { IChatHookService, PreCompactHookInput, PreCompactHookOutput } from '../../../../platform/chat/common/chatHookService';
 import { ChatFetchResponseType, ChatLocation, ChatResponse, FetchSuccess } from '../../../../platform/chat/common/commonTypes';
 import { IHistoricalTurn, ISessionTranscriptService } from '../../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
@@ -585,12 +585,24 @@ class ConversationHistorySummarizer {
 
 	async summarizeHistory(): Promise<{ summary: string; toolCallRoundId: string; thinking?: ThinkingData; usage?: APIUsage; promptTokenDetails?: readonly ChatResultPromptTokenDetail[]; model?: string; summarizationMode?: string; numRounds?: number; numRoundsSinceLastSummarization?: number; durationMs?: number }> {
 		// Execute pre-compact hook before summarization to allow hooks to archive transcripts or perform cleanup
-		await this.executePreCompactHook();
+		// and optionally provide additional context for the summarization
+		const hookAdditionalContext = await this.executePreCompactHook();
 
 		// Just a function for test to create props and call this
 		const propsInfo = this.instantiationService.createInstance(SummarizedConversationHistoryPropsBuilder).getProps(this.props);
 
-		const summaryPromise = this.getSummaryWithFallback(propsInfo);
+		// If hook returned additional context, merge it into summarization instructions
+		const effectivePropsInfo = hookAdditionalContext ? {
+			...propsInfo,
+			props: {
+				...propsInfo.props,
+				summarizationInstructions: propsInfo.props.summarizationInstructions
+					? `${propsInfo.props.summarizationInstructions}\n${hookAdditionalContext}`
+					: hookAdditionalContext,
+			}
+		} : propsInfo;
+
+		const summaryPromise = this.getSummaryWithFallback(effectivePropsInfo);
 		this.progress?.report(new ChatResponseProgressPart2(l10n.t('Compacting conversation...'), async () => {
 			try {
 				await summaryPromise;
@@ -638,12 +650,15 @@ class ConversationHistorySummarizer {
 	/**
 	 * Executes the PreCompact hook before summarization starts.
 	 * This gives hook scripts a chance to archive the transcript or perform cleanup
-	 * before the conversation is compacted.
+	 * before the conversation is compacted, and optionally provide additional context
+	 * to include in the summarization instructions.
+	 *
+	 * @returns Additional context from hooks to merge into summarization instructions, or undefined.
 	 */
-	private async executePreCompactHook(): Promise<void> {
+	private async executePreCompactHook(): Promise<string | undefined> {
 		const hooks = this.props.promptContext.request?.hooks;
 		if (!hooks) {
-			return;
+			return undefined;
 		}
 
 		try {
@@ -651,14 +666,23 @@ class ConversationHistorySummarizer {
 				trigger: 'auto',
 			} satisfies PreCompactHookInput, this.props.promptContext.conversation?.sessionId, this.token ?? CancellationToken.None);
 
+			const allAdditionalContext: string[] = [];
 			for (const result of results) {
 				if (result.resultKind === 'error') {
 					const errorMessage = typeof result.output === 'string' ? result.output : 'Unknown error';
 					this.logService.error(`[ConversationHistorySummarizer] PreCompact hook error: ${errorMessage}`);
+				} else if (result.resultKind === 'success' && result.output && typeof result.output === 'object') {
+					const output = result.output as PreCompactHookOutput;
+					if (output.hookSpecificOutput?.additionalContext) {
+						allAdditionalContext.push(output.hookSpecificOutput.additionalContext);
+					}
 				}
 			}
+
+			return allAdditionalContext.length > 0 ? allAdditionalContext.join('\n') : undefined;
 		} catch (error) {
 			this.logService.error('[ConversationHistorySummarizer] Error executing PreCompact hook', error);
+			return undefined;
 		}
 	}
 

--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -164,7 +164,7 @@ export class ConversationHistorySummarizationPrompt extends PromptElement<Conver
 					{SummaryPrompt}
 					{this.props.summarizationInstructions && <>
 						<br /><br />
-						## Additional instructions from the user:<br />
+						## Additional summarization instructions:<br />
 						{this.props.summarizationInstructions}
 					</>}
 				</SystemMessage>
@@ -584,21 +584,27 @@ class ConversationHistorySummarizer {
 	) { }
 
 	async summarizeHistory(): Promise<{ summary: string; toolCallRoundId: string; thinking?: ThinkingData; usage?: APIUsage; promptTokenDetails?: readonly ChatResultPromptTokenDetail[]; model?: string; summarizationMode?: string; numRounds?: number; numRoundsSinceLastSummarization?: number; durationMs?: number }> {
-		// Execute pre-compact hook before summarization to allow hooks to archive transcripts or perform cleanup
-		// and optionally provide additional context for the summarization
+		// Execute pre-compact hook to allow hooks to archive transcripts or provide additional context
 		const hookAdditionalContext = await this.executePreCompactHook();
 
 		// Just a function for test to create props and call this
 		const propsInfo = this.instantiationService.createInstance(SummarizedConversationHistoryPropsBuilder).getProps(this.props);
 
-		// If hook returned additional context, merge it into summarization instructions
-		const effectivePropsInfo = hookAdditionalContext ? {
+		// Merge hook context into summarization instructions, labeling sources separately
+		const effectiveSummarizationInstructions = hookAdditionalContext
+			? [
+				propsInfo.props.summarizationInstructions
+					? `User-provided additional instructions:\n${propsInfo.props.summarizationInstructions}`
+					: undefined,
+				`Additional instructions from hooks:\n${hookAdditionalContext}`,
+			].filter(value => !!value).join('\n\n')
+			: propsInfo.props.summarizationInstructions;
+
+		const effectivePropsInfo = effectiveSummarizationInstructions !== propsInfo.props.summarizationInstructions ? {
 			...propsInfo,
 			props: {
 				...propsInfo.props,
-				summarizationInstructions: propsInfo.props.summarizationInstructions
-					? `${propsInfo.props.summarizationInstructions}\n${hookAdditionalContext}`
-					: hookAdditionalContext,
+				summarizationInstructions: effectiveSummarizationInstructions,
 			}
 		} : propsInfo;
 

--- a/src/extension/prompts/node/agent/test/preCompactHook.spec.tsx
+++ b/src/extension/prompts/node/agent/test/preCompactHook.spec.tsx
@@ -157,7 +157,8 @@ describe('PreCompact Hook Integration', () => {
 				.filter(m => m.role === Raw.ChatRole.System)
 				.map(m => messageToMarkdown(m))
 				.join('\n');
-			expect(allSystemContent).toContain('Additional instructions from the user:');
+			expect(allSystemContent).toContain('Additional summarization instructions:');
+			expect(allSystemContent).toContain('Additional instructions from hooks:');
 			expect(allSystemContent).toContain('Focus on preserving database query details');
 		});
 
@@ -185,6 +186,7 @@ describe('PreCompact Hook Integration', () => {
 				.filter(m => m.role === Raw.ChatRole.System)
 				.map(m => messageToMarkdown(m))
 				.join('\n');
+			expect(allSystemContent).toContain('Additional instructions from hooks:');
 			expect(allSystemContent).toContain('Keep file paths');
 			expect(allSystemContent).toContain('Remember error messages');
 		});
@@ -205,7 +207,7 @@ describe('PreCompact Hook Integration', () => {
 				.filter(m => m.role === Raw.ChatRole.System)
 				.map(m => messageToMarkdown(m))
 				.join('\n');
-			expect(allSystemContent).not.toContain('Additional instructions from the user:');
+			expect(allSystemContent).not.toContain('Additional summarization instructions:');
 		});
 	});
 
@@ -236,7 +238,7 @@ describe('PreCompact Hook Integration', () => {
 				.filter(m => m.role === Raw.ChatRole.System)
 				.map(m => messageToMarkdown(m))
 				.join('\n');
-			expect(allSystemContent).not.toContain('Additional instructions from the user:');
+			expect(allSystemContent).not.toContain('Additional summarization instructions:');
 		});
 	});
 });

--- a/src/extension/prompts/node/agent/test/preCompactHook.spec.tsx
+++ b/src/extension/prompts/node/agent/test/preCompactHook.spec.tsx
@@ -1,0 +1,242 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Raw } from '@vscode/prompt-tsx';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ChatHookResult } from 'vscode';
+import { IChatHookService, PreCompactHookInput } from '../../../../../platform/chat/common/chatHookService';
+import { IChatMLFetcher } from '../../../../../platform/chat/common/chatMLFetcher';
+import { ChatLocation } from '../../../../../platform/chat/common/commonTypes';
+import { StreamingMockChatMLFetcher } from '../../../../../platform/chat/test/common/streamingMockChatMLFetcher';
+import { MockEndpoint } from '../../../../../platform/endpoint/test/node/mockEndpoint';
+import { messageToMarkdown } from '../../../../../platform/log/common/messageStringify';
+import { IChatEndpoint } from '../../../../../platform/networking/common/networking';
+import { ITestingServicesAccessor } from '../../../../../platform/test/node/services';
+import { TestWorkspaceService } from '../../../../../platform/test/node/testWorkspaceService';
+import { IWorkspaceService } from '../../../../../platform/workspace/common/workspaceService';
+import { createTextDocumentData } from '../../../../../util/common/test/shims/textDocument';
+import { DisposableStore } from '../../../../../util/vs/base/common/lifecycle';
+import { URI } from '../../../../../util/vs/base/common/uri';
+import { SyncDescriptor } from '../../../../../util/vs/platform/instantiation/common/descriptors';
+import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
+import { LanguageModelTextPart, LanguageModelToolResult } from '../../../../../vscodeTypes';
+import { MockChatHookService } from '../../../../intents/test/node/toolCallingLoopHooks.spec';
+import { ChatVariablesCollection } from '../../../../prompt/common/chatVariablesCollection';
+import { Conversation, Turn } from '../../../../prompt/common/conversation';
+import { IBuildPromptContext } from '../../../../prompt/common/intents';
+import { ToolCallRound } from '../../../../prompt/common/toolCallRound';
+import { createExtensionUnitTestingServices } from '../../../../test/node/services';
+import { ToolName } from '../../../../tools/common/toolNames';
+import { PromptRenderer } from '../../base/promptRenderer';
+import { SummarizedConversationHistory, SummarizedConversationHistoryMetadata } from '../summarizedConversationHistory';
+
+const fileTsUri = URI.file('/workspace/file.ts');
+
+describe('PreCompact Hook Integration', () => {
+	let disposables: DisposableStore;
+	let mockHookService: MockChatHookService;
+	let streamingFetcher: StreamingMockChatMLFetcher;
+	let hookAccessor: ITestingServicesAccessor;
+
+	beforeEach(() => {
+		disposables = new DisposableStore();
+		mockHookService = new MockChatHookService();
+		streamingFetcher = new StreamingMockChatMLFetcher();
+		streamingFetcher.setStreamingLines(['summarized conversation']);
+
+		const testDoc = createTextDocumentData(fileTsUri, 'line 1\nline 2\n\nline 4\nline 5', 'ts').document;
+		const services = disposables.add(createExtensionUnitTestingServices());
+		services.define(IWorkspaceService, new SyncDescriptor(
+			TestWorkspaceService,
+			[
+				[URI.file('/workspace')],
+				[testDoc]
+			]
+		));
+		services.define(IChatHookService, mockHookService);
+		services.define(IChatMLFetcher, streamingFetcher);
+		hookAccessor = services.createTestingAccessor();
+	});
+
+	afterEach(() => {
+		disposables.dispose();
+	});
+
+	function createHookTestProps() {
+		const instaService = hookAccessor.get(IInstantiationService);
+		const endpoint = instaService.createInstance(MockEndpoint, undefined);
+
+		const toolCallRounds = [
+			new ToolCallRound('ok', [{
+				id: 'tooluse_1',
+				name: ToolName.EditFile,
+				arguments: JSON.stringify({ filePath: fileTsUri.fsPath, code: 'console.log("hi")' }),
+			}]),
+			new ToolCallRound('ok 2', [{
+				id: 'tooluse_2',
+				name: ToolName.EditFile,
+				arguments: JSON.stringify({ filePath: fileTsUri.fsPath, code: 'console.log("hello")' }),
+			}]),
+		];
+		const turn = new Turn('turnId', { type: 'user', message: 'hello' });
+		const testConversation = new Conversation('sessionId', [turn]);
+
+		const promptContext: IBuildPromptContext = {
+			chatVariables: new ChatVariablesCollection([]),
+			history: [],
+			query: 'edit this file',
+			toolCallRounds,
+			toolCallResults: {
+				'tooluse_1': new LanguageModelToolResult([new LanguageModelTextPart('success')]),
+				'tooluse_2': new LanguageModelToolResult([new LanguageModelTextPart('success')]),
+			},
+			tools: {
+				availableTools: [],
+				toolInvocationToken: null as never,
+				toolReferences: [],
+			},
+			conversation: testConversation,
+			request: { hooks: { PreCompact: [] } } as any,
+		};
+
+		return { instaService, endpoint, promptContext };
+	}
+
+	function renderSummarization(instaService: IInstantiationService, endpoint: IChatEndpoint, promptContext: IBuildPromptContext) {
+		return PromptRenderer.create(instaService, endpoint, SummarizedConversationHistory, {
+			priority: 1,
+			endpoint,
+			location: ChatLocation.Panel,
+			promptContext,
+			maxToolResultLength: Infinity,
+			triggerSummarize: true,
+		});
+	}
+
+	describe('hook execution conditions', () => {
+		it('should call PreCompact hook with trigger auto during summarization', async () => {
+			const { instaService, endpoint, promptContext } = createHookTestProps();
+			await renderSummarization(instaService, endpoint, promptContext).render();
+
+			const preCompactCalls = mockHookService.getCallsForHook('PreCompact' as any);
+			expect(preCompactCalls).toHaveLength(1);
+			expect((preCompactCalls[0].input as PreCompactHookInput).trigger).toBe('auto');
+		});
+
+		it('should not call PreCompact hook when promptContext has no request hooks', async () => {
+			const { instaService, endpoint, promptContext } = createHookTestProps();
+			// Create new context without request to simulate background compaction without hooks
+			const { request: _, ...contextWithoutRequest } = promptContext;
+			const noHooksContext: IBuildPromptContext = { ...contextWithoutRequest };
+
+			await renderSummarization(instaService, endpoint, noHooksContext).render();
+
+			const preCompactCalls = mockHookService.getCallsForHook('PreCompact' as any);
+			expect(preCompactCalls).toHaveLength(0);
+		});
+	});
+
+	describe('additionalContext injection', () => {
+		it('should include hook additionalContext in summarization prompt sent to LLM', async () => {
+			mockHookService.setHookResults('PreCompact' as any, [{
+				resultKind: 'success' as const,
+				output: {
+					hookSpecificOutput: { additionalContext: 'Focus on preserving database query details' },
+				},
+			} as ChatHookResult]);
+
+			const { instaService, endpoint, promptContext } = createHookTestProps();
+			await renderSummarization(instaService, endpoint, promptContext).render();
+
+			expect(streamingFetcher.callCount).toBeGreaterThan(0);
+			const capturedMessages = streamingFetcher.capturedOptions[0]?.messages;
+			expect(capturedMessages).toBeDefined();
+			const allSystemContent = capturedMessages!
+				.filter(m => m.role === Raw.ChatRole.System)
+				.map(m => messageToMarkdown(m))
+				.join('\n');
+			expect(allSystemContent).toContain('Additional instructions from the user:');
+			expect(allSystemContent).toContain('Focus on preserving database query details');
+		});
+
+		it('should concatenate additionalContext from multiple hook results', async () => {
+			mockHookService.setHookResults('PreCompact' as any, [
+				{
+					resultKind: 'success' as const,
+					output: {
+						hookSpecificOutput: { additionalContext: 'Keep file paths' },
+					},
+				} as ChatHookResult,
+				{
+					resultKind: 'success' as const,
+					output: {
+						hookSpecificOutput: { additionalContext: 'Remember error messages' },
+					},
+				} as ChatHookResult,
+			]);
+
+			const { instaService, endpoint, promptContext } = createHookTestProps();
+			await renderSummarization(instaService, endpoint, promptContext).render();
+
+			const capturedMessages = streamingFetcher.capturedOptions[0]?.messages;
+			const allSystemContent = capturedMessages!
+				.filter(m => m.role === Raw.ChatRole.System)
+				.map(m => messageToMarkdown(m))
+				.join('\n');
+			expect(allSystemContent).toContain('Keep file paths');
+			expect(allSystemContent).toContain('Remember error messages');
+		});
+
+		it('should not include additional instructions section when hook returns no additionalContext', async () => {
+			mockHookService.setHookResults('PreCompact' as any, [{
+				resultKind: 'success' as const,
+				output: {},
+			} as ChatHookResult]);
+
+			const { instaService, endpoint, promptContext } = createHookTestProps();
+			await renderSummarization(instaService, endpoint, promptContext).render();
+
+			expect(streamingFetcher.callCount).toBeGreaterThan(0);
+			const capturedMessages = streamingFetcher.capturedOptions[0]?.messages;
+			expect(capturedMessages).toBeDefined();
+			const allSystemContent = capturedMessages!
+				.filter(m => m.role === Raw.ChatRole.System)
+				.map(m => messageToMarkdown(m))
+				.join('\n');
+			expect(allSystemContent).not.toContain('Additional instructions from the user:');
+		});
+	});
+
+	describe('error handling', () => {
+		it('should complete summarization when hook throws an error', async () => {
+			mockHookService.setHookError('PreCompact' as any, new Error('Hook script failed'));
+
+			const { instaService, endpoint, promptContext } = createHookTestProps();
+			const result = await renderSummarization(instaService, endpoint, promptContext).render();
+
+			const summaryMeta = result.metadata.get(SummarizedConversationHistoryMetadata);
+			expect(summaryMeta).toBeDefined();
+			expect(summaryMeta!.text).toContain('summarized conversation');
+		});
+
+		it('should not include additional instructions when hook returns error result', async () => {
+			mockHookService.setHookResults('PreCompact' as any, [{
+				resultKind: 'error' as const,
+				output: 'Hook execution failed',
+			} as ChatHookResult]);
+
+			const { instaService, endpoint, promptContext } = createHookTestProps();
+			await renderSummarization(instaService, endpoint, promptContext).render();
+
+			expect(streamingFetcher.callCount).toBeGreaterThan(0);
+			const capturedMessages = streamingFetcher.capturedOptions[0]?.messages;
+			const allSystemContent = capturedMessages!
+				.filter(m => m.role === Raw.ChatRole.System)
+				.map(m => messageToMarkdown(m))
+				.join('\n');
+			expect(allSystemContent).not.toContain('Additional instructions from the user:');
+		});
+	});
+});

--- a/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -508,7 +508,7 @@ suite('Agent Summarization', () => {
 			.filter(m => m.role === Raw.ChatRole.System)
 			.map(m => messageToMarkdown(m))
 			.join('\n');
-		expect(systemContent).toContain('Additional instructions from the user:');
+		expect(systemContent).toContain('Additional summarization instructions:');
 		expect(systemContent).toContain('Please preserve all file paths and line numbers');
 	});
 
@@ -530,7 +530,7 @@ suite('Agent Summarization', () => {
 			.filter(m => m.role === Raw.ChatRole.System)
 			.map(m => messageToMarkdown(m))
 			.join('\n');
-		expect(systemContent).not.toContain('Additional instructions from the user:');
+		expect(systemContent).not.toContain('Additional summarization instructions:');
 	});
 });
 

--- a/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -488,6 +488,50 @@ suite('Agent Summarization', () => {
 			&& successMeta!.outcome !== 'success';
 		expect(shouldSkipAfterSuccess).toBe(false);
 	});
+
+	test('summarization prompt renders additional instructions from summarizationInstructions prop', async () => {
+		const { instaService, endpoint, promptContext } = createSummarizationTestContext();
+		const propsInfo = instaService.createInstance(SummarizedConversationHistoryPropsBuilder).getProps({
+			priority: 1,
+			endpoint,
+			location: ChatLocation.Panel,
+			promptContext,
+			maxToolResultLength: Infinity,
+			summarizationInstructions: 'Please preserve all file paths and line numbers',
+		});
+		const renderer = PromptRenderer.create(instaService, endpoint, ConversationHistorySummarizationPrompt, {
+			...propsInfo.props,
+			simpleMode: false,
+		});
+		const r = await renderer.render();
+		const systemContent = r.messages
+			.filter(m => m.role === Raw.ChatRole.System)
+			.map(m => messageToMarkdown(m))
+			.join('\n');
+		expect(systemContent).toContain('Additional instructions from the user:');
+		expect(systemContent).toContain('Please preserve all file paths and line numbers');
+	});
+
+	test('summarization prompt does not include additional instructions section when summarizationInstructions is undefined', async () => {
+		const { instaService, endpoint, promptContext } = createSummarizationTestContext();
+		const propsInfo = instaService.createInstance(SummarizedConversationHistoryPropsBuilder).getProps({
+			priority: 1,
+			endpoint,
+			location: ChatLocation.Panel,
+			promptContext,
+			maxToolResultLength: Infinity,
+		});
+		const renderer = PromptRenderer.create(instaService, endpoint, ConversationHistorySummarizationPrompt, {
+			...propsInfo.props,
+			simpleMode: false,
+		});
+		const r = await renderer.render();
+		const systemContent = r.messages
+			.filter(m => m.role === Raw.ChatRole.System)
+			.map(m => messageToMarkdown(m))
+			.join('\n');
+		expect(systemContent).not.toContain('Additional instructions from the user:');
+	});
 });
 
 suite('extractInlineSummary', () => {

--- a/src/platform/chat/common/chatHookService.ts
+++ b/src/platform/chat/common/chatHookService.ts
@@ -282,4 +282,23 @@ export interface PreCompactHookInput {
 	readonly custom_instructions?: string;
 }
 
+/**
+ * Output from the PreCompact hook.
+ */
+export interface PreCompactHookOutput {
+	/**
+	 * Hook-specific output from the PreCompact hook.
+	 * This is nested under `hookSpecificOutput` to match the JSON contract used
+	 * by other hook types.
+	 */
+	readonly hookSpecificOutput?: {
+		readonly hookEventName?: string;
+		/**
+		 * Additional context to include in the compaction/summarization instructions.
+		 * Multiple hooks' values are concatenated.
+		 */
+		readonly additionalContext?: string;
+	};
+}
+
 //#endregion

--- a/src/platform/chat/common/hookCommandTypes.ts
+++ b/src/platform/chat/common/hookCommandTypes.ts
@@ -56,3 +56,15 @@ export interface IPostToolUseHookSpecificCommandOutput {
 }
 
 //#endregion
+
+//#region PreCompact
+
+/**
+ * Hook-specific output fields returned by a PreCompact hook command (inside `hookSpecificOutput`).
+ */
+export interface IPreCompactHookSpecificCommandOutput {
+	readonly hookEventName?: string;
+	readonly additionalContext?: string;
+}
+
+//#endregion


### PR DESCRIPTION
Allow PreCompact hook to inject additional context into the summarization prompt, matching the pattern used by other hooks (PreToolUse, PostToolUse, SessionStart, SubagentStart, UserPromptSubmit).

Changes:
- Add IPreCompactHookSpecificCommandOutput type in hookCommandTypes.ts
- Add PreCompactHookOutput interface in chatHookService.ts
- Modify executePreCompactHook() to collect additionalContext from hook results
- Merge hook additionalContext into summarizationInstructions in summarizeHistory()
- Add unit tests for prompt rendering with summarizationInstructions
- Add integration tests for PreCompact hook flow in preCompactHook.spec.tsx