### PR TITLE
Security: Unvalidated URI schemes passed to VS Code opener

### DIFF
--- a/src/platform/open/vscode/opener.ts
+++ b/src/platform/open/vscode/opener.ts
@@ -11,6 +11,11 @@ export class RealUrlOpener implements IUrlOpener {
 	declare readonly _serviceBrand: undefined;
 
 	async open(target: string): Promise<void> {
-		await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(target));
+		const uri = vscode.Uri.parse(target, true);
+		if (uri.scheme !== 'https' && uri.scheme !== 'http') {
+			throw new Error(`Unsupported URI scheme: ${uri.scheme}`);
+		}
+
+		await vscode.commands.executeCommand('vscode.open', uri);
 	}
 }


### PR DESCRIPTION
## Problem

The `open` method accepts an arbitrary string and directly passes `vscode.Uri.parse(target)` into `vscode.open` without validating scheme or destination. If `target` can be influenced by untrusted input (e.g., chat/tool output), this may allow opening dangerous URI schemes (including command-like or external handlers), enabling phishing flows or unintended command execution paths in the host environment.

**Severity**: `medium`
**File**: `src/platform/open/vscode/opener.ts`

## Solution

Enforce an allowlist of safe schemes (for example `https` and optionally `http`), reject or sanitize all others, and consider explicit user confirmation for external links. Also validate hostnames when opening security-sensitive URLs.

## Changes

- `src/platform/open/vscode/opener.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
