### PR TITLE
provide more terminal tools to subagent

### DIFF
--- a/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
+++ b/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
@@ -118,6 +118,9 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 
 		const allowedExecutionTools = new Set([
 			ToolName.CoreRunInTerminal,
+			ToolName.CoreGetTerminalOutput,
+			ToolName.CoreSendToTerminal,
+			ToolName.CoreKillTerminal,
 		]);
 
 		return allTools.filter(tool => allowedExecutionTools.has(tool.name as ToolName));

--- a/src/extension/tools/common/toolNames.ts
+++ b/src/extension/tools/common/toolNames.ts
@@ -54,6 +54,8 @@ export enum ToolName {
 	CoreManageTodoList = 'manage_todo_list',
 	CoreRunInTerminal = 'run_in_terminal',
 	CoreGetTerminalOutput = 'get_terminal_output',
+	CoreSendToTerminal = 'send_to_terminal',
+	CoreKillTerminal = 'kill_terminal',
 	CoreTerminalSelection = 'terminal_selection',
 	CoreTerminalLastCommand = 'terminal_last_command',
 	CoreCreateAndRunTask = 'create_and_run_task',
@@ -209,6 +211,8 @@ export const toolCategories: Record<ToolName, ToolCategory> = {
 	[ToolName.SearchViewResults]: ToolCategory.VSCodeInteraction,
 	[ToolName.CoreTerminalSelection]: ToolCategory.VSCodeInteraction,
 	[ToolName.CoreTerminalLastCommand]: ToolCategory.VSCodeInteraction,
+	[ToolName.CoreSendToTerminal]: ToolCategory.Core,
+	[ToolName.CoreKillTerminal]: ToolCategory.Core,
 
 	// Testing
 	[ToolName.TestFailure]: ToolCategory.Testing,


### PR DESCRIPTION
part of https://github.com/microsoft/vscode/issues/308048

Expand execution subagent's allowed tools to include `get_terminal_output`, `send_to_terminal`, and `kill_terminal` so it can actively manage terminals instead of relying on notifications (which are only passed to the main agent)