### PR TITLE
Add `vscode-chat-response-resource://` URIs to allowlist to fix chat response resource reads

### DIFF
--- a/src/extension/tools/node/test/readFile.spec.tsx
+++ b/src/extension/tools/node/test/readFile.spec.tsx
@@ -343,6 +343,38 @@ suite('ReadFile', () => {
 			testAccessor.dispose();
 		});
 
+		test('reads chat response resources without requiring an open tab', async () => {
+			const resourceUri = URI.parse('vscode-chat-response-resource://session/tool/call-1/0/file.md');
+			const resourceDoc = createTextDocumentData(resourceUri, 'linked resource line 1\nlinked resource line 2', 'markdown').document;
+
+			const services = createExtensionUnitTestingServices();
+			services.define(IWorkspaceService, new SyncDescriptor(
+				TestWorkspaceService,
+				[
+					[],
+					[resourceDoc],
+				]
+			));
+
+			const testAccessor = services.createTestingAccessor();
+			const readFileTool = testAccessor.get(IInstantiationService).createInstance(ReadFileTool);
+
+			const input: IReadFileParamsV2 = {
+				filePath: resourceUri.toString()
+			};
+
+			const prepareResult = await readFileTool.prepareInvocation(
+				{ input },
+				CancellationToken.None
+			);
+
+			expect(prepareResult).toBeDefined();
+			expect((prepareResult!.invocationMessage as MarkdownString).value).toBe(`Reading [](${resourceUri.toString()})`);
+			expect((prepareResult!.pastTenseMessage as MarkdownString).value).toBe(`Read [](${resourceUri.toString()})`);
+
+			testAccessor.dispose();
+		});
+
 		test('should return "Reading skill/Read skill" message for skill files with line range', async () => {
 			const testDoc = createTextDocumentData(URI.file('/workspace/test.skill.md'), 'line 1\nline 2\nline 3\nline 4\nline 5', 'markdown').document;
 

--- a/src/extension/tools/node/test/toolUtils.spec.ts
+++ b/src/extension/tools/node/test/toolUtils.spec.ts
@@ -154,6 +154,17 @@ suite('toolUtils - additionalReadAccessPaths', () => {
 			await expect(invokeAssertFileOkForTool(URI.file('/external/file.ts'), true))
 				.rejects.toThrow(/outside of the workspace/);
 		});
+
+		test('chat response resources are allowed for read-only access', async () => {
+			const resourceUri = URI.parse('vscode-chat-response-resource://session/tool/call-1/0/file.md');
+			await expect(invokeAssertFileOkForTool(resourceUri, true)).resolves.toBeUndefined();
+		});
+
+		test('chat response resources are not allowlisted outside read-only access', async () => {
+			const resourceUri = URI.parse('vscode-chat-response-resource://session/tool/call-1/0/file.md');
+			await expect(invokeAssertFileOkForTool(resourceUri))
+				.rejects.toThrow(/outside of the workspace/);
+		});
 	});
 
 	describe('isFileExternalAndNeedsConfirmation', () => {
@@ -196,6 +207,11 @@ suite('toolUtils - additionalReadAccessPaths', () => {
 			await configService.setConfig(ConfigKey.AdditionalReadAccessPaths, ['/allowed']);
 			await expect(invokeIsFileExternalAndNeedsConfirmation(URI.file('/disallowed/file.ts'), true))
 				.rejects.toThrow(/does not exist/);
+		});
+
+		test('chat response resources do not need confirmation for read-only access', async () => {
+			const resourceUri = URI.parse('vscode-chat-response-resource://session/tool/call-1/0/file.md');
+			expect(await invokeIsFileExternalAndNeedsConfirmation(resourceUri, true)).toBe(false);
 		});
 	});
 

--- a/src/extension/tools/node/toolUtils.ts
+++ b/src/extension/tools/node/toolUtils.ts
@@ -164,6 +164,42 @@ export interface AssertFileOkForToolOptions {
 	readOnly?: boolean;
 }
 
+async function isUriAllowedWithoutWorkspaceMembership(
+	uri: URI,
+	normalizedUri: URI,
+	tabsAndEditorsService: ITabsAndEditorsService,
+	customInstructionsService: ICustomInstructionsService,
+	diskSessionResources: IChatDiskSessionResources,
+	chatDebugFileLogger: IChatDebugFileLoggerService,
+	sessionTranscriptService: ISessionTranscriptService,
+	buildPromptContext?: IBuildPromptContext,
+	options?: AssertFileOkForToolOptions,
+): Promise<boolean> {
+	if (uri.scheme === Schemas.untitled) {
+		return true;
+	}
+	if (options?.readOnly && uri.scheme === 'vscode-chat-response-resource') {
+		return true;
+	}
+	if (await isExternalInstructionsFile(normalizedUri, customInstructionsService, buildPromptContext)) {
+		return true;
+	}
+	if (diskSessionResources.isSessionResourceUri(normalizedUri)) {
+		return true;
+	}
+	if (chatDebugFileLogger.isDebugLogUri(normalizedUri)) {
+		return true;
+	}
+	if (sessionTranscriptService.isTranscriptUri(normalizedUri)) {
+		return true;
+	}
+	if (tabsAndEditorsService.tabs.some(tab => isEqual(tab.uri, uri))) {
+		return true;
+	}
+
+	return false;
+}
+
 export async function assertFileOkForTool(accessor: ServicesAccessor, uri: URI, buildPromptContext?: IBuildPromptContext, options?: AssertFileOkForToolOptions): Promise<void> {
 	const workspaceService = accessor.get(IWorkspaceService);
 	const tabsAndEditorsService = accessor.get(ITabsAndEditorsService);
@@ -183,23 +219,17 @@ export async function assertFileOkForTool(accessor: ServicesAccessor, uri: URI, 
 	if (options?.readOnly && isUriUnderAdditionalReadAccessPaths(normalizedUri, configurationService)) {
 		return;
 	}
-	if (uri.scheme === Schemas.untitled) {
-		return;
-	}
-	const fileOpenInSomeTab = tabsAndEditorsService.tabs.some(tab => isEqual(tab.uri, uri));
-	if (fileOpenInSomeTab) {
-		return;
-	}
-	if (diskSessionResources.isSessionResourceUri(normalizedUri)) {
-		return;
-	}
-	if (chatDebugFileLogger.isDebugLogUri(normalizedUri)) {
-		return;
-	}
-	if (sessionTranscriptService.isTranscriptUri(normalizedUri)) {
-		return;
-	}
-	if (await isExternalInstructionsFile(normalizedUri, customInstructionsService, buildPromptContext)) {
+	if (await isUriAllowedWithoutWorkspaceMembership(
+		uri,
+		normalizedUri,
+		tabsAndEditorsService,
+		customInstructionsService,
+		diskSessionResources,
+		chatDebugFileLogger,
+		sessionTranscriptService,
+		buildPromptContext,
+		options,
+	)) {
 		return;
 	}
 	throw new Error(`File ${promptPathRepresentationService.getFilePath(normalizedUri)} is outside of the workspace, and not open in an editor, and can't be read`);
@@ -281,29 +311,24 @@ export async function isFileExternalAndNeedsConfirmation(accessor: ServicesAcces
 
 	const normalizedUri = normalizePath(uri);
 
-	// Not external if: in workspace, untitled, instructions file, session resource, or open in editor
+	// Not external if: in workspace, under configured read-only paths, or otherwise allowlisted for read-only access.
 	if (workspaceService.getWorkspaceFolder(normalizedUri)) {
 		return false;
 	}
 	if (options?.readOnly && isUriUnderAdditionalReadAccessPaths(normalizedUri, configurationService)) {
 		return false;
 	}
-	if (uri.scheme === Schemas.untitled || uri.scheme === 'vscode-chat-response-resource') {
-		return false;
-	}
-	if (await isExternalInstructionsFile(normalizedUri, customInstructionsService, buildPromptContext)) {
-		return false;
-	}
-	if (diskSessionResources.isSessionResourceUri(normalizedUri)) {
-		return false;
-	}
-	if (chatDebugFileLogger.isDebugLogUri(normalizedUri)) {
-		return false;
-	}
-	if (sessionTranscriptService.isTranscriptUri(normalizedUri)) {
-		return false;
-	}
-	if (tabsAndEditorsService.tabs.some(tab => isEqual(tab.uri, uri))) {
+	if (await isUriAllowedWithoutWorkspaceMembership(
+		uri,
+		normalizedUri,
+		tabsAndEditorsService,
+		customInstructionsService,
+		diskSessionResources,
+		chatDebugFileLogger,
+		sessionTranscriptService,
+		buildPromptContext,
+		options,
+	)) {
 		return false;
 	}
 


### PR DESCRIPTION
In microsoft/vscode#308877 we're running into a problem where the resources from the GitHub MCP server (specifically for copilot spaces) come in under URIs like: `vscode-chat-response-resource://...`

These aren't part of the allowlist for readonly files so the model can't access them.

## Summary
- centralize the read-only allowlist for URIs that are readable without workspace membership
- allow `vscode-chat-response-resource` URIs through both read-file access checks
- add regressions for unopened chat response resource reads

## Testing
- npx vitest run src/extension/tools/node/test/toolUtils.spec.ts
- npx vitest run src/extension/tools/node/test/readFile.spec.tsx -t "reads chat response resources without requiring an open tab"

I also tested this locally in my Insiders instance using the launch copilot extension run and debug. 
<img width="686" height="252" alt="CleanShot 2026-05-13 at 14 32 49@2x" src="https://github.com/user-attachments/assets/9fcaebb1-2bda-4b7b-b294-953b2eed2e3c" />

and it works swimmingly. 

<img width="1534" height="1798" alt="CleanShot 2026-05-13 at 14 30 24@2x" src="https://github.com/user-attachments/assets/ef9497e9-96f8-4911-8742-7f59b5cbbd67" />

