### PR TITLE
Add support for CLS to setConfigs mid-runtime

### DIFF
--- a/src/lib/node/chatLibMain.ts
+++ b/src/lib/node/chatLibMain.ts
@@ -67,7 +67,7 @@ import { IChatQuotaService } from '../../platform/chat/common/chatQuotaService';
 import { ChatQuotaService } from '../../platform/chat/common/chatQuotaServiceImpl';
 import { IConversationOptions } from '../../platform/chat/common/conversationOptions';
 import { IInteractionService, InteractionService } from '../../platform/chat/common/interactionService';
-import { BaseConfig, Config, ConfigKey, ExperimentBasedConfig, ExperimentBasedConfigType, IConfigurationService } from '../../platform/configuration/common/configurationService';
+import { BaseConfig, Config, ConfigKey, CopilotConfigPrefix, ExperimentBasedConfig, ExperimentBasedConfigType, globalConfigRegistry, IConfigurationService } from '../../platform/configuration/common/configurationService';
 import { DefaultsOnlyConfigurationService } from '../../platform/configuration/common/defaultsOnlyConfigurationService';
 import { IDiffService } from '../../platform/diff/common/diffService';
 import { DiffServiceImpl } from '../../platform/diff/node/diffServiceImpl';
@@ -208,6 +208,7 @@ export interface INESProvider<T extends INESResult = INESResult> {
 	handleRejection(suggestion: T): void;
 	handleIgnored(suggestion: T, supersededByRequestUuid: T | undefined): void;
 	updateTreatmentVariables(variables: Record<string, boolean | number | string>): void;
+	setConfigs(overrides: Map<string, unknown>): void;
 	dispose(): void;
 }
 
@@ -348,6 +349,15 @@ class NESProvider extends Disposable implements INESProvider<NESResult> {
 		}
 	}
 
+	setConfigs(overrides: Map<string, unknown>) {
+		for (const [key, value] of overrides) {
+			const config = globalConfigRegistry.configs.get(`${CopilotConfigPrefix}.${key}`);
+			if (config) {
+				this._configurationService.setConfig(config, value);
+			}
+		}
+	}
+
 }
 
 function setupServices(options: INESProviderOptions) {
@@ -402,8 +412,26 @@ function setupServices(options: INESProviderOptions) {
 }
 
 class OverridableConfigurationService extends DefaultsOnlyConfigurationService {
-	constructor(private readonly _overrides: Map<string, unknown>) {
+	private _overrides: Map<string, unknown>;
+
+	constructor(overrides: Map<string, unknown>) {
 		super();
+		this._overrides = overrides;
+	}
+
+	override async setConfig<T>(key: BaseConfig<T>, value: T): Promise<void> {
+		const existing = this._overrides.get(key.id);
+		if (existing === value) {
+			return;
+		}
+		this._overrides.set(key.id, value);
+		const fullyQualifiedKey = key.fullyQualifiedId;
+		this._onDidChangeConfiguration.fire({
+			affectsConfiguration: (section) => {
+				return fullyQualifiedKey === section || fullyQualifiedKey.startsWith(section + '.') || section.startsWith(fullyQualifiedKey + '.');
+			}
+		});
+		return;
 	}
 
 	override getConfig<T>(key: Config<T>): T {
@@ -727,6 +755,7 @@ export type IGetInlineCompletionsOptions = Exclude<Partial<GetGhostTextOptions>,
 
 export interface IInlineCompletionsProvider {
 	updateTreatmentVariables(variables: Record<string, boolean | number | string>): void;
+	setConfigs(overrides: Map<string, unknown>): void;
 	getInlineCompletions(textDocument: ITextDocument, position: Position, token?: CancellationToken, options?: IGetInlineCompletionsOptions): Promise<CopilotCompletion[] | undefined>;
 	inlineCompletionShown(completionId: string): Promise<void>;
 	dispose(): void;
@@ -746,6 +775,8 @@ class InlineCompletionsProvider extends Disposable implements IInlineCompletions
 		@IExperimentationService private readonly _expService: IExperimentationService,
 		@ICompletionsSpeculativeRequestCache private readonly _speculativeRequestCache: ICompletionsSpeculativeRequestCache,
 		@ILogService private readonly _logService: ILogService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ICompletionsConfigProvider private readonly _completionsConfigProvider: ICompletionsConfigProvider,
 	) {
 		super();
 		this._register(_insta);
@@ -755,6 +786,18 @@ class InlineCompletionsProvider extends Disposable implements IInlineCompletions
 	updateTreatmentVariables(variables: Record<string, boolean | number | string>) {
 		if (this._expService instanceof SimpleExperimentationService) {
 			this._expService.updateTreatmentVariables(variables);
+		}
+	}
+
+	setConfigs(overrides: Map<string, unknown>) {
+		for (const [key, value] of overrides) {
+			const config = globalConfigRegistry.configs.get(`${CopilotConfigPrefix}.${key}`);
+			if (config) {
+				this._configurationService.setConfig(config, value);
+			}
+		}
+		if (this._completionsConfigProvider instanceof InMemoryConfigProvider) {
+			this._completionsConfigProvider.setCopilotSettings(Object.fromEntries(overrides));
 		}
 	}
 

--- a/src/lib/node/chatLibMain.ts
+++ b/src/lib/node/chatLibMain.ts
@@ -424,7 +424,11 @@ class OverridableConfigurationService extends DefaultsOnlyConfigurationService {
 		if (existing === value) {
 			return;
 		}
-		this._overrides.set(key.id, value);
+		if (value === undefined) {
+			this._overrides.delete(key.id);
+		} else {
+			this._overrides.set(key.id, value);
+		}
 		const fullyQualifiedKey = key.fullyQualifiedId;
 		this._onDidChangeConfiguration.fire({
 			affectsConfiguration: (section) => {

--- a/src/platform/configuration/common/defaultsOnlyConfigurationService.ts
+++ b/src/platform/configuration/common/defaultsOnlyConfigurationService.ts
@@ -21,7 +21,7 @@ export class DefaultsOnlyConfigurationService extends AbstractConfigurationServi
 		};
 	}
 
-	override setConfig(): Promise<void> {
+	override setConfig<T>(key: BaseConfig<T>, value: T): Promise<void> {
 		return Promise.resolve();
 	}
 


### PR DESCRIPTION
Adds `setConfigs` to `INESProvider` and `IInlineCompletionsProvider` to ensure that configs can be added. With this, editor reloads don't need to happen for config to refresh. 