### PR TITLE
Add user-scoped memory store and retrieval via unified /prompt endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"@anthropic-ai/sdk": "^0.82.0",
 				"@github/blackbird-external-ingest-utils": "^0.3.0",
 				"@github/copilot": "^1.0.17",
+				"@github/copilot-agentic-tools": "file:../copilot-agentic-tools",
 				"@google/genai": "^1.22.0",
 				"@humanwhocodes/gitignore-to-minimatch": "1.0.2",
 				"@microsoft/tiktokenizer": "^1.0.10",
@@ -157,6 +158,19 @@
 				"node": ">=22.14.0",
 				"npm": ">=9.0.0",
 				"vscode": "^1.115.0"
+			}
+		},
+		"../copilot-agentic-tools": {
+			"name": "@github/copilot-agentic-tools",
+			"version": "0.6.0",
+			"license": "MIT",
+			"dependencies": {
+				"zod": "^3.23.0"
+			},
+			"devDependencies": {
+				"@types/node": "^25.5.2",
+				"typescript": "^6.0.2",
+				"vitest": "^4.1.2"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -3221,6 +3235,10 @@
 				"@github/copilot-win32-arm64": "1.0.17",
 				"@github/copilot-win32-x64": "1.0.17"
 			}
+		},
+		"node_modules/@github/copilot-agentic-tools": {
+			"resolved": "../copilot-agentic-tools",
+			"link": true
 		},
 		"node_modules/@github/copilot-darwin-arm64": {
 			"version": "1.0.17",

--- a/package.json
+++ b/package.json
@@ -6354,6 +6354,7 @@
 		"@anthropic-ai/sdk": "^0.82.0",
 		"@github/blackbird-external-ingest-utils": "^0.3.0",
 		"@github/copilot": "^1.0.17",
+		"@github/copilot-agentic-tools": "file:../copilot-agentic-tools",
 		"@google/genai": "^1.22.0",
 		"@humanwhocodes/gitignore-to-minimatch": "1.0.2",
 		"@microsoft/tiktokenizer": "^1.0.10",

--- a/src/extension/extension/vscode-node/services.ts
+++ b/src/extension/extension/vscode-node/services.ts
@@ -137,6 +137,7 @@ import { FixCookbookService, IFixCookbookService } from '../../prompts/node/inli
 import { WorkspaceMutationManager } from '../../testing/node/setupTestsFileManager';
 import { AgentMemoryService, IAgentMemoryService } from '../../tools/common/agentMemoryService';
 import { IMemoryCleanupService, MemoryCleanupService } from '../../tools/common/memoryCleanupService';
+import { AgentMemoryToolRegistrar, IAgentMemoryToolRegistrar } from '../../tools/node/agentMemoryToolRegistrar';
 import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
 import { ToolDeferralService } from '../../tools/common/toolDeferralService';
 import { IToolsService } from '../../tools/common/toolsService';
@@ -167,6 +168,7 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 	builder.define(IToolsService, new SyncDescriptor(ToolsService));
 	builder.define(IToolDeferralService, new ToolDeferralService());
 	builder.define(IAgentMemoryService, new SyncDescriptor(AgentMemoryService));
+	builder.define(IAgentMemoryToolRegistrar, new SyncDescriptor(AgentMemoryToolRegistrar));
 	builder.define(IMemoryCleanupService, new SyncDescriptor(MemoryCleanupService));
 	builder.define(IChatDiskSessionResources, new SyncDescriptor(ChatDiskSessionResources));
 	builder.define(IRequestLogger, new SyncDescriptor(RequestLogger));

--- a/src/extension/tools/common/agentMemoryService.ts
+++ b/src/extension/tools/common/agentMemoryService.ts
@@ -27,6 +27,24 @@ export interface RepoMemoryEntry {
 }
 
 /**
+ * User memory entry format for user-scoped memories.
+ */
+export interface UserMemoryEntry {
+	subject: string;
+	fact: string;
+	citations?: string | string[];
+	reason?: string;
+}
+
+/**
+ * Response from the unified /prompt endpoint.
+ * Contains combined memory context text for both repo and user scopes.
+ */
+export interface MemoryPromptResponse {
+	prompt: string;
+}
+
+/**
  * Type guard to validate if an object is a valid RepoMemoryEntry.
  * Accepts both new format (citations: string[]) and legacy format (citations: string).
  */
@@ -76,8 +94,8 @@ export function normalizeCitations(citations: string | string[] | undefined): st
 }
 
 /**
- * Service for managing repository memories via the Copilot Memory service (CAPI).
- * Memories are stored in the cloud and available when Copilot Memory is enabled for the repository.
+ * Service for managing memories via the Copilot Memory service (CAPI).
+ * Memories are stored in the cloud and available when Copilot Memory is enabled.
  */
 export interface IAgentMemoryService {
 	readonly _serviceBrand: undefined;
@@ -100,6 +118,19 @@ export interface IAgentMemoryService {
 	 * Returns true if stored successfully, false if Copilot Memory is not enabled or if storing fails.
 	 */
 	storeRepoMemory(memory: RepoMemoryEntry): Promise<boolean>;
+
+	/**
+	 * Store a user-scoped memory to Copilot Memory service.
+	 * Returns true if stored successfully, false if not enabled or if storing fails.
+	 */
+	storeUserMemory(memory: UserMemoryEntry): Promise<boolean>;
+
+	/**
+	 * Fetch the unified memory prompt from the /prompt endpoint.
+	 * Returns combined repo + user memory context text, or undefined on failure.
+	 * Pass repoNwo to include repo-scoped memories alongside user memories.
+	 */
+	getMemoryPrompt(repoNwo?: string): Promise<MemoryPromptResponse | undefined>;
 }
 
 export const IAgentMemoryService = createServiceIdentifier<IAgentMemoryService>('IAgentMemoryService');
@@ -328,6 +359,104 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 		} catch (error) {
 			this.logService.warn(`[AgentMemoryService] Failed to store repo memory: ${error}`);
 			return false;
+		}
+	}
+
+	async storeUserMemory(memory: UserMemoryEntry): Promise<boolean> {
+		try {
+			if (!this.isCAPIMemorySyncConfigEnabled()) {
+				this.logService.debug('[AgentMemoryService] Copilot Memory not enabled, skipping user memory store');
+				return false;
+			}
+
+			const session = await this.authenticationService.getGitHubSession('any', { silent: true });
+			if (!session) {
+				this.logService.warn('[AgentMemoryService] No GitHub session available for storing user memory');
+				return false;
+			}
+
+			const username = session.account.label;
+			const citations = normalizeCitations(memory.citations) ?? [];
+
+			// Derive base URL from capiPingURL (strips /_ping suffix)
+			const capiBase = this.capiClientService.capiPingURL.replace(/\/_ping$/, '');
+			const url = `${capiBase}/agents/swe/internal/memory/v0/users/${encodeURIComponent(username)}`;
+
+			const response = await fetch(url, {
+				method: 'PUT',
+				headers: {
+					'Authorization': `Bearer ${session.accessToken}`,
+					'Content-Type': 'application/json',
+					'X-GitHub-Api-Version': '2025-10-01',
+				},
+				body: JSON.stringify({
+					subject: memory.subject,
+					fact: memory.fact,
+					citations,
+					reason: memory.reason,
+					source: { agent: 'vscode' },
+				}),
+			});
+
+			if (!response.ok) {
+				this.logService.warn(`[AgentMemoryService] Failed to store user memory: ${response.statusText}`);
+				return false;
+			}
+
+			this.logService.info(`[AgentMemoryService] Stored user memory for ${username}: ${memory.subject}`);
+			return true;
+		} catch (error) {
+			this.logService.warn(`[AgentMemoryService] Failed to store user memory: ${error}`);
+			return false;
+		}
+	}
+
+	async getMemoryPrompt(repoNwo?: string): Promise<MemoryPromptResponse | undefined> {
+		try {
+			if (!this.isCAPIMemorySyncConfigEnabled()) {
+				this.logService.debug('[AgentMemoryService] Copilot Memory not enabled, skipping prompt fetch');
+				return undefined;
+			}
+
+			const session = await this.authenticationService.getGitHubSession('any', { silent: true });
+			if (!session) {
+				this.logService.warn('[AgentMemoryService] No GitHub session available for fetching memory prompt');
+				return undefined;
+			}
+
+			const username = session.account.label;
+			const capiBase = this.capiClientService.capiPingURL.replace(/\/_ping$/, '');
+
+			const params = new URLSearchParams({ user: username });
+			if (repoNwo) {
+				params.set('repo', repoNwo);
+			}
+			const url = `${capiBase}/agents/swe/internal/memory/v0/prompt?${params.toString()}`;
+
+			const response = await fetch(url, {
+				method: 'GET',
+				headers: {
+					'Authorization': `Bearer ${session.accessToken}`,
+					'X-GitHub-Api-Version': '2025-10-01',
+				},
+			});
+
+			if (!response.ok) {
+				this.logService.warn(`[AgentMemoryService] Failed to fetch memory prompt: ${response.statusText}`);
+				return undefined;
+			}
+
+			const data = await response.json() as { prompt?: string };
+			if (typeof data?.prompt !== 'string') {
+				this.logService.warn('[AgentMemoryService] Unexpected response shape from /prompt endpoint');
+				return undefined;
+			}
+
+			this.logService.info(`[AgentMemoryService] Fetched unified memory prompt (${data.prompt.length} chars)`);
+			return { prompt: data.prompt };
+		} catch (error) {
+			this.logService.warn(`[AgentMemoryService] Failed to fetch memory prompt: ${error}`);
+			return undefined;
 		}
 	}
 }

--- a/src/extension/tools/common/agentMemoryService.ts
+++ b/src/extension/tools/common/agentMemoryService.ts
@@ -3,7 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RequestType } from '@vscode/copilot-api';
+import {
+	fetchMemoryPrompts,
+	fetchRecentMemories,
+	storeMemory,
+	voteMemory,
+	type MemoryApiOptions,
+	type MemoryPromptResponse,
+	type MemoryResponse,
+	type StoreMemoryRequest,
+	type VoteMemoryRequest,
+	type VoteMemoryOptions,
+} from '@github/copilot-agentic-tools/memory';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { ICAPIClientService } from '../../../platform/endpoint/common/capiClient';
@@ -14,20 +25,12 @@ import { IWorkspaceService } from '../../../platform/workspace/common/workspaceS
 import { createServiceIdentifier } from '../../../util/common/services';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 
-/**
- * Repository memory entry format aligned with CAPI service contract.
- * Supports both new format (citations as string[]) and legacy format (citations as string).
- */
-export interface RepoMemoryEntry {
-	subject: string;
-	fact: string;
-	citations?: string | string[];
-	reason?: string;
-	category?: string;
-}
+// Re-export package types that callers depend on
+export type { MemoryPromptResponse, MemoryResponse as RepoMemoryEntry };
 
 /**
  * User memory entry format for user-scoped memories.
+ * @deprecated Use StoreMemoryRequest from @github/copilot-agentic-tools/memory directly.
  */
 export interface UserMemoryEntry {
 	subject: string;
@@ -37,29 +40,32 @@ export interface UserMemoryEntry {
 }
 
 /**
- * Response from the unified /prompt endpoint.
- * Contains combined memory context text for both repo and user scopes.
+ * Normalize citations field to string[] format.
+ * Handles backward compatibility for legacy string format.
  */
-export interface MemoryPromptResponse {
-	prompt: string;
+export function normalizeCitations(citations: string | string[] | undefined): string[] | undefined {
+	if (citations === undefined) {
+		return undefined;
+	}
+	if (typeof citations === 'string') {
+		return citations.split(',').map(c => c.trim()).filter(c => c.length > 0);
+	}
+	return citations;
 }
 
 /**
- * Type guard to validate if an object is a valid RepoMemoryEntry.
- * Accepts both new format (citations: string[]) and legacy format (citations: string).
+ * Type guard to validate if an object is a valid RepoMemoryEntry (MemoryResponse from package).
  */
-export function isRepoMemoryEntry(obj: unknown): obj is RepoMemoryEntry {
+export function isRepoMemoryEntry(obj: unknown): obj is MemoryResponse {
 	if (typeof obj !== 'object' || obj === null) {
 		return false;
 	}
 	const entry = obj as Record<string, unknown>;
 
-	// Required fields
 	if (typeof entry.subject !== 'string' || typeof entry.fact !== 'string') {
 		return false;
 	}
 
-	// Optional fields
 	if (entry.citations !== undefined) {
 		const isString = typeof entry.citations === 'string';
 		const isStringArray = Array.isArray(entry.citations) && entry.citations.every(c => typeof c === 'string');
@@ -79,56 +85,44 @@ export function isRepoMemoryEntry(obj: unknown): obj is RepoMemoryEntry {
 	return true;
 }
 
-/**
- * Normalize citations field to string[] format.
- * Handles backward compatibility for legacy string format.
- */
-export function normalizeCitations(citations: string | string[] | undefined): string[] | undefined {
-	if (citations === undefined) {
-		return undefined;
-	}
-	if (typeof citations === 'string') {
-		return citations.split(',').map(c => c.trim()).filter(c => c.length > 0);
-	}
-	return citations;
-}
+const INTEGRATION_ID = 'vscode-chat';
 
 /**
  * Service for managing memories via the Copilot Memory service (CAPI).
- * Memories are stored in the cloud and available when Copilot Memory is enabled.
+ * Delegates to @github/copilot-agentic-tools/memory for all API calls.
  */
 export interface IAgentMemoryService {
 	readonly _serviceBrand: undefined;
 
 	/**
 	 * Check if Copilot Memory is enabled for the current repository.
-	 * Makes a lightweight API call to the enablement check endpoint.
-	 * Returns false if not enabled or if the check fails.
 	 */
 	checkMemoryEnabled(): Promise<boolean>;
 
 	/**
 	 * Get repo memories from Copilot Memory service.
-	 * Returns undefined if Copilot Memory is not enabled or if fetching fails.
 	 */
-	getRepoMemories(limit?: number): Promise<RepoMemoryEntry[] | undefined>;
+	getRepoMemories(limit?: number): Promise<MemoryResponse[] | undefined>;
 
 	/**
 	 * Store a repo memory to Copilot Memory service.
-	 * Returns true if stored successfully, false if Copilot Memory is not enabled or if storing fails.
 	 */
-	storeRepoMemory(memory: RepoMemoryEntry): Promise<boolean>;
+	storeRepoMemory(memory: StoreMemoryRequest): Promise<boolean>;
 
 	/**
 	 * Store a user-scoped memory to Copilot Memory service.
-	 * Returns true if stored successfully, false if not enabled or if storing fails.
 	 */
-	storeUserMemory(memory: UserMemoryEntry): Promise<boolean>;
+	storeUserMemory(memory: StoreMemoryRequest): Promise<boolean>;
+
+	/**
+	 * Vote on a memory via the Copilot Memory service.
+	 */
+	voteOnMemory(vote: VoteMemoryRequest, scope: 'repository' | 'user'): Promise<boolean>;
 
 	/**
 	 * Fetch the unified memory prompt from the /prompt endpoint.
-	 * Returns combined repo + user memory context text, or undefined on failure.
-	 * Pass repoNwo to include repo-scoped memories alongside user memories.
+	 * Returns the full MemoryPromptResponse including storeToolDefinition and voteToolDefinition,
+	 * or undefined on failure.
 	 */
 	getMemoryPrompt(repoNwo?: string): Promise<MemoryPromptResponse | undefined>;
 }
@@ -150,10 +144,6 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 		super();
 	}
 
-	/**
-	 * Get the GitHub repository NWO (name with owner) for the current workspace.
-	 * Returns the NWO in lowercase format (e.g., "microsoft/vscode").
-	 */
 	private async getRepoNwo(): Promise<string | undefined> {
 		try {
 			const workspaceFolders = this.workspaceService.getWorkspaceFolders();
@@ -166,7 +156,6 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 				return undefined;
 			}
 
-			// Try to get GitHub repo info from remote URLs
 			for (const remoteUrl of getOrderedRemoteUrlsFromContext(repo)) {
 				const repoId = getGithubRepoIdFromFetchUrl(remoteUrl);
 				if (repoId) {
@@ -181,17 +170,28 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 		}
 	}
 
-	/**
-	 * Check if the chat.copilotMemory.enabled config is enabled.
-	 * Uses experiment-based configuration for gradual rollout.
-	 */
 	private isCAPIMemorySyncConfigEnabled(): boolean {
 		return this.configService.getExperimentBasedConfig(ConfigKey.CopilotMemoryEnabled, this.experimentationService);
 	}
 
+	private getBaseUrl(): string {
+		return this.capiClientService.capiPingURL.replace(/\/_ping$/, '');
+	}
+
+	private async getToken(): Promise<string | undefined> {
+		const session = await this.authenticationService.getGitHubSession('any', { silent: true });
+		return session?.accessToken;
+	}
+
+	private makeLogger() {
+		return {
+			info: (msg: string) => this.logService.info(`[AgentMemoryService] ${msg}`),
+			error: (msg: string) => this.logService.warn(`[AgentMemoryService] ${msg}`),
+		};
+	}
+
 	async checkMemoryEnabled(): Promise<boolean> {
 		try {
-			// Check if CAPI sync is enabled via config
 			if (!this.isCAPIMemorySyncConfigEnabled()) {
 				return false;
 			}
@@ -201,23 +201,22 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 				return false;
 			}
 
-			// Get OAuth token for API call
-			const session = await this.authenticationService.getGitHubSession('any', { silent: true });
-			if (!session) {
+			const token = await this.getToken();
+			if (!token) {
 				this.logService.warn('[AgentMemoryService] No GitHub session available for memory enablement check');
 				return false;
 			}
 
-			// Make API call to check enablement
-			const response = await this.capiClientService.makeRequest<Response>({
+			const [owner, repo] = repoNwo.split('/');
+			const baseUrl = this.getBaseUrl();
+			const url = `${baseUrl}/agents/swe/internal/memory/v0/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/enabled`;
+
+			const response = await fetch(url, {
 				method: 'GET',
 				headers: {
-					'Authorization': `Bearer ${session.accessToken}`
-				}
-			}, {
-				type: RequestType.CopilotAgentMemory,
-				repo: repoNwo,
-				action: 'enabled'
+					'Authorization': `Bearer ${token}`,
+					'Copilot-Integration-Id': INTEGRATION_ID,
+				},
 			});
 
 			if (!response.ok) {
@@ -227,7 +226,6 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 
 			const data = await response.json() as { enabled?: boolean };
 			const enabled = data?.enabled ?? false;
-
 			this.logService.info(`[AgentMemoryService] Copilot Memory enabled for ${repoNwo}: ${enabled}`);
 			return enabled;
 		} catch (error) {
@@ -236,12 +234,10 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 		}
 	}
 
-	async getRepoMemories(limit: number = 10): Promise<RepoMemoryEntry[] | undefined> {
+	async getRepoMemories(limit: number = 10): Promise<MemoryResponse[] | undefined> {
 		try {
-			// Check if Copilot Memory is enabled
 			const enabled = await this.checkMemoryEnabled();
 			if (!enabled) {
-				this.logService.debug('[AgentMemoryService] Copilot Memory not enabled, skipping repo memory fetch');
 				return undefined;
 			}
 
@@ -250,68 +246,37 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 				return undefined;
 			}
 
-			// Get OAuth token for API call
-			const session = await this.authenticationService.getGitHubSession('any', { silent: true });
-			if (!session) {
+			const token = await this.getToken();
+			if (!token) {
 				this.logService.warn('[AgentMemoryService] No GitHub session available for fetching memories');
 				return undefined;
 			}
 
-			// Fetch memories from Copilot Memory service
-			const response = await this.capiClientService.makeRequest<Response>({
-				method: 'GET',
-				headers: {
-					'Authorization': `Bearer ${session.accessToken}`
-				}
-			}, {
-				type: RequestType.CopilotAgentMemory,
-				repo: repoNwo,
-				action: 'recent',
-				limit
-			});
+			const [owner, repo] = repoNwo.split('/');
+			const options: MemoryApiOptions = {
+				scope: 'repository',
+				owner,
+				repo,
+				token,
+				integrationId: INTEGRATION_ID,
+				baseUrl: this.getBaseUrl(),
+				limit,
+				logger: this.makeLogger(),
+			};
 
-			if (!response.ok) {
-				this.logService.warn(`[AgentMemoryService] Failed to fetch memories: ${response.statusText}`);
-				return undefined;
-			}
-
-			const data = await response.json() as Array<{
-				subject: string;
-				fact: string;
-				citations?: string[];
-				reason?: string;
-				category?: string;
-			}>;
-
-			if (!data || !Array.isArray(data)) {
-				return undefined;
-			}
-
-			// Transform response to RepoMemoryEntry format
-			const memories: RepoMemoryEntry[] = data
-				.filter(isRepoMemoryEntry)
-				.map(entry => ({
-					subject: entry.subject,
-					fact: entry.fact,
-					citations: entry.citations,
-					reason: entry.reason,
-					category: entry.category
-				}));
-
-			this.logService.info(`[AgentMemoryService] Fetched ${memories.length} repo memories for ${repoNwo}`);
-			return memories.length > 0 ? memories : undefined;
+			const memories = await fetchRecentMemories(options);
+			this.logService.info(`[AgentMemoryService] Fetched ${memories?.length ?? 0} repo memories for ${repoNwo}`);
+			return memories;
 		} catch (error) {
 			this.logService.warn(`[AgentMemoryService] Failed to fetch repo memories: ${error}`);
 			return undefined;
 		}
 	}
 
-	async storeRepoMemory(memory: RepoMemoryEntry): Promise<boolean> {
+	async storeRepoMemory(memory: StoreMemoryRequest): Promise<boolean> {
 		try {
-			// Check if Copilot Memory is enabled
 			const enabled = await this.checkMemoryEnabled();
 			if (!enabled) {
-				this.logService.debug('[AgentMemoryService] Copilot Memory not enabled, skipping repo memory store');
 				return false;
 			}
 
@@ -320,93 +285,114 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 				return false;
 			}
 
-			// Normalize citations to array format for CAPI
-			const citations = normalizeCitations(memory.citations) ?? [];
-
-			// Get OAuth token for API call
-			const session = await this.authenticationService.getGitHubSession('any', { silent: true });
-			if (!session) {
+			const token = await this.getToken();
+			if (!token) {
 				this.logService.warn('[AgentMemoryService] No GitHub session available for storing memory');
 				return false;
 			}
 
-			// Store memory to Copilot Memory service
-			const response = await this.capiClientService.makeRequest<Response>({
-				method: 'PUT',
-				headers: {
-					'Authorization': `Bearer ${session.accessToken}`
-				},
-				json: {
-					subject: memory.subject,
-					fact: memory.fact,
-					citations,
-					reason: memory.reason,
-					category: memory.category,
-					source: { agent: 'vscode' }
-				}
-			}, {
-				type: RequestType.CopilotAgentMemory,
-				repo: repoNwo
-			});
+			const [owner, repo] = repoNwo.split('/');
+			const options = {
+				scope: 'repository' as const,
+				owner,
+				repo,
+				token,
+				integrationId: INTEGRATION_ID,
+				baseUrl: this.getBaseUrl(),
+				agent: 'vscode',
+				logger: this.makeLogger(),
+			};
 
-			if (!response.ok) {
-				this.logService.warn(`[AgentMemoryService] Failed to store memory: ${response.statusText}`);
-				return false;
+			const result = await storeMemory(memory, options);
+			if (!result.success) {
+				this.logService.warn(`[AgentMemoryService] Failed to store repo memory: ${result.error}`);
 			}
-
-			this.logService.info(`[AgentMemoryService] Stored repo memory for ${repoNwo}: ${memory.subject}`);
-			return true;
+			return result.success;
 		} catch (error) {
 			this.logService.warn(`[AgentMemoryService] Failed to store repo memory: ${error}`);
 			return false;
 		}
 	}
 
-	async storeUserMemory(memory: UserMemoryEntry): Promise<boolean> {
+	async storeUserMemory(memory: StoreMemoryRequest): Promise<boolean> {
 		try {
 			if (!this.isCAPIMemorySyncConfigEnabled()) {
-				this.logService.debug('[AgentMemoryService] Copilot Memory not enabled, skipping user memory store');
 				return false;
 			}
 
-			const session = await this.authenticationService.getGitHubSession('any', { silent: true });
-			if (!session) {
+			const token = await this.getToken();
+			if (!token) {
 				this.logService.warn('[AgentMemoryService] No GitHub session available for storing user memory');
 				return false;
 			}
 
-			const username = session.account.label;
-			const citations = normalizeCitations(memory.citations) ?? [];
+			const options = {
+				scope: 'user' as const,
+				token,
+				integrationId: INTEGRATION_ID,
+				baseUrl: this.getBaseUrl(),
+				agent: 'vscode',
+				logger: this.makeLogger(),
+			};
 
-			// Derive base URL from capiPingURL (strips /_ping suffix)
-			const capiBase = this.capiClientService.capiPingURL.replace(/\/_ping$/, '');
-			const url = `${capiBase}/agents/swe/internal/memory/v0/users/${encodeURIComponent(username)}`;
+			const result = await storeMemory(memory, options);
+			if (!result.success) {
+				this.logService.warn(`[AgentMemoryService] Failed to store user memory: ${result.error}`);
+			}
+			return result.success;
+		} catch (error) {
+			this.logService.warn(`[AgentMemoryService] Failed to store user memory: ${error}`);
+			return false;
+		}
+	}
 
-			const response = await fetch(url, {
-				method: 'PUT',
-				headers: {
-					'Authorization': `Bearer ${session.accessToken}`,
-					'Content-Type': 'application/json',
-					'X-GitHub-Api-Version': '2025-10-01',
-				},
-				body: JSON.stringify({
-					subject: memory.subject,
-					fact: memory.fact,
-					citations,
-					reason: memory.reason,
-					source: { agent: 'vscode' },
-				}),
-			});
-
-			if (!response.ok) {
-				this.logService.warn(`[AgentMemoryService] Failed to store user memory: ${response.statusText}`);
+	async voteOnMemory(vote: VoteMemoryRequest, scope: 'repository' | 'user'): Promise<boolean> {
+		try {
+			if (!this.isCAPIMemorySyncConfigEnabled()) {
 				return false;
 			}
 
-			this.logService.info(`[AgentMemoryService] Stored user memory for ${username}: ${memory.subject}`);
-			return true;
+			const token = await this.getToken();
+			if (!token) {
+				this.logService.warn('[AgentMemoryService] No GitHub session available for voting on memory');
+				return false;
+			}
+
+			let options: VoteMemoryOptions;
+			if (scope === 'repository') {
+				const repoNwo = await this.getRepoNwo();
+				if (!repoNwo) {
+					return false;
+				}
+				const [owner, repo] = repoNwo.split('/');
+				options = {
+					scope: 'repository',
+					owner,
+					repo,
+					token,
+					integrationId: INTEGRATION_ID,
+					baseUrl: this.getBaseUrl(),
+					agent: 'vscode',
+					logger: this.makeLogger(),
+				};
+			} else {
+				options = {
+					scope: 'user',
+					token,
+					integrationId: INTEGRATION_ID,
+					baseUrl: this.getBaseUrl(),
+					agent: 'vscode',
+					logger: this.makeLogger(),
+				};
+			}
+
+			const result = await voteMemory(vote, options);
+			if (!result.success) {
+				this.logService.warn(`[AgentMemoryService] Failed to vote on memory: ${result.error}`);
+			}
+			return result.success;
 		} catch (error) {
-			this.logService.warn(`[AgentMemoryService] Failed to store user memory: ${error}`);
+			this.logService.warn(`[AgentMemoryService] Failed to vote on memory: ${error}`);
 			return false;
 		}
 	}
@@ -414,46 +400,43 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 	async getMemoryPrompt(repoNwo?: string): Promise<MemoryPromptResponse | undefined> {
 		try {
 			if (!this.isCAPIMemorySyncConfigEnabled()) {
-				this.logService.debug('[AgentMemoryService] Copilot Memory not enabled, skipping prompt fetch');
 				return undefined;
 			}
 
-			const session = await this.authenticationService.getGitHubSession('any', { silent: true });
-			if (!session) {
+			const token = await this.getToken();
+			if (!token) {
 				this.logService.warn('[AgentMemoryService] No GitHub session available for fetching memory prompt');
 				return undefined;
 			}
 
-			const username = session.account.label;
-			const capiBase = this.capiClientService.capiPingURL.replace(/\/_ping$/, '');
-
-			const params = new URLSearchParams({ user: username });
+			// Use repo-scoped options when a repoNwo is available, otherwise user-scoped
+			let options: MemoryApiOptions;
 			if (repoNwo) {
-				params.set('repo', repoNwo);
-			}
-			const url = `${capiBase}/agents/swe/internal/memory/v0/prompt?${params.toString()}`;
-
-			const response = await fetch(url, {
-				method: 'GET',
-				headers: {
-					'Authorization': `Bearer ${session.accessToken}`,
-					'X-GitHub-Api-Version': '2025-10-01',
-				},
-			});
-
-			if (!response.ok) {
-				this.logService.warn(`[AgentMemoryService] Failed to fetch memory prompt: ${response.statusText}`);
-				return undefined;
-			}
-
-			const data = await response.json() as { prompt?: string };
-			if (typeof data?.prompt !== 'string') {
-				this.logService.warn('[AgentMemoryService] Unexpected response shape from /prompt endpoint');
-				return undefined;
+				const [owner, repo] = repoNwo.split('/');
+				options = {
+					scope: 'repository',
+					owner,
+					repo,
+					token,
+					integrationId: INTEGRATION_ID,
+					baseUrl: this.getBaseUrl(),
+					logger: this.makeLogger(),
+				};
+			} else {
+				options = {
+					scope: 'user',
+					token,
+					integrationId: INTEGRATION_ID,
+					baseUrl: this.getBaseUrl(),
+					logger: this.makeLogger(),
+				};
 			}
 
-			this.logService.info(`[AgentMemoryService] Fetched unified memory prompt (${data.prompt.length} chars)`);
-			return { prompt: data.prompt };
+			const response = await fetchMemoryPrompts(options);
+			if (response) {
+				this.logService.info(`[AgentMemoryService] Fetched memory prompt (${response.memoriesContext.memoriesCount} memories)`);
+			}
+			return response;
 		} catch (error) {
 			this.logService.warn(`[AgentMemoryService] Failed to fetch memory prompt: ${error}`);
 			return undefined;

--- a/src/extension/tools/common/test/agentMemoryService.spec.ts
+++ b/src/extension/tools/common/test/agentMemoryService.spec.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, it } from 'vitest';
-import { isRepoMemoryEntry, normalizeCitations } from '../agentMemoryService';
+import { isRepoMemoryEntry, normalizeCitations, type MemoryPromptResponse, type UserMemoryEntry } from '../agentMemoryService';
 
 describe('AgentMemoryService', () => {
 	describe('isRepoMemoryEntry', () => {
@@ -124,6 +124,61 @@ describe('AgentMemoryService', () => {
 		it('should handle empty string', () => {
 			const result = normalizeCitations('');
 			expect(result).toEqual([]);
+		});
+	});
+
+	describe('UserMemoryEntry', () => {
+		it('should accept entry with required fields only', () => {
+			const entry: UserMemoryEntry = {
+				subject: 'preferences',
+				fact: 'Prefer tabs over spaces',
+			};
+			expect(entry.subject).toBe('preferences');
+			expect(entry.fact).toBe('Prefer tabs over spaces');
+			expect(entry.citations).toBeUndefined();
+			expect(entry.reason).toBeUndefined();
+		});
+
+		it('should accept entry with all optional fields', () => {
+			const entry: UserMemoryEntry = {
+				subject: 'preferences',
+				fact: 'Prefer tabs over spaces',
+				citations: ['src/editorconfig:1'],
+				reason: 'User stated this during onboarding',
+			};
+			expect(entry.citations).toEqual(['src/editorconfig:1']);
+			expect(entry.reason).toBe('User stated this during onboarding');
+		});
+
+		it('should accept string citations for backward compatibility', () => {
+			const entry: UserMemoryEntry = {
+				subject: 'preferences',
+				fact: 'Prefer tabs over spaces',
+				citations: 'src/editorconfig:1, src/other.ts:5',
+			};
+			expect(typeof entry.citations).toBe('string');
+		});
+
+		it('should not include category field (user memories have no category)', () => {
+			const entry: UserMemoryEntry = {
+				subject: 'preferences',
+				fact: 'Prefer tabs over spaces',
+			};
+			expect('category' in entry).toBe(false);
+		});
+	});
+
+	describe('MemoryPromptResponse', () => {
+		it('should hold a prompt string', () => {
+			const response: MemoryPromptResponse = {
+				prompt: 'The following are repository memories for owner/repo...',
+			};
+			expect(response.prompt).toBe('The following are repository memories for owner/repo...');
+		});
+
+		it('should accept an empty prompt string', () => {
+			const response: MemoryPromptResponse = { prompt: '' };
+			expect(response.prompt).toBe('');
 		});
 	});
 });

--- a/src/extension/tools/common/test/agentMemoryService.spec.ts
+++ b/src/extension/tools/common/test/agentMemoryService.spec.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, it } from 'vitest';
-import { isRepoMemoryEntry, normalizeCitations, type MemoryPromptResponse, type UserMemoryEntry } from '../agentMemoryService';
+import type { MemoryPromptResponse } from '@github/copilot-agentic-tools/memory';
+import { isRepoMemoryEntry, normalizeCitations } from '../agentMemoryService';
 
 describe('AgentMemoryService', () => {
 	describe('isRepoMemoryEntry', () => {
@@ -127,58 +128,28 @@ describe('AgentMemoryService', () => {
 		});
 	});
 
-	describe('UserMemoryEntry', () => {
-		it('should accept entry with required fields only', () => {
-			const entry: UserMemoryEntry = {
-				subject: 'preferences',
-				fact: 'Prefer tabs over spaces',
-			};
-			expect(entry.subject).toBe('preferences');
-			expect(entry.fact).toBe('Prefer tabs over spaces');
-			expect(entry.citations).toBeUndefined();
-			expect(entry.reason).toBeUndefined();
-		});
-
-		it('should accept entry with all optional fields', () => {
-			const entry: UserMemoryEntry = {
-				subject: 'preferences',
-				fact: 'Prefer tabs over spaces',
-				citations: ['src/editorconfig:1'],
-				reason: 'User stated this during onboarding',
-			};
-			expect(entry.citations).toEqual(['src/editorconfig:1']);
-			expect(entry.reason).toBe('User stated this during onboarding');
-		});
-
-		it('should accept string citations for backward compatibility', () => {
-			const entry: UserMemoryEntry = {
-				subject: 'preferences',
-				fact: 'Prefer tabs over spaces',
-				citations: 'src/editorconfig:1, src/other.ts:5',
-			};
-			expect(typeof entry.citations).toBe('string');
-		});
-
-		it('should not include category field (user memories have no category)', () => {
-			const entry: UserMemoryEntry = {
-				subject: 'preferences',
-				fact: 'Prefer tabs over spaces',
-			};
-			expect('category' in entry).toBe(false);
-		});
-	});
-
 	describe('MemoryPromptResponse', () => {
-		it('should hold a prompt string', () => {
+		it('should hold memoriesContext and storeInstructions', () => {
 			const response: MemoryPromptResponse = {
-				prompt: 'The following are repository memories for owner/repo...',
+				storeInstructions: { prompt: 'Store instructions here.', promptVersion: '1.0.0' },
+				memoriesContext: { prompt: 'The following are repository memories...', promptVersion: '1.0.0', memoriesCount: 3 },
+				toolDefinition: { name: 'store_memory', description: 'Store a memory.', definitionVersion: '1.0.0' },
 			};
-			expect(response.prompt).toBe('The following are repository memories for owner/repo...');
+			expect(response.memoriesContext.prompt).toBe('The following are repository memories...');
+			expect(response.memoriesContext.memoriesCount).toBe(3);
+			expect(response.storeInstructions.promptVersion).toBe('1.0.0');
 		});
 
-		it('should accept an empty prompt string', () => {
-			const response: MemoryPromptResponse = { prompt: '' };
-			expect(response.prompt).toBe('');
+		it('should optionally include storeToolDefinition and voteToolDefinition', () => {
+			const response: MemoryPromptResponse = {
+				storeInstructions: { prompt: '', promptVersion: '1.1.0' },
+				memoriesContext: { prompt: '', promptVersion: '1.0.0', memoriesCount: 0 },
+				toolDefinition: { name: 'store_memory', description: 'Store a memory.', definitionVersion: '1.1.0' },
+				storeToolDefinition: { name: 'store_memory', description: 'Store a memory.', definitionVersion: '1.1.0' },
+				voteToolDefinition: { name: 'vote_memory', description: 'Vote on a memory.', definitionVersion: '1.0.0' },
+			};
+			expect(response.storeToolDefinition?.definitionVersion).toBe('1.1.0');
+			expect(response.voteToolDefinition?.name).toBe('vote_memory');
 		});
 	});
 });

--- a/src/extension/tools/node/agentMemoryToolRegistrar.ts
+++ b/src/extension/tools/node/agentMemoryToolRegistrar.ts
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
+import { getGithubRepoIdFromFetchUrl, getOrderedRemoteUrlsFromContext, IGitService, toGithubNwo } from '../../../platform/git/common/gitService';
+import { ILogService } from '../../../platform/log/common/logService';
+import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
+import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
+import { createServiceIdentifier } from '../../../util/common/services';
+import { DisposableStore } from '../../../util/vs/base/common/lifecycle';
+import { IAgentMemoryService } from '../common/agentMemoryService';
+import { ToolRegistry } from '../common/toolsRegistry';
+import { buildStoreMemoryToolDefinition, StoreMemoryTool } from './storeMemoryTool';
+import { buildVoteMemoryToolDefinition, VoteMemoryTool } from './voteMemoryTool';
+
+export interface IAgentMemoryToolRegistrar {
+	readonly _serviceBrand: undefined;
+	/**
+	 * Fetch the /prompt response and register store_memory (and optionally vote_memory)
+	 * as model-specific tools. Safe to call multiple times — re-registers on each call
+	 * to pick up updated tool definitions from the server.
+	 */
+	registerMemoryTools(): Promise<void>;
+}
+
+export const IAgentMemoryToolRegistrar = createServiceIdentifier<IAgentMemoryToolRegistrar>('IAgentMemoryToolRegistrar');
+
+export class AgentMemoryToolRegistrar implements IAgentMemoryToolRegistrar {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _registrations = new DisposableStore();
+
+	constructor(
+		@IAgentMemoryService private readonly agentMemoryService: IAgentMemoryService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IExperimentationService private readonly experimentationService: IExperimentationService,
+		@IGitService private readonly gitService: IGitService,
+		@IWorkspaceService private readonly workspaceService: IWorkspaceService,
+		@ILogService private readonly logService: ILogService,
+	) { }
+
+	private async getRepoNwo(): Promise<string | undefined> {
+		try {
+			const workspaceFolders = this.workspaceService.getWorkspaceFolders();
+			if (!workspaceFolders || workspaceFolders.length === 0) {
+				return undefined;
+			}
+			const repo = await this.gitService.getRepository(workspaceFolders[0]);
+			if (!repo) {
+				return undefined;
+			}
+			for (const remoteUrl of getOrderedRemoteUrlsFromContext(repo)) {
+				const repoId = getGithubRepoIdFromFetchUrl(remoteUrl);
+				if (repoId) {
+					return toGithubNwo(repoId);
+				}
+			}
+			return undefined;
+		} catch {
+			return undefined;
+		}
+	}
+
+	async registerMemoryTools(): Promise<void> {
+		const enabled = this.configurationService.getExperimentBasedConfig(ConfigKey.CopilotMemoryEnabled, this.experimentationService);
+		if (!enabled) {
+			return;
+		}
+
+		const repoNwo = await this.getRepoNwo();
+		const promptResponse = await this.agentMemoryService.getMemoryPrompt(repoNwo);
+		if (!promptResponse) {
+			this.logService.warn('[AgentMemoryToolRegistrar] Could not fetch memory prompt — skipping tool registration');
+			return;
+		}
+
+		// Dispose any previously registered memory tools before re-registering
+		this._registrations.clear();
+
+		// Use storeToolDefinition if present (version >= 1.1.0 includes scope param),
+		// fall back to the legacy toolDefinition for older servers.
+		const storeToolDef = promptResponse.storeToolDefinition ?? promptResponse.toolDefinition;
+		const storeDefinition = buildStoreMemoryToolDefinition(
+			storeToolDef.name,
+			storeToolDef.description,
+			storeToolDef.definitionVersion,
+		);
+		this._registrations.add(ToolRegistry.registerModelSpecificTool(storeDefinition, StoreMemoryTool));
+		this.logService.info(`[AgentMemoryToolRegistrar] Registered store_memory tool (schema v${storeToolDef.definitionVersion})`);
+
+		// vote_memory is only registered when the server returns voteToolDefinition
+		if (promptResponse.voteToolDefinition) {
+			const { name, description } = promptResponse.voteToolDefinition;
+			const voteDefinition = buildVoteMemoryToolDefinition(name, description);
+			this._registrations.add(ToolRegistry.registerModelSpecificTool(voteDefinition, VoteMemoryTool));
+			this.logService.info('[AgentMemoryToolRegistrar] Registered vote_memory tool');
+		}
+	}
+
+	dispose(): void {
+		this._registrations.dispose();
+	}
+}

--- a/src/extension/tools/node/memoryContextPrompt.tsx
+++ b/src/extension/tools/node/memoryContextPrompt.tsx
@@ -8,8 +8,10 @@ import { ConfigKey, IConfigurationService } from '../../../platform/configuratio
 import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
 import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
 import { FileType } from '../../../platform/filesystem/common/fileTypes';
+import { IGitService, getGithubRepoIdFromFetchUrl, getOrderedRemoteUrlsFromContext, toGithubNwo } from '../../../platform/git/common/gitService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
+import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
 import { URI } from '../../../util/vs/base/common/uri';
 import { Tag } from '../../prompts/node/base/tag';
 import { IAgentMemoryService, normalizeCitations, RepoMemoryEntry } from '../common/agentMemoryService';
@@ -32,21 +34,57 @@ export class MemoryContextPrompt extends PromptElement<MemoryContextPromptProps>
 		@IVSCodeExtensionContext private readonly extensionContext: IVSCodeExtensionContext,
 		@IFileSystemService private readonly fileSystemService: IFileSystemService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@IGitService private readonly gitService: IGitService,
+		@IWorkspaceService private readonly workspaceService: IWorkspaceService,
 	) {
 		super(props);
+	}
+
+	private async getRepoNwo(): Promise<string | undefined> {
+		try {
+			const workspaceFolders = this.workspaceService.getWorkspaceFolders();
+			if (!workspaceFolders || workspaceFolders.length === 0) {
+				return undefined;
+			}
+			const repo = await this.gitService.getRepository(workspaceFolders[0]);
+			if (!repo) {
+				return undefined;
+			}
+			for (const remoteUrl of getOrderedRemoteUrlsFromContext(repo)) {
+				const repoId = getGithubRepoIdFromFetchUrl(remoteUrl);
+				if (repoId) {
+					return toGithubNwo(repoId);
+				}
+			}
+			return undefined;
+		} catch {
+			return undefined;
+		}
 	}
 
 	async render() {
 		const enableCopilotMemory = this.configurationService.getExperimentBasedConfig(ConfigKey.CopilotMemoryEnabled, this.experimentationService);
 		const enableMemoryTool = this.configurationService.getExperimentBasedConfig(ConfigKey.MemoryToolEnabled, this.experimentationService);
 
-		const userMemoryContent = enableMemoryTool ? await this.getUserMemoryContent() : undefined;
-		const sessionMemoryFiles = enableMemoryTool ? await this.getSessionMemoryFiles(this.props.sessionResource) : undefined;
-		const repoMemories = enableCopilotMemory ? await this.agentMemoryService.getRepoMemories() : undefined;
-		const localRepoMemoryFiles = (enableMemoryTool && !enableCopilotMemory) ? await this.getLocalRepoMemoryFiles() : undefined;
-
 		if (!enableMemoryTool && !enableCopilotMemory) {
 			return null;
+		}
+
+		const userMemoryContent = enableMemoryTool ? await this.getUserMemoryContent() : undefined;
+		const sessionMemoryFiles = enableMemoryTool ? await this.getSessionMemoryFiles(this.props.sessionResource) : undefined;
+		const localRepoMemoryFiles = (enableMemoryTool && !enableCopilotMemory) ? await this.getLocalRepoMemoryFiles() : undefined;
+
+		// When CAPI memory is enabled, fetch from the unified /prompt endpoint
+		let memoryPromptText: string | undefined;
+		let repoMemories: RepoMemoryEntry[] | undefined;
+		if (enableCopilotMemory) {
+			const repoNwo = await this.getRepoNwo();
+			const promptResponse = await this.agentMemoryService.getMemoryPrompt(repoNwo);
+			memoryPromptText = promptResponse?.prompt;
+			// Fall back to individual repo memories if /prompt endpoint is unavailable
+			if (!memoryPromptText) {
+				repoMemories = await this.agentMemoryService.getRepoMemories();
+			}
 		}
 
 		this._sendContextReadTelemetry(
@@ -84,7 +122,12 @@ export class MemoryContextPrompt extends PromptElement<MemoryContextPromptProps>
 						}
 					</Tag>
 				)}
-				{repoMemories && repoMemories.length > 0 && (
+				{memoryPromptText && (
+					<Tag name='memory_context'>
+						{memoryPromptText}
+					</Tag>
+				)}
+				{!memoryPromptText && repoMemories && repoMemories.length > 0 && (
 					<Tag name='repository_memories'>
 						The following are recent memories stored for this repository from previous agent interactions. These memories may contain useful context about the codebase conventions, patterns, and practices. However, be aware that memories might be obsolete or incorrect or may not apply to your current task. Use the citations provided to verify the accuracy of any relevant memory before relying on it.<br />
 						<br />

--- a/src/extension/tools/node/memoryContextPrompt.tsx
+++ b/src/extension/tools/node/memoryContextPrompt.tsx
@@ -14,8 +14,10 @@ import { ITelemetryService } from '../../../platform/telemetry/common/telemetry'
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
 import { URI } from '../../../util/vs/base/common/uri';
 import { Tag } from '../../prompts/node/base/tag';
-import { IAgentMemoryService, normalizeCitations, RepoMemoryEntry } from '../common/agentMemoryService';
+import type { MemoryResponse } from '@github/copilot-agentic-tools/memory';
+import { IAgentMemoryService } from '../common/agentMemoryService';
 import { ToolName } from '../common/toolNames';
+import { IAgentMemoryToolRegistrar } from './agentMemoryToolRegistrar';
 import { extractSessionId } from './memoryTool';
 
 const MEMORY_BASE_DIR = 'memory-tool/memories';
@@ -29,6 +31,7 @@ export class MemoryContextPrompt extends PromptElement<MemoryContextPromptProps>
 	constructor(
 		props: any,
 		@IAgentMemoryService private readonly agentMemoryService: IAgentMemoryService,
+		@IAgentMemoryToolRegistrar private readonly agentMemoryToolRegistrar: IAgentMemoryToolRegistrar,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IExperimentationService private readonly experimentationService: IExperimentationService,
 		@IVSCodeExtensionContext private readonly extensionContext: IVSCodeExtensionContext,
@@ -76,11 +79,16 @@ export class MemoryContextPrompt extends PromptElement<MemoryContextPromptProps>
 
 		// When CAPI memory is enabled, fetch from the unified /prompt endpoint
 		let memoryPromptText: string | undefined;
-		let repoMemories: RepoMemoryEntry[] | undefined;
+		let repoMemories: MemoryResponse[] | undefined;
 		if (enableCopilotMemory) {
 			const repoNwo = await this.getRepoNwo();
-			const promptResponse = await this.agentMemoryService.getMemoryPrompt(repoNwo);
-			memoryPromptText = promptResponse?.prompt;
+			// Fetch prompt and register tools in parallel — both depend on the same /prompt call
+			// but registerMemoryTools() makes its own call so they can run concurrently.
+			const [promptResponse] = await Promise.all([
+				this.agentMemoryService.getMemoryPrompt(repoNwo),
+				this.agentMemoryToolRegistrar.registerMemoryTools(),
+			]);
+			memoryPromptText = promptResponse?.memoriesContext.prompt;
 			// Fall back to individual repo memories if /prompt endpoint is unavailable
 			if (!memoryPromptText) {
 				repoMemories = await this.agentMemoryService.getRepoMemories();
@@ -240,16 +248,12 @@ export class MemoryContextPrompt extends PromptElement<MemoryContextPromptProps>
 		return files.length > 0 ? files : undefined;
 	}
 
-	private formatMemories(memories: RepoMemoryEntry[]): string {
+	private formatMemories(memories: MemoryResponse[]): string {
 		return memories.map(m => {
 			const lines = [`**${m.subject}**`, `- Fact: ${m.fact}`];
 
-			// Format citations (handle both string and string[] formats)
-			if (m.citations) {
-				const citationsArray = normalizeCitations(m.citations) ?? [];
-				if (citationsArray.length > 0) {
-					lines.push(`- Citations: ${citationsArray.join(', ')}`);
-				}
+			if (m.citations.length > 0) {
+				lines.push(`- Citations: ${m.citations.join(', ')}`);
 			}
 
 			// Include reason if present (from CAPI format)

--- a/src/extension/tools/node/memoryTool.tsx
+++ b/src/extension/tools/node/memoryTool.tsx
@@ -15,7 +15,7 @@ import { ITelemetryService } from '../../../platform/telemetry/common/telemetry'
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
 import { URI } from '../../../util/vs/base/common/uri';
 import { LanguageModelTextPart, LanguageModelToolResult, MarkdownString } from '../../../vscodeTypes';
-import { IAgentMemoryService, RepoMemoryEntry } from '../common/agentMemoryService';
+import { IAgentMemoryService, RepoMemoryEntry, UserMemoryEntry } from '../common/agentMemoryService';
 import { IMemoryCleanupService } from '../common/memoryCleanupService';
 import { ToolName } from '../common/toolNames';
 import { ICopilotTool, ToolRegistry } from '../common/toolsRegistry';
@@ -285,10 +285,23 @@ export class MemoryTool implements ICopilotTool<MemoryToolParams> {
 		}
 
 		// Route /memories/session/* to session-scoped local storage
-		// Everything else under /memories/* goes to user-scoped storage
-		const scope: MemoryScope = isSessionPath(path) ? 'session' : 'user';
-		const result = await this._dispatchLocal(params, scope, sessionResource);
-		this._sendLocalTelemetry(params.command, scope, result.outcome, requestId, model);
+		if (isSessionPath(path)) {
+			const result = await this._dispatchLocal(params, 'session', sessionResource);
+			this._sendLocalTelemetry(params.command, 'session', result.outcome, requestId, model);
+			return result.text;
+		}
+
+		// Route user-scope creates through CAPI when enabled
+		const capiEnabled = await this.agentMemoryService.checkMemoryEnabled();
+		if (capiEnabled && params.command === 'create') {
+			const result = await this._userCreate(params as ICreateParams);
+			this._sendLocalTelemetry(params.command, 'user', result.outcome, requestId, model);
+			return result.text;
+		}
+
+		// Fall back to local file-based user memory
+		const result = await this._dispatchLocal(params, 'user', sessionResource);
+		this._sendLocalTelemetry(params.command, 'user', result.outcome, requestId, model);
 		return result.text;
 	}
 
@@ -339,6 +352,41 @@ export class MemoryTool implements ICopilotTool<MemoryToolParams> {
 		} catch (error) {
 			this.logService.error('[MemoryTool] Error creating repo memory:', error);
 			return { text: `Error: Cannot create repository memory: ${error.message}`, outcome: 'error' };
+		}
+	}
+
+	private async _userCreate(params: ICreateParams): Promise<MemoryToolResult> {
+		try {
+			const filename = params.path.split('/').pop() || 'memory';
+			const pathHint = filename.replace(/\.\w+$/, '');
+
+			let entry: UserMemoryEntry;
+			try {
+				const parsed = JSON.parse(params.file_text);
+				entry = {
+					subject: parsed.subject || pathHint,
+					fact: parsed.fact || '',
+					citations: parsed.citations || '',
+					reason: parsed.reason || '',
+				};
+			} catch {
+				entry = {
+					subject: pathHint,
+					fact: params.file_text,
+					citations: '',
+					reason: 'Stored from memory tool create command.',
+				};
+			}
+
+			const success = await this.agentMemoryService.storeUserMemory(entry);
+			if (success) {
+				return { text: `File created successfully at: ${params.path}`, outcome: 'success' };
+			} else {
+				return { text: 'Error: Failed to store user memory entry.', outcome: 'error' };
+			}
+		} catch (error) {
+			this.logService.error('[MemoryTool] Error creating user memory:', error);
+			return { text: `Error: Cannot create user memory: ${error.message}`, outcome: 'error' };
 		}
 	}
 

--- a/src/extension/tools/node/memoryTool.tsx
+++ b/src/extension/tools/node/memoryTool.tsx
@@ -15,7 +15,8 @@ import { ITelemetryService } from '../../../platform/telemetry/common/telemetry'
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
 import { URI } from '../../../util/vs/base/common/uri';
 import { LanguageModelTextPart, LanguageModelToolResult, MarkdownString } from '../../../vscodeTypes';
-import { IAgentMemoryService, RepoMemoryEntry, UserMemoryEntry } from '../common/agentMemoryService';
+import type { StoreMemoryRequest } from '@github/copilot-agentic-tools/memory';
+import { IAgentMemoryService } from '../common/agentMemoryService';
 import { IMemoryCleanupService } from '../common/memoryCleanupService';
 import { ToolName } from '../common/toolNames';
 import { ICopilotTool, ToolRegistry } from '../common/toolsRegistry';
@@ -322,24 +323,28 @@ export class MemoryTool implements ICopilotTool<MemoryToolParams> {
 
 			// Parse the file_text as a memory entry.
 			// Accept either a JSON-formatted entry or a plain text fact.
-			let entry: RepoMemoryEntry;
+			let entry: StoreMemoryRequest;
 			try {
 				const parsed = JSON.parse(params.file_text);
+				const rawCitations = parsed.citations;
+				const citations: string[] = Array.isArray(rawCitations)
+					? rawCitations
+					: typeof rawCitations === 'string' && rawCitations.length > 0
+						? rawCitations.split(',').map((c: string) => c.trim()).filter((c: string) => c.length > 0)
+						: [];
 				entry = {
 					subject: parsed.subject || pathHint,
 					fact: parsed.fact || '',
-					citations: parsed.citations || '',
+					citations,
 					reason: parsed.reason || '',
-					category: parsed.category || pathHint,
 				};
 			} catch {
 				// Plain text: treat the whole content as a fact, use path as subject
 				entry = {
 					subject: pathHint,
 					fact: params.file_text,
-					citations: '',
+					citations: [],
 					reason: 'Stored from memory tool create command.',
-					category: pathHint,
 				};
 			}
 
@@ -360,20 +365,26 @@ export class MemoryTool implements ICopilotTool<MemoryToolParams> {
 			const filename = params.path.split('/').pop() || 'memory';
 			const pathHint = filename.replace(/\.\w+$/, '');
 
-			let entry: UserMemoryEntry;
+			let entry: StoreMemoryRequest;
 			try {
 				const parsed = JSON.parse(params.file_text);
+				const rawCitations = parsed.citations;
+				const citations: string[] = Array.isArray(rawCitations)
+					? rawCitations
+					: typeof rawCitations === 'string' && rawCitations.length > 0
+						? rawCitations.split(',').map((c: string) => c.trim()).filter((c: string) => c.length > 0)
+						: [];
 				entry = {
 					subject: parsed.subject || pathHint,
 					fact: parsed.fact || '',
-					citations: parsed.citations || '',
+					citations,
 					reason: parsed.reason || '',
 				};
 			} catch {
 				entry = {
 					subject: pathHint,
 					fact: params.file_text,
-					citations: '',
+					citations: [],
 					reason: 'Stored from memory tool create command.',
 				};
 			}

--- a/src/extension/tools/node/storeMemoryTool.tsx
+++ b/src/extension/tools/node/storeMemoryTool.tsx
@@ -1,0 +1,143 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as vscode from 'vscode';
+import {
+	resolveStoreMemorySchema,
+	type ScopedStoreMemoryInput,
+	type StoreMemoryInput,
+	type StoreMemoryRequest,
+} from '@github/copilot-agentic-tools/memory';
+import { ILogService } from '../../../platform/log/common/logService';
+import { CancellationToken } from '../../../util/vs/base/common/cancellation';
+import { LanguageModelTextPart, LanguageModelToolResult } from '../../../vscodeTypes';
+import { IAgentMemoryService } from '../common/agentMemoryService';
+import { ICopilotModelSpecificTool } from '../common/toolsRegistry';
+
+type StoreMemoryParams = StoreMemoryInput | ScopedStoreMemoryInput;
+
+/**
+ * Implements the store_memory tool using @github/copilot-agentic-tools/memory.
+ * The tool definition (description, schema) is dynamically built from the /prompt
+ * response and registered via AgentMemoryToolRegistrar.
+ */
+export class StoreMemoryTool implements ICopilotModelSpecificTool<StoreMemoryParams> {
+	constructor(
+		@IAgentMemoryService private readonly agentMemoryService: IAgentMemoryService,
+		@ILogService private readonly logService: ILogService,
+	) { }
+
+	async invoke(options: vscode.LanguageModelToolInvocationOptions<StoreMemoryParams>, _token: CancellationToken): Promise<vscode.LanguageModelToolResult> {
+		const input = options.input;
+
+		try {
+			const memory: StoreMemoryRequest = {
+				subject: input.subject,
+				fact: input.fact,
+				citations: input.citations,
+				reason: input.reason,
+			};
+
+			// Route by scope if provided, otherwise default to repo
+			const scope = 'scope' in input ? input.scope : 'repo';
+			let success: boolean;
+			if (scope === 'user') {
+				success = await this.agentMemoryService.storeUserMemory(memory);
+			} else {
+				success = await this.agentMemoryService.storeRepoMemory(memory);
+			}
+
+			if (success) {
+				this.logService.info(`[StoreMemoryTool] Stored memory: ${input.subject}`);
+				return new LanguageModelToolResult([new LanguageModelTextPart('Memory stored successfully.')]);
+			} else {
+				return new LanguageModelToolResult([new LanguageModelTextPart('Failed to store memory. Copilot Memory may not be enabled for this repository.')]);
+			}
+		} catch (error) {
+			this.logService.error('[StoreMemoryTool] Error storing memory:', error);
+			return new LanguageModelToolResult([new LanguageModelTextPart(`Error storing memory: ${error}`)]);
+		}
+	}
+}
+
+/**
+ * Build the vscode.LanguageModelToolDefinition for store_memory from the tool
+ * definition version returned by the /prompt endpoint.
+ */
+export function buildStoreMemoryToolDefinition(
+	name: string,
+	description: string,
+	definitionVersion: string,
+): vscode.LanguageModelToolDefinition {
+	const schema = resolveStoreMemorySchema(definitionVersion);
+	const jsonSchema = zodSchemaToJsonSchema(schema);
+
+	return {
+		name,
+		displayName: 'Store Memory',
+		description,
+		tags: [],
+		source: undefined,
+		inputSchema: jsonSchema,
+	};
+}
+
+/**
+ * Minimal zod-to-JSON-schema converter for the known store_memory schemas.
+ * Only handles the object shapes produced by storeMemoryInputSchema and
+ * scopedStoreMemoryInputSchema from @github/copilot-agentic-tools/memory.
+ */
+function zodSchemaToJsonSchema(schema: ReturnType<typeof resolveStoreMemorySchema>): object {
+	// Both schemas share the same 4 base fields; scoped adds 'scope'
+	const baseProperties: Record<string, object> = {
+		subject: {
+			type: 'string',
+			// eslint-disable-next-line local/no-unexternalized-strings
+			description: "The topic to which this memory relates. 1-2 words. Examples: 'naming conventions', 'testing practices', 'documentation', 'logging', 'authentication', 'sanitization', 'error handling'.",
+		},
+		fact: {
+			type: 'string',
+			// eslint-disable-next-line local/no-unexternalized-strings
+			description: "A clear and short description of a fact about the codebase or a convention used in the codebase. Must be less than 200 characters.",
+		},
+		citations: {
+			type: 'array',
+			items: { type: 'string' },
+			// eslint-disable-next-line local/no-unexternalized-strings
+			description: "Sources of this fact, such as file and line numbers in the codebase (e.g., ['path/file.go:123', 'other/file.ts:45']).",
+		},
+		reason: {
+			type: 'string',
+			// eslint-disable-next-line local/no-unexternalized-strings
+			description: "A clear and detailed explanation of the reason behind storing this fact. Must be at least 2-3 sentences long.",
+		},
+	};
+
+	const required = ['subject', 'fact', 'citations', 'reason'];
+
+	// Check if this is the scoped schema by inspecting its shape keys
+	const shape = (schema as { shape?: Record<string, unknown> }).shape;
+	if (shape && 'scope' in shape) {
+		return {
+			type: 'object',
+			properties: {
+				...baseProperties,
+				scope: {
+					type: 'string',
+					enum: ['repo', 'user'],
+					// eslint-disable-next-line local/no-unexternalized-strings
+					description: "Scope of the memory to be stored, must be either 'repo' or 'user', depending on whether the memory is to be repo or user specific.",
+				},
+			},
+			required: [...required, 'scope'],
+		};
+	}
+
+	return {
+		type: 'object',
+		properties: baseProperties,
+		required,
+	};
+}

--- a/src/extension/tools/node/test/memoryTool.spec.tsx
+++ b/src/extension/tools/node/test/memoryTool.spec.tsx
@@ -17,7 +17,10 @@ import { SyncDescriptor } from '../../../../util/vs/platform/instantiation/commo
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { MarkdownString } from '../../../../vscodeTypes';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
-import { IAgentMemoryService, MemoryPromptResponse, RepoMemoryEntry, UserMemoryEntry } from '../../common/agentMemoryService';
+import type { MemoryPromptResponse, MemoryResponse, StoreMemoryRequest, VoteMemoryRequest } from '@github/copilot-agentic-tools/memory';
+import { IAgentMemoryService } from '../../common/agentMemoryService';
+
+type RepoMemoryEntry = MemoryResponse;
 import { MemoryTool } from '../memoryTool';
 
 /**
@@ -45,7 +48,7 @@ class MockCapturingTelemetryService extends NullTelemetryService {
 class MockAgentMemoryService implements IAgentMemoryService {
 	declare readonly _serviceBrand: undefined;
 	storedMemories: RepoMemoryEntry[] = [];
-	storedUserMemories: UserMemoryEntry[] = [];
+	storedUserMemories: StoreMemoryRequest[] = [];
 
 	async checkMemoryEnabled(): Promise<boolean> {
 		return true;
@@ -55,13 +58,17 @@ class MockAgentMemoryService implements IAgentMemoryService {
 		return this.storedMemories;
 	}
 
-	async storeRepoMemory(memory: RepoMemoryEntry): Promise<boolean> {
-		this.storedMemories.push(memory);
+	async storeRepoMemory(memory: StoreMemoryRequest): Promise<boolean> {
+		this.storedMemories.push({ ...memory, citations: memory.citations ?? [] });
 		return true;
 	}
 
-	async storeUserMemory(memory: UserMemoryEntry): Promise<boolean> {
+	async storeUserMemory(memory: StoreMemoryRequest): Promise<boolean> {
 		this.storedUserMemories.push(memory);
+		return true;
+	}
+
+	async voteOnMemory(_vote: VoteMemoryRequest, _scope: 'repository' | 'user'): Promise<boolean> {
 		return true;
 	}
 
@@ -89,11 +96,15 @@ class DisabledMockAgentMemoryService implements IAgentMemoryService {
 		return undefined;
 	}
 
-	async storeRepoMemory(_memory: RepoMemoryEntry): Promise<boolean> {
+	async storeRepoMemory(_memory: StoreMemoryRequest): Promise<boolean> {
 		return false;
 	}
 
-	async storeUserMemory(_memory: UserMemoryEntry): Promise<boolean> {
+	async storeUserMemory(_memory: StoreMemoryRequest): Promise<boolean> {
+		return false;
+	}
+
+	async voteOnMemory(_vote: VoteMemoryRequest, _scope: 'repository' | 'user'): Promise<boolean> {
 		return false;
 	}
 

--- a/src/extension/tools/node/test/memoryTool.spec.tsx
+++ b/src/extension/tools/node/test/memoryTool.spec.tsx
@@ -17,7 +17,7 @@ import { SyncDescriptor } from '../../../../util/vs/platform/instantiation/commo
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { MarkdownString } from '../../../../vscodeTypes';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
-import { IAgentMemoryService, RepoMemoryEntry } from '../../common/agentMemoryService';
+import { IAgentMemoryService, MemoryPromptResponse, RepoMemoryEntry, UserMemoryEntry } from '../../common/agentMemoryService';
 import { MemoryTool } from '../memoryTool';
 
 /**
@@ -45,6 +45,7 @@ class MockCapturingTelemetryService extends NullTelemetryService {
 class MockAgentMemoryService implements IAgentMemoryService {
 	declare readonly _serviceBrand: undefined;
 	storedMemories: RepoMemoryEntry[] = [];
+	storedUserMemories: UserMemoryEntry[] = [];
 
 	async checkMemoryEnabled(): Promise<boolean> {
 		return true;
@@ -59,8 +60,18 @@ class MockAgentMemoryService implements IAgentMemoryService {
 		return true;
 	}
 
+	async storeUserMemory(memory: UserMemoryEntry): Promise<boolean> {
+		this.storedUserMemories.push(memory);
+		return true;
+	}
+
+	async getMemoryPrompt(_repoNwo?: string): Promise<MemoryPromptResponse | undefined> {
+		return undefined;
+	}
+
 	clearMemories(): void {
 		this.storedMemories = [];
+		this.storedUserMemories = [];
 	}
 }
 
@@ -80,6 +91,14 @@ class DisabledMockAgentMemoryService implements IAgentMemoryService {
 
 	async storeRepoMemory(_memory: RepoMemoryEntry): Promise<boolean> {
 		return false;
+	}
+
+	async storeUserMemory(_memory: UserMemoryEntry): Promise<boolean> {
+		return false;
+	}
+
+	async getMemoryPrompt(_repoNwo?: string): Promise<MemoryPromptResponse | undefined> {
+		return undefined;
 	}
 }
 

--- a/src/extension/tools/node/voteMemoryTool.tsx
+++ b/src/extension/tools/node/voteMemoryTool.tsx
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as vscode from 'vscode';
+import type { VoteMemoryInput } from '@github/copilot-agentic-tools/memory';
+import { ILogService } from '../../../platform/log/common/logService';
+import { CancellationToken } from '../../../util/vs/base/common/cancellation';
+import { LanguageModelTextPart, LanguageModelToolResult } from '../../../vscodeTypes';
+import { IAgentMemoryService } from '../common/agentMemoryService';
+import { ICopilotModelSpecificTool } from '../common/toolsRegistry';
+
+/**
+ * Implements the vote_memory tool using @github/copilot-agentic-tools/memory.
+ * Only registered when voteToolDefinition is present in the /prompt response.
+ */
+export class VoteMemoryTool implements ICopilotModelSpecificTool<VoteMemoryInput> {
+	constructor(
+		@IAgentMemoryService private readonly agentMemoryService: IAgentMemoryService,
+		@ILogService private readonly logService: ILogService,
+	) { }
+
+	async invoke(options: vscode.LanguageModelToolInvocationOptions<VoteMemoryInput>, _token: CancellationToken): Promise<vscode.LanguageModelToolResult> {
+		const { fact, direction, reason } = options.input;
+
+		try {
+			// Vote on both scopes; the service will route to the right endpoint
+			const success = await this.agentMemoryService.voteOnMemory({ fact, direction, reason }, 'repository');
+
+			if (success) {
+				this.logService.info(`[VoteMemoryTool] Recorded ${direction} for memory fact`);
+				return new LanguageModelToolResult([new LanguageModelTextPart(`Vote (${direction}) recorded successfully.`)]);
+			} else {
+				return new LanguageModelToolResult([new LanguageModelTextPart('Failed to record vote. Copilot Memory may not be enabled.')]);
+			}
+		} catch (error) {
+			this.logService.error('[VoteMemoryTool] Error voting on memory:', error);
+			return new LanguageModelToolResult([new LanguageModelTextPart(`Error voting on memory: ${error}`)]);
+		}
+	}
+}
+
+/**
+ * Build the vscode.LanguageModelToolDefinition for vote_memory from the tool
+ * definition returned by the /prompt endpoint.
+ */
+export function buildVoteMemoryToolDefinition(
+	name: string,
+	description: string,
+): vscode.LanguageModelToolDefinition {
+	return {
+		name,
+		displayName: 'Vote on Memory',
+		description,
+		tags: [],
+		source: undefined,
+		inputSchema: {
+			type: 'object',
+			properties: {
+				fact: {
+					type: 'string',
+					// eslint-disable-next-line local/no-unexternalized-strings
+					description: "The exact text of the 'fact' field from the original memory. Must match the string exactly as it appears in the prompt.",
+				},
+				direction: {
+					type: 'string',
+					enum: ['upvote', 'downvote'],
+					// eslint-disable-next-line local/no-unexternalized-strings
+					description: "Vote direction: 'upvote' for useful verified memories, 'downvote' for incorrect or outdated memories.",
+				},
+				reason: {
+					type: 'string',
+					description: 'A clear and detailed explanation of the reason for your vote. Must be at least 2-3 sentences long.',
+				},
+			},
+			required: ['fact', 'direction', 'reason'],
+		},
+	};
+}


### PR DESCRIPTION
## Summary

Adds support for user-scoped memories in VSCode Copilot Chat, covering both the store and retrieve paths.

- **Store**: When Copilot Memory is enabled, user-scope memory writes (`/memories/`) are routed to the sweagentd API (`PUT /agents/swe/internal/memory/v0/users/{username}`) instead of local file storage
- **Retrieve**: Migrates from hardcoded client-side prompt construction to a unified `GET /memory/v0/prompt?user={username}&repo={nwo}` endpoint that returns combined repo and user memory context in a single response. Falls back to the existing `getRepoMemories()` path if the endpoint is unavailable.

## Changes

- `agentMemoryService.ts` — adds `UserMemoryEntry` and `MemoryPromptResponse` types; adds `storeUserMemory()` and `getMemoryPrompt()` to `IAgentMemoryService` and `AgentMemoryService`
- `memoryTool.tsx` — routes user-scope `create` commands through CAPI when enabled via new `_userCreate()` method
- `memoryContextPrompt.tsx` — fetches unified memory prompt from the backend and injects it as-is rather than constructing it client-side; injects `IGitService` and `IWorkspaceService` to resolve the repo NWO
- Tests updated to cover new interface methods and types