### PR TITLE
Remove default truncation of otel trace and make it configurable via env vars

### DIFF
--- a/src/platform/otel/common/genAiEvents.ts
+++ b/src/platform/otel/common/genAiEvents.ts
@@ -51,7 +51,7 @@ export function emitInferenceDetailsEvent(
 		attributes[StdAttr.ERROR_TYPE] = error.type;
 	}
 
-	// Full content capture with truncation to prevent OTLP batch failures
+	// Full content capture (truncation only if COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH is set)
 	if (otel.config.captureContent) {
 		if (request.messages !== undefined) {
 			attributes[GenAiAttr.INPUT_MESSAGES] = truncateForOTel(JSON.stringify(request.messages));

--- a/src/platform/otel/common/messageFormatters.ts
+++ b/src/platform/otel/common/messageFormatters.ts
@@ -10,22 +10,30 @@
  */
 
 /**
- * Maximum size (in characters) for a single OTel span/log attribute value.
- * Aligned with common backend limits (Jaeger 64KB, Tempo 100KB).
- * Matches gemini-cli's approach of capping content to prevent OTLP batch failures.
- */
-const MAX_OTEL_ATTRIBUTE_LENGTH = 64_000;
-
-/**
  * Truncate a string to fit within OTel attribute size limits.
- * Returns the original string if within bounds, otherwise truncates with a suffix.
+ *
+ * By default no truncation is applied, so observability platforms such as
+ * Langfuse receive complete, parseable data.  To re-enable truncation set the
+ * COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH environment variable to a positive integer
+ * (e.g. "64000").  An explicit `maxLength` argument always takes precedence
+ * over the environment variable.
  */
-export function truncateForOTel(value: string, maxLength: number = MAX_OTEL_ATTRIBUTE_LENGTH): string {
-	if (value.length <= maxLength) {
+export function truncateForOTel(value: string, maxLength?: number): string {
+	let limit = maxLength;
+	if (limit === undefined) {
+		const raw = typeof process !== 'undefined' ? process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'] : undefined;
+		if (raw) {
+			const n = parseInt(raw, 10);
+			if (Number.isFinite(n) && n > 0) {
+				limit = n;
+			}
+		}
+	}
+	if (limit === undefined || value.length <= limit) {
 		return value;
 	}
 	const suffix = `...[truncated, original ${value.length} chars]`;
-	return value.substring(0, maxLength - suffix.length) + suffix;
+	return value.substring(0, limit - suffix.length) + suffix;
 }
 
 export interface OTelChatMessage {

--- a/src/platform/otel/common/test/messageFormatters.spec.ts
+++ b/src/platform/otel/common/test/messageFormatters.spec.ts
@@ -183,22 +183,72 @@ describe('truncateForOTel', () => {
 		expect(truncateForOTel(s, 100)).toBe(s);
 	});
 
-	it('truncates strings over the limit with suffix', () => {
+	it('truncates strings over the explicit limit with suffix', () => {
 		const s = 'a'.repeat(200);
 		const result = truncateForOTel(s, 100);
 		expect(result.length).toBeLessThanOrEqual(100);
 		expect(result).toContain('...[truncated, original 200 chars]');
 	});
 
-	it('uses default 64000 limit', () => {
-		const s = 'x'.repeat(64_001);
-		const result = truncateForOTel(s);
-		expect(result.length).toBeLessThanOrEqual(64_000);
-		expect(result).toContain('...[truncated');
+	it('does not truncate by default (no env var set)', () => {
+		const saved = process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'];
+		delete process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'];
+		try {
+			const s = 'x'.repeat(100_000);
+			expect(truncateForOTel(s)).toBe(s);
+		} finally {
+			if (saved !== undefined) {
+				process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'] = saved;
+			}
+		}
 	});
 
-	it('does not truncate at exactly 64000', () => {
-		const s = 'x'.repeat(64_000);
-		expect(truncateForOTel(s)).toBe(s);
+	it('truncates when COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH env var is set', () => {
+		const saved = process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'];
+		process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'] = '64000';
+		try {
+			const s = 'x'.repeat(64_001);
+			const result = truncateForOTel(s);
+			expect(result.length).toBeLessThanOrEqual(64_000);
+			expect(result).toContain('...[truncated');
+		} finally {
+			if (saved !== undefined) {
+				process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'] = saved;
+			} else {
+				delete process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'];
+			}
+		}
+	});
+
+	it('ignores invalid COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH values', () => {
+		const saved = process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'];
+		process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'] = 'invalid';
+		try {
+			const s = 'x'.repeat(100_000);
+			expect(truncateForOTel(s)).toBe(s);
+		} finally {
+			if (saved !== undefined) {
+				process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'] = saved;
+			} else {
+				delete process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'];
+			}
+		}
+	});
+
+	it('explicit maxLength overrides env var', () => {
+		const saved = process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'];
+		process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'] = '64000';
+		try {
+			// explicit limit of 100 should override the env var
+			const s = 'a'.repeat(200);
+			const result = truncateForOTel(s, 100);
+			expect(result.length).toBeLessThanOrEqual(100);
+		} finally {
+			if (saved !== undefined) {
+				process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'] = saved;
+			} else {
+				delete process.env['COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH'];
+			}
+		}
 	});
 });


### PR DESCRIPTION
fix(otel): remove default truncation of trace attributes; make it configurable via env var

Previously truncateForOTel() silently capped every attribute at 64 000 characters, producing broken JSON that Langfuse and other observability platforms could not parse.

The new behaviour sends complete data by default.  Truncation can be re-enabled by setting COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH to a positive integer (e.g. export COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH=64000).

- Remove MAX_OTEL_ATTRIBUTE_LENGTH constant and the hardcoded 64 K default
- truncateForOTel() now reads COPILOT_OTEL_MAX_ATTRIBUTE_LENGTH at call time; an explicit maxLength argument still takes precedence
- Update tests: replace the "default 64000" assertions with no-truncation by default, and add coverage for the env-var path and invalid values
- Update stale comment in genAiEvents.ts

https://claude.ai/code/session_01WuZzmxwP2ycygD1kGjJWhV