### PR TITLE
Fix skillContentRead and readFileToolInvoked telemetry in readFileTool

### DIFF
--- a/src/extension/tools/node/readFileTool.tsx
+++ b/src/extension/tools/node/readFileTool.tsx
@@ -362,9 +362,9 @@ export class ReadFileTool implements ICopilotTool<ReadFileParams> {
 				toolOutcome: outcome, // Props named "outcome" often get stuck in the kusto pipeline
 				isV2: isParamsV2(options.input) ? 'true' : 'false',
 				isEntireFile: isParamsV2(options.input) && options.input.offset === undefined && options.input.limit === undefined ? 'true' : 'false',
-				fileType,
-				nameField,
-				model,
+				fileType: fileType,
+				nameField: nameField,
+				model: model,
 			},
 			{
 				linesRead: end - start,
@@ -386,10 +386,10 @@ export class ReadFileTool implements ICopilotTool<ReadFileParams> {
 			const plaintextProps = {
 				skillName: skillInfo.skillName,
 				skillPath: uri.toString(),
-				extensionId,
-				extensionVersion,
+				extensionId: extensionId,
+				extensionVersion: extensionVersion,
 				skillStorage: skillInfo.storage,
-				contentHash,
+				contentHash: contentHash,
 			};
 
 			this.telemetryService.sendGHTelemetryEvent('skillContentRead',
@@ -398,7 +398,7 @@ export class ReadFileTool implements ICopilotTool<ReadFileParams> {
 					extensionIdHash: extensionId ? String(hash(extensionId)) : '',
 					extensionVersion: plaintextProps.extensionVersion,
 					skillStorage: plaintextProps.skillStorage,
-					contentHash,
+					contentHash: plaintextProps.contentHash,
 				}
 			);
 


### PR DESCRIPTION
Fixes `skillContentRead` telemetry to ensure each field has a proper prefix instead of using shorthand properties.\n\nAlso fixed `readFileToolInvoked` telemetry properties to use explicit key-value pairs instead of shorthand. Both events validated in local telemetry.