### PR TITLE
Fix vscode-remote path corruption in PromptPathRepresentationService

### DIFF
--- a/src/platform/prompts/common/promptPathRepresentationService.ts
+++ b/src/platform/prompts/common/promptPathRepresentationService.ts
@@ -49,7 +49,12 @@ export class PromptPathRepresentationService implements IPromptPathRepresentatio
 	constructor(@IWorkspaceService private readonly workspaceService: IWorkspaceService) { }
 
 	getFilePath(uri: Uri): string {
-		if (uri.scheme === Schemas.file || uri.scheme === Schemas.vscodeRemote) {
+		if (uri.scheme === Schemas.vscodeRemote) {
+			// Use uri.path (always POSIX) instead of uri.fsPath which applies
+			// local OS separators — corrupting remote Linux paths on Windows.
+			return uri.path;
+		}
+		if (uri.scheme === Schemas.file) {
 			return uri.fsPath;
 		}
 		return uri.toString();
@@ -64,6 +69,14 @@ export class PromptPathRepresentationService implements IPromptPathRepresentatio
 	 * @returns The resolved URI or undefined if filepath does not look like a file path or URI.
 	 */
 	resolveFilePath(filepath: string, predominantScheme = Schemas.file): Uri | undefined {
+		// Match against workspace folders first — this preserves scheme and
+		// authority for remote workspaces where a plain path string cannot
+		// encode the full URI (e.g. vscode-remote://ssh-remote+host/...).
+		const folderMatch = this._matchWorkspaceFolder(filepath);
+		if (folderMatch) {
+			return folderMatch;
+		}
+
 		// Always check for posix-like absolute paths, and also for platform-like
 		// (i.e. Windows) absolute paths in case the model generates them.
 		const isPosixPath = filepath.startsWith('/');
@@ -100,6 +113,33 @@ export class PromptPathRepresentationService implements IPromptPathRepresentatio
 				return URI.parse(filepath);
 			} catch (e) {
 				return undefined;
+			}
+		}
+		return undefined;
+	}
+
+	/**
+	 * Matches a filepath string against known workspace folders and reconstructs
+	 * the full URI (preserving scheme and authority) from the folder.
+	 */
+	private _matchWorkspaceFolder(filepath: string): Uri | undefined {
+		for (const folder of this.workspaceService.getWorkspaceFolders()) {
+			const raw = this.getFilePath(folder);
+			// Normalize trailing separators so root folders (e.g. "/" or "C:\")
+			// match correctly — the separator check below needs folderPath to
+			// NOT end with a separator.
+			const folderPath = raw.length > 1 ? raw.replace(/[\/\\]+$/, '') : raw;
+			if (!filepath.startsWith(folderPath)) {
+				continue;
+			}
+			if (filepath.length === folderPath.length) {
+				return folder;
+			}
+			const sep = filepath[folderPath.length];
+			if (sep === '/' || sep === '\\') {
+				const relative = filepath.substring(folderPath.length + 1);
+				const segments = relative.split(/[\/\\]/).filter(Boolean);
+				return segments.length > 0 ? URI.joinPath(folder, ...segments) : folder;
 			}
 		}
 		return undefined;

--- a/src/platform/prompts/test/node/promptPathRepresentationService.spec.ts
+++ b/src/platform/prompts/test/node/promptPathRepresentationService.spec.ts
@@ -34,9 +34,9 @@ describe('PromptPathRepresentationService', () => {
 			expect(service.getFilePath(uri)).toBe(uri.fsPath);
 		});
 
-		it('returns fsPath for vscode-remote scheme URIs', () => {
+		it('returns posix path (uri.path) for vscode-remote scheme URIs', () => {
 			const uri = URI.from({ scheme: Schemas.vscodeRemote, path: '/home/user/project/file.ts', authority: 'ssh-remote+myhost' });
-			expect(service.getFilePath(uri)).toBe(uri.fsPath);
+			expect(service.getFilePath(uri)).toBe(uri.path);
 		});
 
 		it('returns toString for other schemes', () => {
@@ -103,6 +103,56 @@ describe('PromptPathRepresentationService', () => {
 			const resolved = service.resolveFilePath(filepath);
 			expect(resolved).toBeDefined();
 			expect(resolved!.path).toBe(original.path);
+		});
+
+		it('resolves vscode-remote paths back to vscode-remote URIs via workspace folder match', () => {
+			const folderUri = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project' });
+			workspaceService = new TestWorkspaceService([folderUri]);
+			service = new PromptPathRepresentationService(workspaceService);
+
+			const result = service.resolveFilePath('/home/user/project/src/file.ts');
+			expect(result).toBeDefined();
+			expect(result!.scheme).toBe(Schemas.vscodeRemote);
+			expect(result!.authority).toBe('ssh-remote+myhost');
+			expect(result!.path).toBe('/home/user/project/src/file.ts');
+		});
+
+		it('roundtrips vscode-remote URIs through getFilePath and resolveFilePath', () => {
+			const folderUri = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project' });
+			workspaceService = new TestWorkspaceService([folderUri]);
+			service = new PromptPathRepresentationService(workspaceService);
+
+			const original = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project/src/file.ts' });
+			const filepath = service.getFilePath(original);
+			const resolved = service.resolveFilePath(filepath);
+			expect(resolved).toBeDefined();
+			expect(resolved!.scheme).toBe(Schemas.vscodeRemote);
+			expect(resolved!.authority).toBe('ssh-remote+myhost');
+			expect(resolved!.path).toBe(original.path);
+		});
+
+		it('resolves vscode-remote workspace folder root path', () => {
+			const folderUri = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project' });
+			workspaceService = new TestWorkspaceService([folderUri]);
+			service = new PromptPathRepresentationService(workspaceService);
+
+			const result = service.resolveFilePath('/home/user/project');
+			expect(result).toBeDefined();
+			expect(result!.scheme).toBe(Schemas.vscodeRemote);
+			expect(result!.authority).toBe('ssh-remote+myhost');
+			expect(result!.path).toBe('/home/user/project');
+		});
+
+		it('matches correct folder in multi-root vscode-remote workspace', () => {
+			const folder1 = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project-a' });
+			const folder2 = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project-b' });
+			workspaceService = new TestWorkspaceService([folder1, folder2]);
+			service = new PromptPathRepresentationService(workspaceService);
+
+			const result = service.resolveFilePath('/home/user/project-b/src/main.ts');
+			expect(result).toBeDefined();
+			expect(result!.scheme).toBe(Schemas.vscodeRemote);
+			expect(result!.path).toBe('/home/user/project-b/src/main.ts');
 		});
 	});
 


### PR DESCRIPTION
## Problem

When a user configures `remote.extensionKind: { "GitHub.copilot-chat": ["ui"] }` to run Copilot Chat on the local (Windows) side while connected to a Remote-SSH (Linux) host, **all file-based tools fail** — `createFile`, `editFile`, `insertCodeToFile`, etc. produce incorrect paths and cannot resolve files.

This configuration is necessary for air-gapped or restricted-internet remote hosts where the extension cannot authenticate or reach GitHub APIs from the remote side.

### Root Cause: Two-defect round-trip corruption

**Defect 1 — `getFilePath()` corrupts remote paths:**  
Uses `uri.fsPath` for `vscode-remote` URIs. `fsPath` calls `uriToFsPath()` which converts `/` → `\` when `isWindows` is `true`. With `extensionKind: ["ui"]`, the extension process runs on the local Windows machine, so `isWindows = true` — and remote Linux paths like `/opt/app/file.ts` become `\opt\app\file.ts`.

**Defect 2 — `resolveFilePath()` loses scheme and authority:**  
Uses `URI.file()` to reconstruct URIs from path strings, which always produces `file://` scheme — losing the `vscode-remote` scheme and `ssh-remote+host` authority needed to reach the remote filesystem.

## Fix

Two targeted changes in `PromptPathRepresentationService`:

1. **`getFilePath()`**: Split `vscode-remote` into its own branch, returning `uri.path` (always POSIX per RFC 3986) instead of `uri.fsPath`.

2. **`resolveFilePath()`**: Add workspace folder prefix-matching at the top. When a filepath matches a known workspace folder's path, reconstruct the full URI via `URI.joinPath(folder, ...segments)`, preserving the original scheme and authority.

## Verification — 8-Scenario Matrix (Logic Trace)

All combinations of Local OS × Remote OS × extensionKind analyzed by tracing through `isWindows`, `uri.path`, `uri.fsPath`, and `uriToFsPath()` behavior:

| #     | Local OS    | Remote OS | extensionKind | `isWindows` | getFilePath output | resolveFilePath result              | Status    |
| ----- | ----------- | --------- | ------------- | ----------- | ------------------ | ----------------------------------- | --------- |
| 1     | Linux       | Linux     | workspace     | false       | `/opt/app/f.ts`    | ✅ file:// (exthost transforms)      | ✅         |
| 2     | Linux       | Linux     | ui            | false       | `/opt/app/f.ts`    | ✅ vscode-remote:// via folder match | ✅         |
| 3     | Linux       | Windows   | workspace     | true        | `/c:/Users/f.ts`   | ✅ file:// (exthost transforms)      | ✅         |
| 4     | Linux       | Windows   | ui            | false       | `/c:/Users/f.ts`   | ✅ vscode-remote:// via folder match | ✅         |
| 5     | Windows     | Linux     | workspace     | false       | `/opt/app/f.ts`    | ✅ file:// (exthost transforms)      | ✅         |
| **6** | **Windows** | **Linux** | **ui**        | **true**    | `/opt/app/f.ts`    | ✅ vscode-remote:// via folder match | **Fixed** |
| 7     | Windows     | Windows   | workspace     | true        | `/c:/Users/f.ts`   | ✅ file:// (exthost transforms)      | ✅         |
| 8     | Windows     | Windows   | ui            | true        | `/c:/Users/f.ts`   | ✅ vscode-remote:// via folder match | ✅         |

**Scenario #6** is the primary bug — the only configuration where `isWindows` (local) disagrees with the remote OS (Linux), causing `fsPath` to corrupt paths.

> **Note:** This matrix is a logic trace (code-path analysis), not automated E2E testing across all eight OS/extensionKind combinations. Unit tests cover the core getFilePath/resolveFilePath logic; the cross-platform interaction with `isWindows` is a build-time constant that cannot be toggled in unit tests.

## Prior Art

This is a corrected and improved version of [PR #3177](https://github.com/microsoft/vscode-copilot-chat/pull/3177) by @bryanchen-d, which was closed based on two assumptions:

1. **"Copilot Chat is defined to run on the remote workspace"** — True by default, but `extensionKind: ["ui"]` is a supported VS Code override that changes this. It's the documented workaround for air-gapped remotes.

2. **"This would cause issues for Windows remotes"** — `uri.path` for Windows remote URIs returns `/c:/Users/...` (POSIX, per URI spec). This round-trips correctly through `resolveFilePath` because the workspace folder prefix-match reconstructs the full `vscode-remote://` URI regardless of the remote OS.

### Improvements over [PR #3177](https://github.com/microsoft/vscode-copilot-chat/pull/3177)

| Aspect                    | [PR #3177](https://github.com/microsoft/vscode-copilot-chat/pull/3177) | This PR                                |
| ------------------------- | ---------------------------------------------------------------------- | -------------------------------------- |
| Workspace folder matching | Only checks `folders[0].scheme`                                        | Iterates all folders with prefix-match |
| Path validation           | Any `/`-prefixed path → remote                                         | Only workspace-matched paths → remote  |
| Multi-root safety         | Uses first folder only                                                 | Works with any folder in multi-root    |
| URI construction          | `URI.from()` with raw path                                             | `URI.joinPath()` preserving folder URI |

## Related Issues

- [Agent mode cannot edit files with remote-ssh extension #11526](https://github.com/microsoft/vscode-copilot-release/issues/11526)
- [Copilot attempts writing files in windows format on linux remote host via ssh #284417](https://github.com/microsoft/vscode/issues/284417)

## Use Case — Air-Gapped / Restricted-Internet Remote Hosts

In laboratory and enterprise environments, remote hosts often operate behind strict network policies — air-gapped networks, firewalls that block external APIs, or hosts with no direct internet access. In these scenarios:

- The Copilot Chat extension **cannot authenticate or reach GitHub APIs** from the remote side.
- Users must set `remote.extensionKind: { "GitHub.copilot-chat": ["ui"] }` to run the extension on the local (Windows) machine, which has network access.
- This is a **supported VS Code configuration** — `extensionKind` override is a documented feature, not a hack.

With this override, all Copilot Chat features work (authentication, LLM communication) **except** file-based tools, which break due to the path corruption described above. This PR fixes that gap.

## Test

All 26 existing unit tests pass (1 skipped — non-Windows platform test on Windows):

```
✓ src/platform/prompts/test/node/promptPathRepresentationService.spec.ts (27 tests | 1 skipped)
  Test Files  1 passed (1)
```

## Competitive Context

The competing Claude Code extension has the **same class of bug** under `extensionKind: ["ui"]` and has **closed it as "not planned"**:

- [anthropics/claude-code#34628](https://github.com/anthropics/claude-code/issues/34628) — `ENOENT: /home/<redacted> not found on local machine when using Claude Code extension in UI mode over SSH` (closed as stale, never fixed)
- [anthropics/claude-code#37919](https://github.com/anthropics/claude-code/issues/37919) — `claudeVSCodeSidebarSecondary fails to render in VS Code Remote SSH with ["ui"] extensionKind` (**still open**, reported multiple times with no official response)

Fixing this in Copilot Chat gives GitHub Copilot a concrete advantage for the air-gapped / restricted-internet Remote-SSH user segment that Claude Code currently cannot serve.

## Disclosure

This patch (code + commit message + PR description) was fully generated by AI — **Claude Opus 4.6** driven by **GitHub Copilot** in VS Code agent mode. The author reviewed, verified, and approved all changes before submission.
