### PR TITLE
ChatSessionCustomizationProvider testing fixes

### DIFF
--- a/src/extension/chatSessions/copilotcli/node/copilotCli.ts
+++ b/src/extension/chatSessions/copilotcli/node/copilotCli.ts
@@ -289,6 +289,11 @@ export class CopilotCLIAgents extends Disposable implements ICopilotCLIAgents {
 			});
 		}
 		for (const promptFile of this.chatPromptFileService.customAgentPromptFiles) {
+			// Skip legacy .chatmode.md files — they are a deprecated format
+			// and should not appear in the Copilot CLI agent list.
+			if (promptFile.uri.path.toLowerCase().endsWith('.chatmode.md')) {
+				continue;
+			}
 			const info = this.toCustomAgent(promptFile);
 			if (!info) {
 				continue;
@@ -346,9 +351,16 @@ export class CopilotCLIAgents extends Disposable implements ICopilotCLIAgents {
 
 export function getAgentFileNameFromFilePath(filePath: URI): string {
 	const nameFromFile = basename(filePath);
-	const indexOfAgentMd = nameFromFile.toLowerCase().indexOf('.agent.md');
-	const agentName = indexOfAgentMd > 0 ? nameFromFile.substring(0, indexOfAgentMd) : nameFromFile;
-	return agentName;
+	const lowerName = nameFromFile.toLowerCase();
+	const indexOfAgentMd = lowerName.indexOf('.agent.md');
+	if (indexOfAgentMd > 0) {
+		return nameFromFile.substring(0, indexOfAgentMd);
+	}
+	const indexOfChatmodeMd = lowerName.indexOf('.chatmode.md');
+	if (indexOfChatmodeMd > 0) {
+		return nameFromFile.substring(0, indexOfChatmodeMd);
+	}
+	return nameFromFile;
 }
 
 

--- a/src/extension/chatSessions/copilotcli/node/test/copilotCliAgents.spec.ts
+++ b/src/extension/chatSessions/copilotcli/node/test/copilotCliAgents.spec.ts
@@ -202,4 +202,28 @@ Second body`)]);
 		expect(second.map(a => a.agent.name)).toEqual(['Second']);
 		expect(sdk.getPackage).toHaveBeenCalled();
 	});
+
+	it('filters out legacy .chatmode.md files', async () => {
+		const chatmodeFile = new PromptFileParser().parse(
+			URI.file('/workspace/.github/chatmodes/test.chatmode.md'),
+			`---
+name: TestMode
+description: A legacy chatmode
+---
+Body`
+		);
+		const agentFile = parsePromptFile('real.agent.md', `---
+name: RealAgent
+description: A real agent
+---
+Body`);
+		const { agents } = createAgents({
+			sdkAgentsByCall: [[]],
+			promptAgents: [chatmodeFile, agentFile]
+		});
+
+		const result = await agents.getAgents();
+		expect(result).toHaveLength(1);
+		expect(result[0].agent.name).toBe('RealAgent');
+	});
 });

--- a/src/extension/chatSessions/vscode-node/copilotCLICustomizationProvider.ts
+++ b/src/extension/chatSessions/vscode-node/copilotCLICustomizationProvider.ts
@@ -28,7 +28,7 @@ export class CopilotCLICustomizationProvider extends Disposable implements vscod
 	static get metadata(): vscode.ChatSessionCustomizationProviderMetadata {
 		return {
 			label: 'Copilot CLI',
-			iconId: 'worktree',
+			iconId: 'copilot',
 			supportedTypes: [
 				vscode.ChatSessionCustomizationType.Agent,
 				vscode.ChatSessionCustomizationType.Skill,

--- a/src/extension/chatSessions/vscode-node/test/copilotCLICustomizationProvider.spec.ts
+++ b/src/extension/chatSessions/vscode-node/test/copilotCLICustomizationProvider.spec.ts
@@ -173,7 +173,7 @@ describe('CopilotCLICustomizationProvider', () => {
 	describe('metadata', () => {
 		it('has correct label and icon', () => {
 			expect(CopilotCLICustomizationProvider.metadata.label).toBe('Copilot CLI');
-			expect(CopilotCLICustomizationProvider.metadata.iconId).toBe('worktree');
+			expect(CopilotCLICustomizationProvider.metadata.iconId).toBe('copilot');
 		});
 
 		it('supports Agent, Skill, Instructions, Hook, and Plugins types', () => {


### PR DESCRIPTION
Fixes several issues found during testing of the `ChatSessionCustomizationProvider` API (testing issue microsoft/vscode-internalbacklog#7330).

## Commits

- **Filter legacy .chatmode.md files from CopilotCLI agents** — Skips `.chatmode.md` files in `getAgentsImpl()` (case-insensitive). Also handles `.chatmode.md` extension stripping in `getAgentFileNameFromFilePath()`. Includes test. Fixes microsoft/vscode-internalbacklog#7376
- **Use Copilot logo for CopilotCLI customization provider** — Changes icon from `worktree` to `copilot`. Fixes microsoft/vscode-internalbacklog#7372

Companion PR: microsoft/vscode#308071