### PR TITLE
Enable BYOK for Business/Enterprise users with client_byok policy

### DIFF
--- a/src/extension/byok/common/byokProvider.ts
+++ b/src/extension/byok/common/byokProvider.ts
@@ -160,7 +160,7 @@ export function isBYOKEnabled(copilotToken: Omit<CopilotToken, 'token'>, capiCli
 	}
 
 	const isGHE = capiClientService.dotcomAPIURL !== 'https://api.github.com';
-	const byokAllowed = (copilotToken.isInternal || copilotToken.isIndividual) && !isGHE;
+	const byokAllowed = (copilotToken.isInternal || copilotToken.isIndividual || copilotToken.isClientBYOKEnabled()) && !isGHE;
 	return byokAllowed;
 }
 

--- a/src/extension/byok/common/test/byokProvider.spec.ts
+++ b/src/extension/byok/common/test/byokProvider.spec.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { CopilotToken, createTestExtendedTokenInfo } from '../../../../platform/authentication/common/copilotToken';
+import { ICAPIClientService } from '../../../../platform/endpoint/common/capiClient';
+import { isBYOKEnabled } from '../byokProvider';
+
+function createToken(overrides: { individual?: boolean; organization_list?: string[]; token?: string }): Omit<CopilotToken, 'token'> {
+	return new CopilotToken(createTestExtendedTokenInfo({
+		individual: overrides.individual ?? false,
+		organization_list: overrides.organization_list ?? [],
+		token: overrides.token ?? 'test-token',
+	}));
+}
+
+const dotcomCAPI = { dotcomAPIURL: 'https://api.github.com' } as ICAPIClientService;
+const gheCAPI = { dotcomAPIURL: 'https://ghe.example.com/api/v3' } as ICAPIClientService;
+
+describe('isBYOKEnabled', () => {
+	it('returns true for individual users on dotcom', () => {
+		const token = createToken({ individual: true });
+		expect(isBYOKEnabled(token, dotcomCAPI)).toBe(true);
+	});
+
+	it('returns false for individual users on GHE', () => {
+		const token = createToken({ individual: true });
+		expect(isBYOKEnabled(token, gheCAPI)).toBe(false);
+	});
+
+	it('returns false for business users without client_byok policy', () => {
+		const token = createToken({ individual: false });
+		expect(isBYOKEnabled(token, dotcomCAPI)).toBe(false);
+	});
+
+	it('returns true for business users with client_byok=1 policy', () => {
+		const token = createToken({ individual: false, token: 'client_byok=1' });
+		expect(isBYOKEnabled(token, dotcomCAPI)).toBe(true);
+	});
+
+	it('returns false for business users with client_byok=0 policy', () => {
+		const token = createToken({ individual: false, token: 'client_byok=0' });
+		expect(isBYOKEnabled(token, dotcomCAPI)).toBe(false);
+	});
+
+	it('returns false for business users with client_byok=1 on GHE', () => {
+		const token = createToken({ individual: false, token: 'client_byok=1' });
+		expect(isBYOKEnabled(token, gheCAPI)).toBe(false);
+	});
+});

--- a/src/extension/contextKeys/vscode-node/contextKeys.contribution.ts
+++ b/src/extension/contextKeys/vscode-node/contextKeys.contribution.ts
@@ -34,6 +34,7 @@ const showLogViewContextKey = `github.copilot.chat.showLogView`;
 const debugReportFeedbackContextKey = 'github.copilot.debugReportFeedback';
 
 const previewFeaturesDisabledContextKey = 'github.copilot.previewFeaturesDisabled';
+const clientByokEnabledContextKey = 'github.copilot.clientByokEnabled';
 
 const debugContextKey = 'github.copilot.chat.debug';
 
@@ -197,6 +198,15 @@ export class ContextKeysContribution extends Disposable {
 		}
 	}
 
+	private async _updateClientByokEnabledContext() {
+		try {
+			const copilotToken = await this._authenticationService.getCopilotToken();
+			commands.executeCommand('setContext', clientByokEnabledContextKey, copilotToken.isClientBYOKEnabled());
+		} catch (e) {
+			commands.executeCommand('setContext', clientByokEnabledContextKey, undefined);
+		}
+	}
+
 	private _updateShowLogViewContext() {
 		if (this._showLogView) {
 			return;
@@ -221,6 +231,7 @@ export class ContextKeysContribution extends Disposable {
 		this._inspectContext();
 		this._updateQuotaExceededContext();
 		this._updatePreviewFeaturesDisabledContext();
+		this._updateClientByokEnabledContext();
 		this._updateShowLogViewContext();
 		this._updatePermissiveSessionContext();
 	}

--- a/src/platform/authentication/common/copilotToken.ts
+++ b/src/platform/authentication/common/copilotToken.ts
@@ -217,6 +217,10 @@ export class CopilotToken {
 		return this.getTokenValue('mcp') !== '0';
 	}
 
+	isClientBYOKEnabled(): boolean {
+		return this.getTokenValue('client_byok') === '1';
+	}
+
 	getTokenValue(key: string): string | undefined {
 		return this.tokenMap.get(key);
 	}


### PR DESCRIPTION
## Summary

Enables BYOK (Bring Your Own Key) model configuration for Business and Enterprise SKU users whose organization has the BYOK policy enabled.

## Changes

### 1. `copilotToken. Read `client_byok` claimts` 
- Added `isClientBYOKEnabled()` method to `CopilotToken` that checks for `client_byok=1` in the token claims
- This claim is set server-side only for Business/Enterprise orgs that have the BYOK policy enabled

### 2. `contextKeys.contribution. Set context key for VS Code corets` 
- Sets `github.copilot.clientByokEnabled` context key based on `isClientBYOKEnabled()`
- VS Code core reads this key to show the "Add Models" button in the model picker

## Behavior

1. **Only affects Business and Enterprise SKU  the `client_byok=1` claim is only present in Copilot tokens for these plans when the BYOK policy is enabledusers** 
2. **Users will only be able to use BYOK if the BYOK policy is  controlled server-side by the organization adminenabled** 
3. **Availability in other plans is  Free, Pro, and other plan users are unaffectedunchanged** 

## Companion PR

- VS Code core: https://github.com/microsoft/vscode/pull/ reads the `github.copilot.clientByokEnabled` context key to enable the Add Models button308553 
