### PR TITLE
Security: Overly permissive GitHub remote detection via prefix match

### DIFF
--- a/src/platform/remoteRepositories/common/utils.ts
+++ b/src/platform/remoteRepositories/common/utils.ts
@@ -6,5 +6,13 @@
 import { URI } from '../../../util/vs/base/common/uri';
 
 export function isGitHubRemoteRepository(uri: URI): boolean {
-	return uri.scheme === 'vscode-vfs' && uri.authority.startsWith('github');
+	if (uri.scheme !== 'vscode-vfs') {
+		return false;
+	}
+
+	const authority = uri.authority.toLowerCase();
+	const host = authority.includes('@') ? authority.split('@').pop() ?? '' : authority;
+	const hostname = host.split(':')[0];
+
+	return hostname === 'github' || hostname === 'github.com' || hostname === 'github.dev' || hostname.endsWith('.github.dev');
 }


### PR DESCRIPTION
## Problem

GitHub remotes are identified using `uri.authority.startsWith('github')`. This can be spoofed by authorities like `github.evil.example`, potentially causing untrusted remotes to be treated as GitHub remotes if this check gates trust, auth behavior, or feature enablement.

**Severity**: `medium`
**File**: `src/platform/remoteRepositories/common/utils.ts`

## Solution

Replace prefix matching with strict authority validation (exact host match or vetted suffix list, e.g., `github.com`, `*.github.dev` as required). Normalize case and parse host components before comparison.

## Changes

- `src/platform/remoteRepositories/common/utils.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
