### PR TITLE
Add candidateModel and stickyOverride to automode.routerDecision telemetry

### DIFF
--- a/src/extension/intents/node/agentIntent.ts
+++ b/src/extension/intents/node/agentIntent.ts
@@ -12,6 +12,7 @@ import { ChatLocation, ChatResponse } from '../../../platform/chat/common/common
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { isAnthropicFamily, isGptFamily, modelCanUseApplyPatchExclusively, modelCanUseReplaceStringExclusively, modelSupportsApplyPatch, modelSupportsMultiReplaceString, modelSupportsReplaceString, modelSupportsSimplifiedApplyPatchInstructions } from '../../../platform/endpoint/common/chatModelCapabilities';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { IAutomodeService } from '../../../platform/endpoint/node/automodeService';
 import { IEnvService } from '../../../platform/env/common/envService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IEditLogService } from '../../../platform/multiFileEdit/common/editLogService';
@@ -345,7 +346,6 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		@ICodeMapperService codeMapperService: ICodeMapperService,
 		@IEnvService envService: IEnvService,
 		@IPromptPathRepresentationService promptPathRepresentationService: IPromptPathRepresentationService,
-		@IEndpointProvider endpointProvider: IEndpointProvider,
 		@IWorkspaceService workspaceService: IWorkspaceService,
 		@IToolsService toolsService: IToolsService,
 		@IConfigurationService configurationService: IConfigurationService,
@@ -355,8 +355,10 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		@INotebookService notebookService: INotebookService,
 		@ILogService private readonly logService: ILogService,
 		@IExperimentationService private readonly expService: IExperimentationService,
+		@IAutomodeService private readonly automodeService: IAutomodeService,
+		@IEndpointProvider private readonly _endpointProvider: IEndpointProvider,
 	) {
-		super(intent, location, endpoint, request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService);
+		super(intent, location, endpoint, request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, _endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService);
 	}
 
 	public override getAvailableTools(): Promise<vscode.LanguageModelToolInformation[]> {
@@ -476,13 +478,21 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 			}
 		}
 
-		// Helper function for synchronous summarization flow with fallbacks
+		// --- Post-summarization routing: after Model A produces the summary,
+		// the router picks Model B for subsequent turns. Only wire up when automode routing is enabled. ---
+		const isAutoModeEnabled = this.configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.UseAutoModeRouting, this.expService);
+		const resolveNextEndpoint = isAutoModeEnabled
+			? (summaryText: string) => this._resolveNextEndpointAfterSummarization(promptContext, summaryText)
+			: undefined;
+
 		const renderWithSummarization = async (reason: string, renderProps: AgentPromptProps = props): Promise<RenderPromptResult> => {
 			this.logService.debug(`[Agent] ${reason}, triggering summarization`);
 			try {
 				const renderer = PromptRenderer.create(this.instantiationService, endpoint, this.prompt, {
 					...renderProps,
 					triggerSummarize: true,
+					summarizationSource: 'foreground',
+					resolveNextEndpoint,
 				});
 				return await renderer.render(progress, token);
 			} catch (e) {
@@ -647,7 +657,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 				}
 			} else if (postRenderRatio >= 0.75 && (backgroundSummarizer.state === BackgroundSummarizationState.Idle || backgroundSummarizer.state === BackgroundSummarizationState.Failed)) {
 				// At ≥ 75% with no running compaction (or a previous failure) — kick off background work.
-				this._startBackgroundSummarization(backgroundSummarizer, props, endpoint, token, postRenderRatio);
+				this._startBackgroundSummarization(backgroundSummarizer, props, endpoint, token, postRenderRatio, resolveNextEndpoint);
 			}
 		}
 
@@ -712,12 +722,48 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		}
 	}
 
+	/**
+	 * Shared helper for post-summarization routing.
+	 * Called after Model A produces the summary. Routes based on the
+	 * summary text so Model B takes over for subsequent turns.
+	 */
+	private async _resolveNextEndpointAfterSummarization(
+		promptContext: IBuildPromptContext,
+		summaryText: string,
+	): Promise<void> {
+		try {
+			const allEndpoints = await this._endpointProvider.getAllChatEndpoints();
+			const conversationId = promptContext.conversation?.sessionId ?? 'unknown';
+			const result = await this.automodeService.resolveEndpointForSummarization(
+				conversationId, summaryText, allEndpoints);
+			if (result) {
+				this.logService.debug(
+					`[Agent] Post-summarization routing: ${result.previousModel} -> ${result.endpoint.model} `
+					+ `(label=${result.routerDecision.predicted_label}, `
+					+ `confidence=${(result.routerDecision.confidence * 100).toFixed(1)}%)`);
+			}
+		} catch (e) {
+			this.logService.warn(`[Agent] Post-summarization routing failed: ${(e as Error).message}`);
+			/* __GDPR__
+				"automode.postSummarizationRoutingFailed" : {
+					"owner": "lramos15",
+					"comment": "Reports when the post-summarization routing callback fails",
+					"error": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth", "comment": "Error message" }
+				}
+			*/
+			this.telemetryService.sendMSFTTelemetryEvent('automode.postSummarizationRoutingFailed', {
+				error: (e as Error).message,
+			});
+		}
+	}
+
 	private _startBackgroundSummarization(
 		backgroundSummarizer: BackgroundSummarizer,
 		props: AgentPromptProps,
 		endpoint: IChatEndpoint,
 		token: vscode.CancellationToken,
 		contextRatio: number,
+		resolveNextEndpoint?: (summaryText: string) => Promise<void>,
 	): void {
 		this.logService.debug(`[Agent] context at ${(contextRatio * 100).toFixed(0)}% — starting background compaction`);
 		const snapshotProps: AgentPromptProps = { ...props, promptContext: { ...props.promptContext } };
@@ -725,6 +771,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 			...snapshotProps,
 			triggerSummarize: true,
 			summarizationSource: 'background',
+			resolveNextEndpoint,
 		});
 		const bgProgress: vscode.Progress<vscode.ChatResponseReferencePart | vscode.ChatResponseProgressPart> = { report: () => { } };
 		const bgStartTime = Date.now();

--- a/src/extension/intents/node/askAgentIntent.ts
+++ b/src/extension/intents/node/askAgentIntent.ts
@@ -7,6 +7,7 @@ import type * as vscode from 'vscode';
 import { ChatLocation } from '../../../platform/chat/common/commonTypes';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { IAutomodeService } from '../../../platform/endpoint/node/automodeService';
 import { IEnvService } from '../../../platform/env/common/envService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IEditLogService } from '../../../platform/multiFileEdit/common/editLogService';
@@ -114,7 +115,6 @@ export class AskAgentIntentInvocation extends AgentIntentInvocation {
 		@ICodeMapperService codeMapperService: ICodeMapperService,
 		@IEnvService envService: IEnvService,
 		@IPromptPathRepresentationService promptPathRepresentationService: IPromptPathRepresentationService,
-		@IEndpointProvider endpointProvider: IEndpointProvider,
 		@IWorkspaceService workspaceService: IWorkspaceService,
 		@IToolsService toolsService: IToolsService,
 		@IConfigurationService configurationService: IConfigurationService,
@@ -124,8 +124,10 @@ export class AskAgentIntentInvocation extends AgentIntentInvocation {
 		@INotebookService notebookService: INotebookService,
 		@ILogService logService: ILogService,
 		@IExperimentationService expService: IExperimentationService,
+		@IAutomodeService automodeService: IAutomodeService,
+		@IEndpointProvider endpointProvider: IEndpointProvider,
 	) {
-		super(intent, location, endpoint, request, { processCodeblocks: true }, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, logService, expService);
+		super(intent, location, endpoint, request, { processCodeblocks: true }, instantiationService, codeMapperService, envService, promptPathRepresentationService, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, logService, expService, automodeService, endpointProvider);
 	}
 
 	public override async getAvailableTools(): Promise<vscode.LanguageModelToolInformation[]> {

--- a/src/extension/intents/node/editCodeIntent2.ts
+++ b/src/extension/intents/node/editCodeIntent2.ts
@@ -8,6 +8,7 @@ import { ChatLocation } from '../../../platform/chat/common/commonTypes';
 import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { modelSupportsMultiReplaceString, modelSupportsReplaceString } from '../../../platform/endpoint/common/chatModelCapabilities';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { IAutomodeService } from '../../../platform/endpoint/node/automodeService';
 import { IEnvService } from '../../../platform/env/common/envService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IEditLogService } from '../../../platform/multiFileEdit/common/editLogService';
@@ -75,7 +76,6 @@ export class EditCode2IntentInvocation extends AgentIntentInvocation {
 		@ICodeMapperService codeMapperService: ICodeMapperService,
 		@IEnvService envService: IEnvService,
 		@IPromptPathRepresentationService promptPathRepresentationService: IPromptPathRepresentationService,
-		@IEndpointProvider endpointProvider: IEndpointProvider,
 		@IWorkspaceService workspaceService: IWorkspaceService,
 		@IToolsService toolsService: IToolsService,
 		@IConfigurationService configurationService: IConfigurationService,
@@ -85,8 +85,10 @@ export class EditCode2IntentInvocation extends AgentIntentInvocation {
 		@INotebookService notebookService: INotebookService,
 		@ILogService logService: ILogService,
 		@IExperimentationService expService: IExperimentationService,
+		@IAutomodeService automodeService: IAutomodeService,
+		@IEndpointProvider endpointProvider: IEndpointProvider,
 	) {
-		super(intent, location, endpoint, request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, logService, expService);
+		super(intent, location, endpoint, request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, logService, expService, automodeService, endpointProvider);
 	}
 
 	public override async getAvailableTools(): Promise<vscode.LanguageModelToolInformation[]> {

--- a/src/extension/intents/node/notebookEditorIntent.ts
+++ b/src/extension/intents/node/notebookEditorIntent.ts
@@ -7,6 +7,7 @@ import type * as vscode from 'vscode';
 import { ChatLocation } from '../../../platform/chat/common/commonTypes';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { IAutomodeService } from '../../../platform/endpoint/node/automodeService';
 import { IEnvService } from '../../../platform/env/common/envService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IEditLogService } from '../../../platform/multiFileEdit/common/editLogService';
@@ -93,7 +94,6 @@ export class NotebookEditorIntentInvocation extends EditCode2IntentInvocation {
 		@ICodeMapperService codeMapperService: ICodeMapperService,
 		@IEnvService envService: IEnvService,
 		@IPromptPathRepresentationService promptPathRepresentationService: IPromptPathRepresentationService,
-		@IEndpointProvider endpointProvider: IEndpointProvider,
 		@IWorkspaceService workspaceService: IWorkspaceService,
 		@IToolsService toolsService: IToolsService,
 		@IConfigurationService configurationService: IConfigurationService,
@@ -103,8 +103,10 @@ export class NotebookEditorIntentInvocation extends EditCode2IntentInvocation {
 		@INotebookService notebookService: INotebookService,
 		@ILogService logService: ILogService,
 		@IExperimentationService expService: IExperimentationService,
+		@IAutomodeService automodeService: IAutomodeService,
+		@IEndpointProvider endpointProvider: IEndpointProvider,
 	) {
-		super(intent, location, endpoint, request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, logService, expService);
+		super(intent, location, endpoint, request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, logService, expService, automodeService, endpointProvider);
 	}
 
 	protected override prompt = NotebookInlinePrompt;

--- a/src/extension/prompts/node/agent/agentPrompt.tsx
+++ b/src/extension/prompts/node/agent/agentPrompt.tsx
@@ -72,6 +72,14 @@ export interface AgentPromptProps extends GenericBasePromptElementProps {
 
 	/** Whether this summarization was triggered as a background or foreground operation. */
 	readonly summarizationSource?: 'background' | 'foreground';
+
+	/**
+	 * Optional callback invoked after Model A produces the summary.
+	 * The router classifies the summary text and picks Model B for
+	 * subsequent turns. Called for both foreground and background
+	 * summarization, but not manual `/compact`.
+	 */
+	readonly resolveNextEndpoint?: (summaryText: string) => Promise<void>;
 }
 
 /** Proportion of the prompt token budget any singular textual tool result is allowed to use. */
@@ -145,6 +153,7 @@ export class AgentPrompt extends PromptElement<AgentPromptProps> {
 					tools={this.props.promptContext.tools?.availableTools}
 					enableCacheBreakpoints={this.props.enableCacheBreakpoints}
 					summarizationSource={this.props.summarizationSource}
+					resolveNextEndpoint={this.props.resolveNextEndpoint}
 					userQueryTagName={userQueryTagName}
 					ReminderInstructionsClass={ReminderInstructionsClass}
 					ToolReferencesHintClass={ToolReferencesHintClass}

--- a/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -408,6 +408,20 @@ export interface SummarizedAgentHistoryProps extends BasePromptElementProps, Age
 	readonly summarizationInstructions?: string;
 	/** Whether this summarization was triggered as a background or foreground operation. Defaults to 'foreground'. */
 	readonly summarizationSource?: 'background' | 'foreground';
+	/**
+	 * When true, disables the summarization router callback even for
+	 * foreground/unspecified sources.
+	 * Intended for cases like manual `/compact` where routing should be skipped.
+	 */
+	readonly excludeFromSummarizationRouter?: boolean;
+	/**
+	 * Optional callback invoked after Model A produces the summary.
+	 * When provided, called after the summary is produced so the router
+	 * can pick the next model based on the summary text. Model A (the
+	 * current model with warm cache) performs the summarization; Model B
+	 * takes over for subsequent turns, naturally caching the summary.
+	 */
+	readonly resolveNextEndpoint?: (summaryText: string) => Promise<void>;
 	/** Path to the conversation transcript JSONL file, used to inform the model after summarization */
 	readonly transcriptPath?: string;
 }
@@ -751,8 +765,26 @@ class ConversationHistorySummarizer {
 		});
 
 		const durationMs = stopwatch.elapsed();
+		const result = await this.handleSummarizationResponse(summaryResponse, mode, durationMs);
+
+		// --- Post-summarization routing: now that Model A has produced the
+		// summary using its warm cache, call the router with the summary text
+		// so it can pick Model B for subsequent turns. Model B will naturally
+		// cache the compact summary on its first use. ---
+		const resolveNextEndpoint = this.props.resolveNextEndpoint;
+		const shouldInvokeRouter =
+			!this.props.excludeFromSummarizationRouter
+			&& !!resolveNextEndpoint;
+		if (shouldInvokeRouter && resolveNextEndpoint) {
+			try {
+				await resolveNextEndpoint(result.value);
+			} catch (e) {
+				this.logInfo(`Post-summarization router call failed: ${(e as Error).message}`, mode);
+			}
+		}
+
 		return {
-			result: await this.handleSummarizationResponse(summaryResponse, mode, durationMs),
+			result,
 			promptTokenDetails,
 			model: endpoint.model,
 			summarizationMode: mode,

--- a/src/platform/configuration/common/configurationService.ts
+++ b/src/platform/configuration/common/configurationService.ts
@@ -824,6 +824,7 @@ export namespace ConfigKey {
 		export const InstantApplyModelName = defineTeamInternalSetting<string>('chat.advanced.instantApply.modelName', ConfigType.ExperimentBased, CHAT_MODEL.GPT4OPROXY);
 		export const VerifyTextDocumentChanges = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.verifyTextDocumentChanges', ConfigType.ExperimentBased, false);
 		export const UseAutoModeRouting = defineTeamInternalSetting<boolean>('chat.advanced.useAutoModeRouter', ConfigType.ExperimentBased, false);
+		export const UsePerConversationRouting = defineTeamInternalSetting<boolean>('chat.advanced.usePerConversationRouting', ConfigType.ExperimentBased, false);
 
 		/** Inline Completions */
 		export const InlineCompletionsDefaultDiagnosticsOptions = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineCompletions.defaultDiagnosticsOptionsString', ConfigType.ExperimentBased, undefined);

--- a/src/platform/endpoint/node/automodeService.ts
+++ b/src/platform/endpoint/node/automodeService.ts
@@ -20,7 +20,7 @@ import { IExperimentationService } from '../../telemetry/common/nullExperimentat
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { ICAPIClientService } from '../common/capiClient';
 import { AutoChatEndpoint } from './autoChatEndpoint';
-import { RouterDecisionFetcher, RoutingContextSignals } from './routerDecisionFetcher';
+import { RouterDecisionFetcher, RouterDecisionResponse, RoutingContextSignals } from './routerDecisionFetcher';
 
 interface AutoModeAPIResponse {
 	available_models: string[];
@@ -36,6 +36,8 @@ interface AutoModelCacheEntry {
 	lastRoutedPrompt?: string;
 	routerFallbackReason?: string;
 	turnCount: number;
+	/** When per-conversation routing is active, the model chosen on the first turn. */
+	conversationRoutedModel?: string;
 }
 
 class AutoModeTokenBank extends Disposable {
@@ -150,6 +152,24 @@ export interface IAutomodeService {
 	readonly _serviceBrand: undefined;
 
 	resolveAutoModeEndpoint(chatRequest: ChatRequest | undefined, knownEndpoints: IChatEndpoint[]): Promise<IChatEndpoint>;
+
+	/**
+	 * Re-evaluate model selection at a summarization boundary.
+	 *
+	 * Called AFTER Model A produces the summary. The router classifies
+	 * the summary text and picks Model B for subsequent turns. Model A
+	 * performs the summarization (leveraging its warm KV cache), then
+	 * Model B naturally caches the compact summary on its first turn.
+	 *
+	 * @param prompt The summary text produced by Model A.
+	 * @returns The selected endpoint (Model B) and routing decision,
+	 *          or undefined if routing is disabled / not applicable.
+	 */
+	resolveEndpointForSummarization(
+		conversationId: string,
+		prompt: string,
+		knownEndpoints: IChatEndpoint[],
+	): Promise<{ endpoint: IChatEndpoint; routerDecision: RouterDecisionResponse; previousModel: string } | undefined>;
 }
 
 export class AutomodeService extends Disposable implements IAutomodeService {
@@ -213,6 +233,35 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		const lastRoutedPrompt = routerResult.lastRoutedPrompt;
 		const routerFallbackReason = routerResult.fallbackReason;
 
+		// Telemetry: report model selection with routing mode
+		if (selectedModel) {
+			/* __GDPR__
+				"automode.routerModelSelected" : {
+					"owner": "lramos15",
+					"comment": "Model selection with routing mode context",
+					"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Selected model" },
+					"previousModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Previous turn model" },
+					"routingMode": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "per-turn or per-conversation" },
+					"modelChanged": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether model changed" },
+					"turnNumber": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Turn number" },
+					"discountedCost": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Discounted cost" },
+					"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Chat conversation ID" },
+					"isConversationReuse": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether model was reused from first turn (per-conversation routing)" }
+				}
+			*/
+			this._telemetryService.sendMSFTTelemetryEvent('automode.routerModelSelected', {
+				model: selectedModel.model,
+				previousModel: entry?.endpoint?.model ?? '',
+				routingMode: this._isPerConversationRouting() ? 'per-conversation' : 'per-turn',
+				modelChanged: String(selectedModel.model !== entry?.endpoint?.model),
+				conversationId,
+				isConversationReuse: String(!!routerResult.conversationRoutedModel && !!entry?.conversationRoutedModel),
+			}, {
+				turnNumber: (entry?.turnCount ?? 0) + 1,
+				discountedCost: token.discounted_costs?.[selectedModel.model] ?? 0,
+			});
+		}
+
 		// Default model selection when router was skipped or failed
 		if (!selectedModel) {
 			if (routerFallbackReason) {
@@ -244,7 +293,8 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			lastSessionToken: token.session_token,
 			lastRoutedPrompt,
 			routerFallbackReason,
-			turnCount: (entry?.turnCount ?? 0) + (isNewTurn ? 1 : 0)
+			turnCount: (entry?.turnCount ?? 0) + (isNewTurn ? 1 : 0),
+			conversationRoutedModel: routerResult.conversationRoutedModel ?? entry?.conversationRoutedModel,
 		});
 		return autoEndpoint;
 	}
@@ -266,7 +316,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		entry: AutoModelCacheEntry | undefined,
 		token: AutoModeAPIResponse,
 		knownEndpoints: IChatEndpoint[],
-	): Promise<{ selectedModel?: IChatEndpoint; lastRoutedPrompt?: string; fallbackReason?: string }> {
+	): Promise<{ selectedModel?: IChatEndpoint; lastRoutedPrompt?: string; fallbackReason?: string; conversationRoutedModel?: string }> {
 		const prompt = chatRequest?.prompt?.trim();
 		const lastRoutedPrompt = entry?.lastRoutedPrompt ?? prompt;
 
@@ -276,6 +326,29 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 
 		if (!this._isRouterEnabled(chatRequest) || conversationId === 'unknown') {
 			return { lastRoutedPrompt };
+		}
+
+		// --- Per-conversation routing: route once on first turn, reuse for subsequent turns ---
+		if (this._isPerConversationRouting()) {
+			if (entry?.conversationRoutedModel) {
+				const cachedModel = entry.conversationRoutedModel;
+				const isModelAllowedForToken = !!token.available_models?.includes(cachedModel);
+
+				if (!isModelAllowedForToken) {
+					this._logService.trace(`[AutomodeService] Per-conversation routing: cached model=${cachedModel} not allowed for current token, clearing`);
+					return { lastRoutedPrompt: prompt ?? lastRoutedPrompt, fallbackReason: 'conversationModelNotAllowed' };
+				}
+
+				const selectedModel = knownEndpoints.find(e => e.model === cachedModel);
+				if (selectedModel) {
+					this._logService.trace(`[AutomodeService] Per-conversation routing: reusing model=${cachedModel} for conversation=${conversationId}`);
+					return { selectedModel, lastRoutedPrompt: prompt ?? lastRoutedPrompt, conversationRoutedModel: cachedModel };
+				} else {
+					this._logService.trace(`[AutomodeService] Per-conversation routing: model=${cachedModel} unavailable, clearing`);
+					return { lastRoutedPrompt: prompt ?? lastRoutedPrompt, fallbackReason: 'conversationModelUnavailable' };
+				}
+			}
+			// First turn: fall through to normal router call below, then store the chosen model
 		}
 
 		if (!prompt?.length) {
@@ -312,7 +385,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			if (result.sticky_override) {
 				this._logService.trace(`[AutomodeService] Sticky routing override: confidence=${(result.confidence * 100).toFixed(1)}%, label=${result.predicted_label}, router_model=${result.candidate_models[0]}, actual_model=${selectedModel.model}`);
 			}
-			return { selectedModel, lastRoutedPrompt: prompt };
+			return { selectedModel, lastRoutedPrompt: prompt, conversationRoutedModel: this._isPerConversationRouting() ? selectedModel.model : undefined };
 		} catch (e) {
 			this._logService.error(`Failed to get routed model for conversation ${conversationId}:`, (e as Error).message);
 			return { lastRoutedPrompt: prompt, fallbackReason: 'routerError' };
@@ -333,6 +406,137 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 	private _isRouterEnabled(chatRequest: ChatRequest | undefined): boolean {
 		const isPanelChat = !chatRequest?.location || chatRequest?.location === ChatLocation.Panel;
 		return isPanelChat && this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.UseAutoModeRouting, this._expService);
+	}
+
+	/**
+	 * When true, the router is called only on the first turn of a conversation.
+	 * The chosen model is then reused for all subsequent turns.
+	 */
+	private _isPerConversationRouting(): boolean {
+		return this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.UsePerConversationRouting, this._expService);
+	}
+
+	/**
+	 * Re-evaluate model selection after summarization completes.
+	 *
+	 * Model A (the current model with a warm KV cache) has already produced
+	 * the summary. This method calls the router with the summary text to
+	 * pick Model B for subsequent turns. Model B will naturally cache the
+	 * compact summary as its context prefix on the next turn.
+	 *
+	 * @param prompt The summary text produced by Model A.
+	 */
+	async resolveEndpointForSummarization(
+		conversationId: string,
+		prompt: string,
+		knownEndpoints: IChatEndpoint[],
+	): Promise<{ endpoint: IChatEndpoint; routerDecision: RouterDecisionResponse; previousModel: string } | undefined> {
+		// Only re-route if auto mode routing is enabled
+		if (!this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.UseAutoModeRouting, this._expService)) {
+			this._logService.trace('[AutomodeService] resolveEndpointForSummarization: routing disabled via config');
+			return undefined;
+		}
+
+		const entry = this._autoModelCache.get(conversationId);
+		if (!entry) {
+			this._logService.trace('[AutomodeService] resolveEndpointForSummarization: no cache entry, skipping');
+			return undefined;
+		}
+
+		const previousModel = entry.endpoint.model;
+		if (!prompt?.trim().length) {
+			return undefined;
+		}
+
+		let token: AutoModeAPIResponse;
+		try {
+			token = await entry.tokenBank.getToken();
+		} catch {
+			this._logService.warn('[AutomodeService] resolveEndpointForSummarization: failed to get token');
+			return undefined;
+		}
+
+		try {
+			const contextSignals: RoutingContextSignals = {
+				session_id: conversationId !== 'unknown' ? conversationId : undefined,
+				previous_model: previousModel,
+				turn_number: (entry.turnCount ?? 0) + 1,
+				prompt_char_count: prompt.length,
+			};
+
+			const result = await this._routerDecisionFetcher.getRouterDecision(
+				prompt, token.session_token, token.available_models, undefined, contextSignals);
+
+			if (!result.candidate_models.length) {
+				this._logService.trace('[AutomodeService] resolveEndpointForSummarization: empty candidates');
+				return undefined;
+			}
+
+			let selectedEndpoint = this._findSameProviderModel(
+				entry.endpoint.modelProvider, result.candidate_models, knownEndpoints);
+			selectedEndpoint ??= knownEndpoints.find(e => e.model === result.candidate_models[0]);
+
+			if (!selectedEndpoint) {
+				this._logService.trace('[AutomodeService] resolveEndpointForSummarization: no matching endpoint');
+				return undefined;
+			}
+
+			const modelChanged = selectedEndpoint.model !== previousModel;
+			this._logService.info(
+				`[AutomodeService] resolveEndpointForSummarization: `
+				+ `${previousModel} -> ${selectedEndpoint.model} (changed=${modelChanged}), `
+				+ `label=${result.predicted_label}, confidence=${(result.confidence * 100).toFixed(1)}%`);
+
+			const autoEndpoint = modelChanged
+				? this._instantiationService.createInstance(
+					AutoChatEndpoint, selectedEndpoint, token.session_token,
+					token.discounted_costs?.[selectedEndpoint.model] || 0,
+					this._calculateDiscountRange(token.discounted_costs))
+				: entry.endpoint;
+
+			this._autoModelCache.set(conversationId, {
+				...entry,
+				endpoint: autoEndpoint,
+				lastSessionToken: token.session_token,
+			});
+
+			/* __GDPR__
+				"automode.routerAfterSummarization" : {
+					"owner": "lramos15",
+					"comment": "Reports routing decision made after summarization to switch models for subsequent turns",
+					"previousModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Model that was active when summarization was triggered" },
+					"nextModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Model selected by router for subsequent turns after summarization" },
+					"predictedLabel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Router classification label" },
+					"modelChanged": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the model actually changed" },
+					"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Chat conversation ID" },
+					"confidence": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Router confidence score" }
+				}
+			*/
+			this._telemetryService.sendMSFTTelemetryEvent('automode.routerAfterSummarization', {
+				previousModel,
+				nextModel: selectedEndpoint.model,
+				predictedLabel: result.predicted_label,
+				modelChanged: String(modelChanged),
+				conversationId,
+			}, {
+				confidence: result.confidence,
+			});
+
+			return { endpoint: autoEndpoint, routerDecision: result, previousModel };
+		} catch (e) {
+			this._logService.error('[AutomodeService] resolveEndpointForSummarization failed:', (e as Error).message);
+			/* __GDPR__
+				"automode.routerAfterSummarizationError" : {
+					"owner": "lramos15",
+					"comment": "Reports when the post-summarization router call fails",
+					"error": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth", "comment": "Error message" }
+				}
+			*/
+			this._telemetryService.sendMSFTTelemetryEvent('automode.routerAfterSummarizationError', {
+				error: (e as Error).message,
+			});
+			return undefined;
+		}
 	}
 
 	/**

--- a/src/platform/endpoint/node/automodeService.ts
+++ b/src/platform/endpoint/node/automodeService.ts
@@ -368,7 +368,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 				previous_model: entry?.endpoint?.model,
 				turn_number: (entry?.turnCount ?? 0) + 1,
 			};
-			const result = await this._routerDecisionFetcher.getRouterDecision(prompt, token.session_token, token.available_models, undefined, contextSignals);
+const result = await this._routerDecisionFetcher.getRouterDecision(prompt, token.session_token, token.available_models, undefined, contextSignals, conversationId, chatRequest?.id);
 
 			if (!result.candidate_models.length) {
 				return { lastRoutedPrompt: prompt, fallbackReason: 'emptyCandidateList' };
@@ -465,7 +465,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			};
 
 			const result = await this._routerDecisionFetcher.getRouterDecision(
-				prompt, token.session_token, token.available_models, undefined, contextSignals);
+					prompt, token.session_token, token.available_models, undefined, contextSignals, conversationId);
 
 			if (!result.candidate_models.length) {
 				this._logService.trace('[AutomodeService] resolveEndpointForSummarization: empty candidates');

--- a/src/platform/endpoint/node/routerDecisionFetcher.ts
+++ b/src/platform/endpoint/node/routerDecisionFetcher.ts
@@ -48,7 +48,7 @@ export class RouterDecisionFetcher {
 	) {
 	}
 
-	async getRouterDecision(query: string, autoModeToken: string, availableModels: string[], stickyThreshold?: number, contextSignals?: RoutingContextSignals): Promise<RouterDecisionResponse> {
+	async getRouterDecision(query: string, autoModeToken: string, availableModels: string[], stickyThreshold?: number, contextSignals?: RoutingContextSignals, conversationId?: string, vscodeRequestId?: string): Promise<RouterDecisionResponse> {
 		const startTime = Date.now();
 		const requestBody: Record<string, unknown> = { prompt: query, available_models: availableModels, ...contextSignals };
 		if (stickyThreshold !== undefined) {
@@ -100,20 +100,28 @@ export class RouterDecisionFetcher {
 			"automode.routerDecision" : {
 				"owner": "lramos15",
 				"comment": "Reports the routing decision made by the auto mode router API",
+				"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The conversation ID in which the routing decision was made" },
+				"vscodeRequestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The VS Code chat request ID in which the routing decision was made" },
 				"predictedLabel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The predicted classification label (needs_reasoning or no_reasoning)" },
+				"candidateModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The top candidate model recommended by the router before any overrides" },
 				"confidence": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "The confidence score of the routing decision" },
 				"latencyMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "The latency of the router API call in milliseconds" },
-				"e2eLatencyMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "The end-to-end latency of the router request in milliseconds, including network overhead" }
+				"e2eLatencyMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "The end-to-end latency of the router request in milliseconds, including network overhead" },
+				"stickyOverride": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Whether the router applied a sticky override (1) or not (0)" }
 			}
 		*/
 		this._telemetryService.sendMSFTTelemetryEvent('automode.routerDecision',
 			{
+				conversationId: conversationId ?? '',
+				vscodeRequestId: vscodeRequestId ?? '',
 				predictedLabel: result.predicted_label,
+				candidateModel: result.candidate_models[0] ?? '',
 			},
 			{
 				confidence: result.confidence,
 				latencyMs: result.latency_ms,
 				e2eLatencyMs: e2eLatencyMs,
+				stickyOverride: result.sticky_override ? 1 : 0,
 			}
 		);
 		return result;

--- a/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -706,6 +706,110 @@ describe('AutomodeService', () => {
 		});
 	});
 
+	describe('per-conversation routing', () => {
+		function enablePerConversationRouting(): void {
+			enableRouter();
+			(configurationService as InMemoryConfigurationService).setConfig(
+				ConfigKey.TeamInternal.UsePerConversationRouting,
+				true
+			);
+		}
+
+		function mockRouterResponse(available_models: string[], routerResult: { chosen_model: string; candidate_models: string[] }, session_token = 'test-token'): void {
+			(mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mockImplementation((_body: any, opts: any) => {
+				if (opts?.type === RequestType.ModelRouter) {
+					return Promise.resolve({
+						ok: true,
+						text: vi.fn().mockResolvedValue(JSON.stringify({
+							predicted_label: 'needs_reasoning',
+							confidence: 0.9,
+							latency_ms: 30,
+							chosen_model: routerResult.chosen_model,
+							candidate_models: routerResult.candidate_models,
+							scores: { needs_reasoning: 0.9, no_reasoning: 0.1 },
+							sticky_override: false
+						}))
+					});
+				}
+				return Promise.resolve({
+					ok: true,
+					json: vi.fn().mockResolvedValue({
+						available_models,
+						expires_at: Math.floor(Date.now() / 1000) + 3600,
+						session_token,
+					})
+				});
+			});
+		}
+
+		it('should reuse first turn model on subsequent turns', async () => {
+			enablePerConversationRouting();
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
+			const claudeEndpoint = createEndpoint('claude-sonnet', 'Anthropic');
+
+			mockRouterResponse(
+				['gpt-4o', 'claude-sonnet'],
+				{ chosen_model: 'gpt-4o', candidate_models: ['gpt-4o', 'claude-sonnet'] }
+			);
+
+			automodeService = createService();
+			const chatRequest1: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'first question',
+				sessionId: 'session-per-conv-1'
+			};
+
+			const firstResult = await automodeService.resolveAutoModeEndpoint(chatRequest1 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+			expect(firstResult.model).toBe('gpt-4o');
+
+			const chatRequest2: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'second question completely different',
+				sessionId: 'session-per-conv-1'
+			};
+
+			const secondResult = await automodeService.resolveAutoModeEndpoint(chatRequest2 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+			expect(secondResult.model).toBe('gpt-4o');
+
+			const routerCallCount = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls
+				.filter((call: any[]) => call[1]?.type === RequestType.ModelRouter).length;
+			expect(routerCallCount).toBe(1);
+		});
+
+		it('should still route per-turn when per-conversation routing is disabled', async () => {
+			enableRouter();
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
+			const claudeEndpoint = createEndpoint('claude-sonnet', 'Anthropic');
+
+			mockRouterResponse(
+				['gpt-4o', 'claude-sonnet'],
+				{ chosen_model: 'gpt-4o', candidate_models: ['gpt-4o', 'claude-sonnet'] }
+			);
+
+			automodeService = createService();
+			const chatRequest1: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'first question',
+				sessionId: 'session-per-turn-check'
+			};
+
+			await automodeService.resolveAutoModeEndpoint(chatRequest1 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+
+			const chatRequest2: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'second different question',
+				sessionId: 'session-per-turn-check'
+			};
+
+			await automodeService.resolveAutoModeEndpoint(chatRequest2 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+
+			const routerCallCount = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls
+				.filter((call: any[]) => call[1]?.type === RequestType.ModelRouter).length;
+			expect(routerCallCount).toBe(2);
+		});
+
+	});
+
 	describe('vision fallback', () => {
 		it('should fall back to vision-capable model when selected model does not support vision', async () => {
 			const nonVisionEndpoint = createEndpoint('gpt-4o-mini', 'OpenAI', { supportsVision: false });


### PR DESCRIPTION
## Problem

The `automode.routerDecision` telemetry event only logged `predictedLabel` and `confidence`, making it impossible to distinguish what model the router recommended vs. what model was actually used after sticky-provider and vision overrides. Both `model` and `modelInvoked` in `response.success` resolve to the same concrete model ID, so there was no way to detect when the router's recommendation was overridden.

## Fix

Add four new properties to the `automode.routerDecision` event:

| Property | Type | Description |
|---|---|---|
| `candidateModel` | string | The router's top pick (`candidate_models[0]`) before any overrides |
| `stickyOverride` | measurement | Whether the router applied a sticky override (1 or 0) |
| `conversationId` | string | Enables joining with `response.success` events |
| `vscodeRequestId` | string | Enables per-request correlation |

## How to use

Join `automode.routerDecision.candidateModel` with `response.success.model` on the same `conversationId`/`vscodeRequestId`. When they differ, the router recommended one model but sticky-provider affinity or vision fallback selected a different one.

## Changes

- **routerDecisionFetcher.ts**: Extended `getRouterDecision()` signature and GDPR annotations; added `candidateModel`, `stickyOverride`, `conversationId`, `vscodeRequestId` to telemetry payload
- **automodeService.ts**: Pass `conversationId` and `chatRequest.id` through both call sites