### PR TITLE
Fix debug panel subagent display: parallel trace routing, hooks routing

### DIFF
--- a/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
+++ b/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
@@ -202,15 +202,19 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 	startChildSession(childSessionId: string, parentSessionId: string, label: string, parentToolSpanId?: string): void {
 		if (!this._childSessionMap.has(childSessionId)) {
 			this._childSessionMap.set(childSessionId, { parentSessionId, label, parentToolSpanId });
-			// Pre-register the child session ID in the span→session index so that
-			// hook spans (which fire before the child's invoke_agent span completes)
-			// are routed to the child session instead of the parent.
-			this._spanSessionIndex.set(childSessionId, childSessionId);
 		}
 	}
 
 	registerSpanSession(spanId: string, sessionId: string): void {
 		this._spanSessionIndex.set(spanId, sessionId);
+		// Apply same eviction cap as _onSpanCompleted
+		if (this._spanSessionIndex.size > MAX_SPAN_SESSION_INDEX) {
+			const excess = this._spanSessionIndex.size - MAX_SPAN_SESSION_INDEX;
+			const iter = this._spanSessionIndex.keys();
+			for (let i = 0; i < excess; i++) {
+				this._spanSessionIndex.delete(iter.next().value!);
+			}
+		}
 	}
 
 	/**

--- a/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
+++ b/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
@@ -202,7 +202,15 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 	startChildSession(childSessionId: string, parentSessionId: string, label: string, parentToolSpanId?: string): void {
 		if (!this._childSessionMap.has(childSessionId)) {
 			this._childSessionMap.set(childSessionId, { parentSessionId, label, parentToolSpanId });
+			// Pre-register the child session ID in the span→session index so that
+			// hook spans (which fire before the child's invoke_agent span completes)
+			// are routed to the child session instead of the parent.
+			this._spanSessionIndex.set(childSessionId, childSessionId);
 		}
+	}
+
+	registerSpanSession(spanId: string, sessionId: string): void {
+		this._spanSessionIndex.set(spanId, sessionId);
 	}
 
 	/**
@@ -1044,8 +1052,20 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 	}
 
 	private _extractSessionId(span: ICompletedSpanData): string | undefined {
-		return asString(span.attributes[CopilotChatAttr.CHAT_SESSION_ID])
-			?? asString(span.attributes[GenAiAttr.CONVERSATION_ID])
+		const directSessionId = asString(span.attributes[CopilotChatAttr.CHAT_SESSION_ID])
+			?? asString(span.attributes[GenAiAttr.CONVERSATION_ID]);
+
+		// If the span's parentSpanId maps to a known child session, prefer that.
+		// This handles hook spans that carry the parent's CHAT_SESSION_ID but
+		// whose parent span belongs to a child subagent session.
+		if (span.parentSpanId) {
+			const childSessionId = this._spanSessionIndex.get(span.parentSpanId);
+			if (childSessionId && this._childSessionMap.has(childSessionId)) {
+				return childSessionId;
+			}
+		}
+
+		return directSessionId
 			?? (span.parentSpanId ? this._spanSessionIndex.get(span.parentSpanId) : undefined);
 	}
 

--- a/src/extension/chat/vscode-node/test/chatDebugFileLoggerService.spec.ts
+++ b/src/extension/chat/vscode-node/test/chatDebugFileLoggerService.spec.ts
@@ -715,4 +715,39 @@ describe('ChatDebugFileLoggerService', () => {
 		expect(pathB).toBeDefined();
 		expect(pathA!.fsPath).not.toBe(pathB!.fsPath);
 	});
+
+	it('routes hook spans to child session when registerSpanSession maps parentSpanId', async () => {
+		// Set up parent session
+		await service.startSession('parent-hook');
+		otelService.fireSpan(makeToolCallSpan('parent-hook', 'read_file'));
+
+		// Register child session and its invoke_agent span ID
+		service.startChildSession('child-hook', 'parent-hook', 'runSubagent-default');
+		service.registerSpanSession('invoke-agent-span-123', 'child-hook');
+
+		// Fire a hook span with CHAT_SESSION_ID=parent but parentSpanId=child's invoke_agent
+		const hookSpan = makeSpan({
+			name: 'PreToolUse',
+			spanId: 'hook-span-1',
+			parentSpanId: 'invoke-agent-span-123',
+			attributes: {
+				[GenAiAttr.OPERATION_NAME]: 'execute_hook',
+				[CopilotChatAttr.CHAT_SESSION_ID]: 'parent-hook', // Parent's session ID
+			},
+		});
+		otelService.fireSpan(hookSpan);
+
+		await service.flush('parent-hook');
+		await service.flush('child-hook');
+
+		// Hook should be written to child session, not parent
+		const parentEntries = await readLogEntries('parent-hook');
+		const parentHooks = parentEntries.filter(e => e.type === 'hook');
+		expect(parentHooks).toHaveLength(0);
+
+		const childEntries = await service.readEntries('child-hook');
+		const childHooks = childEntries.filter(e => e.type === 'hook');
+		expect(childHooks).toHaveLength(1);
+		expect(childHooks[0].name).toBe('PreToolUse');
+	});
 });

--- a/src/extension/intents/node/toolCallingLoop.ts
+++ b/src/extension/intents/node/toolCallingLoop.ts
@@ -758,9 +758,16 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 				// (see CapturingToken setup in defaultIntentRequestHandler).
 				if (parentChatSessionId && chatSessionId) {
 					const childLabel = debugLogLabel ?? `runSubagent-${agentName}`;
-					this._instantiationService.invokeFunction(accessor =>
-						accessor.get(IChatDebugFileLoggerService).startChildSession(
-							chatSessionId, parentChatSessionId, childLabel, parentTraceContext?.spanId));
+					const fileLogger = this._instantiationService.invokeFunction(accessor =>
+						accessor.get(IChatDebugFileLoggerService));
+					fileLogger.startChildSession(
+						chatSessionId, parentChatSessionId, childLabel, parentTraceContext?.spanId);
+					// Also register the invoke_agent span's ID so that hook spans
+					// (whose parentSpanId is this span) are routed to the child session.
+					const invokeSpanId = span.getSpanContext()?.spanId;
+					if (invokeSpanId) {
+						fileLogger.registerSpanSession(invokeSpanId, chatSessionId);
+					}
 				}
 
 				// Emit session start event and metric for top-level agent invocations (not subagents)

--- a/src/extension/tools/vscode-node/toolsService.ts
+++ b/src/extension/tools/vscode-node/toolsService.ts
@@ -157,6 +157,10 @@ export class ToolsService extends BaseToolsService {
 			if (traceCtx) {
 				if (chatStreamToolCallId) {
 					this._otelService.storeTraceContext(`subagent:toolcall:${chatStreamToolCallId}`, traceCtx);
+					// VS Code core uses the chatStreamToolCallId (LLM tool_use id) as
+					// the child's subAgentInvocationId, so store under the invocation
+					// prefix too for the child's lookup in toolCallingLoop.
+					this._otelService.storeTraceContext(`subagent:invocation:${chatStreamToolCallId}`, traceCtx);
 				}
 				if (subAgentInvocationId) {
 					this._otelService.storeTraceContext(`subagent:invocation:${subAgentInvocationId}`, traceCtx);

--- a/src/extension/trajectory/vscode-node/otelChatDebugLogProvider.ts
+++ b/src/extension/trajectory/vscode-node/otelChatDebugLogProvider.ts
@@ -121,6 +121,22 @@ export class OTelChatDebugLogProviderContribution extends Disposable implements 
 	}
 
 	/**
+	 * Prefix child entry event IDs that reuse the invoke_agent spanId
+	 * (user_message and subagent entries) so they don't collide with
+	 * parent-session entries (hooks, tool calls) that use the same ID
+	 * as their parentSpanId. Without this, parent hooks get wrongly
+	 * nested under the child node in the tree view.
+	 */
+	private _prefixChildEventId(evt: vscode.ChatDebugEvent, entry: IDebugLogEntry): void {
+		if (entry.type === 'user_message' || entry.type === 'subagent') {
+			const evtWithId = evt as { id?: string };
+			if (evtWithId.id) {
+				evtWithId.id = `child-${evtWithId.id}`;
+			}
+		}
+	}
+
+	/**
 	 * Add an entry to the detail resolution cache with LRU eviction.
 	 */
 	private _cacheEntry(evtId: string, entry: IDebugLogEntry): void {
@@ -179,6 +195,7 @@ export class OTelChatDebugLogProviderContribution extends Disposable implements 
 				const evt = debugLogEntryToDebugEvent(entry, this._skipCoreEvents);
 				if (evt) {
 					this._scopeEventIds(evt, entry.rIdx ?? 0);
+					this._prefixChildEventId(evt, entry);
 					if ('parentEventId' in evt) {
 						(evt as { parentEventId?: string }).parentEventId = childParentId;
 					}
@@ -285,6 +302,7 @@ export class OTelChatDebugLogProviderContribution extends Disposable implements 
 							const childEvt = debugLogEntryToDebugEvent(childEntry, this._skipCoreEvents);
 							if (childEvt) {
 								this._scopeEventIds(childEvt, childEntry.rIdx ?? 0);
+								this._prefixChildEventId(childEvt, childEntry);
 								// Set parent to the child_session_ref entry (with run-index scope)
 								if ('parentEventId' in childEvt) {
 									(childEvt as { parentEventId?: string }).parentEventId = scopedParentId;
@@ -388,6 +406,7 @@ export class OTelChatDebugLogProviderContribution extends Disposable implements 
 				const childEvt = debugLogEntryToDebugEvent(childEntry, this._skipCoreEvents);
 				if (childEvt) {
 					this._scopeEventIds(childEvt, childEntry.rIdx ?? 0);
+					this._prefixChildEventId(childEvt, childEntry);
 					if ('parentEventId' in childEvt) {
 						(childEvt as { parentEventId?: string }).parentEventId = scopedParentId;
 					}

--- a/src/extension/trajectory/vscode-node/otelChatDebugLogProvider.ts
+++ b/src/extension/trajectory/vscode-node/otelChatDebugLogProvider.ts
@@ -124,14 +124,15 @@ export class OTelChatDebugLogProviderContribution extends Disposable implements 
 	 * Prefix child entry event IDs that reuse the invoke_agent spanId
 	 * (user_message and subagent entries) so they don't collide with
 	 * parent-session entries (hooks, tool calls) that use the same ID
-	 * as their parentSpanId. Without this, parent hooks get wrongly
-	 * nested under the child node in the tree view.
+	 * as their parentSpanId. Include the entry type in the prefix so
+	 * child-session user_message and subagent events that share a spanId
+	 * don't collide with each other in UI caches or id-based lookups.
 	 */
 	private _prefixChildEventId(evt: vscode.ChatDebugEvent, entry: IDebugLogEntry): void {
 		if (entry.type === 'user_message' || entry.type === 'subagent') {
 			const evtWithId = evt as { id?: string };
 			if (evtWithId.id) {
-				evtWithId.id = `child-${evtWithId.id}`;
+				evtWithId.id = `child-${entry.type}-${evtWithId.id}`;
 			}
 		}
 	}

--- a/src/platform/chat/common/chatDebugFileLoggerService.ts
+++ b/src/platform/chat/common/chatDebugFileLoggerService.ts
@@ -55,6 +55,13 @@ export interface IChatDebugFileLoggerService {
 	startChildSession(childSessionId: string, parentSessionId: string, label: string, parentToolSpanId?: string): void;
 
 	/**
+	 * Register a span ID → session ID mapping so that child spans
+	 * (e.g. hooks) are routed to the correct session before the
+	 * parent span completes.
+	 */
+	registerSpanSession(spanId: string, sessionId: string): void;
+
+	/**
 	 * End logging for a session. Performs a final flush and removes the
 	 * session from the active set.
 	 */
@@ -170,6 +177,7 @@ export class NullChatDebugFileLoggerService implements IChatDebugFileLoggerServi
 
 	async startSession(): Promise<void> { }
 	startChildSession(): void { }
+	registerSpanSession(): void { }
 	async endSession(): Promise<void> { }
 	async flush(): Promise<void> { }
 	getLogPath(_sessionId?: string): URI | undefined { return undefined; }


### PR DESCRIPTION
Three issues with subagent events in the debug panel:

1. Parallel subagent trace context routing
When two runSubagent tool calls execute in parallel, both child_session_ref entries got the same parentSpanId, causing all child events to nest under one tool call while the other got none.

Root cause: VS Code core uses chatStreamToolCallId (the LLM tool_use ID) as the child's subAgentInvocationId, but toolsService only stored trace context under a generated UUID that the child never looked up.

Fix: Store trace context under subagent:invocation:${chatStreamToolCallId} in toolsService.ts so the child finds its correct unique parent span.

2. Hook spans routed to wrong session
PreToolUse hooks for child subagent tool calls were written to main.jsonl instead of the child's JSONL, causing them to appear as orphaned entries at root level in the panel.

Root cause: Hook spans carry the parent's CHAT_SESSION_ID from the CapturingToken, so _extractSessionId resolved them to the parent session. The child's invoke_agent span hadn't registered in _spanSessionIndex yet.

Fix:
Register the child's invoke_agent spanId in _spanSessionIndex via registerSpanSession() at startChildSession time
In _extractSessionId, prefer child session routing when the span's parentSpanId maps to a known child session


3. Event ID collisions between parent and child sessions
Child user_message and subagent entries reuse the invoke_agent span's raw spanId. Parent-session hooks with the same parentSpanId get wrongly nested under child nodes in the tree view.

Fix: _prefixChildEventId() adds a child- prefix to these event IDs in the provider (display layer only — JSONL on disk is unchanged).
