### PR TITLE
Change providers to accept extra parameter

### DIFF
--- a/src/extension/byok/common/byokProvider.ts
+++ b/src/extension/byok/common/byokProvider.ts
@@ -61,6 +61,7 @@ export interface BYOKModelCapabilities {
 	supportedEndpoints?: ModelSupportedEndpoint[];
 	zeroDataRetentionEnabled?: boolean;
 	supportsReasoningEffort?: string[];
+	extraBody?: Record<string, unknown>;
 }
 
 export interface BYOKModelRegistry {
@@ -121,7 +122,8 @@ export function resolveModelInfo(modelId: string, providerName: string, knownMod
 		is_chat_fallback: false,
 		model_picker_enabled: true,
 		supported_endpoints: knownModelInfo?.supportedEndpoints,
-		zeroDataRetentionEnabled: knownModelInfo?.zeroDataRetentionEnabled
+		zeroDataRetentionEnabled: knownModelInfo?.zeroDataRetentionEnabled,
+		extraBody: knownModelInfo?.extraBody
 	};
 	if (knownModelInfo?.requestHeaders && Object.keys(knownModelInfo.requestHeaders).length > 0) {
 		modelInfo.requestHeaders = { ...knownModelInfo.requestHeaders };

--- a/src/extension/byok/node/openAIEndpoint.ts
+++ b/src/extension/byok/node/openAIEndpoint.ts
@@ -291,6 +291,10 @@ export class OpenAIEndpoint extends ChatEndpoint {
 			if (!this.useResponsesApi && body.stream) {
 				body['stream_options'] = { 'include_usage': true };
 			}
+			// Merge extraBody fields (e.g. thinking: {type: "disabled"} for Fireworks)
+			if (this.modelMetadata.extraBody) {
+				Object.assign(body, this.modelMetadata.extraBody);
+			}
 		}
 	}
 

--- a/src/extension/byok/vscode-node/customOAIProvider.ts
+++ b/src/extension/byok/vscode-node/customOAIProvider.ts
@@ -61,6 +61,7 @@ interface _CustomOAIModelConfig {
 	editTools?: EndpointEditToolName[];
 	requestHeaders?: Record<string, string>;
 	zeroDataRetentionEnabled?: boolean;
+	extraBody?: Record<string, unknown>;
 }
 
 export interface CustomOAIModelConfig extends _CustomOAIModelConfig {
@@ -142,7 +143,8 @@ export abstract class AbstractCustomOAIBYOKModelProvider extends AbstractOpenAIC
 			thinking: modelConfiguration?.thinking ?? false,
 			streaming: modelConfiguration?.streaming,
 			requestHeaders: modelConfiguration?.requestHeaders,
-			zeroDataRetentionEnabled: modelConfiguration?.zeroDataRetentionEnabled
+			zeroDataRetentionEnabled: modelConfiguration?.zeroDataRetentionEnabled,
+			extraBody: modelConfiguration?.extraBody
 		};
 		const modelInfo = resolveModelInfo(model.id, this._name, undefined, modelCapabilities);
 		if (modelCapabilities?.url?.includes('/responses')) {

--- a/src/platform/endpoint/common/endpointProvider.ts
+++ b/src/platform/endpoint/common/endpointProvider.ts
@@ -99,6 +99,7 @@ export type IChatModelInformation = IModelAPIResponse & {
 	urlOrRequestMetadata?: string | RequestMetadata;
 	requestHeaders?: Readonly<Record<string, string>>;
 	zeroDataRetentionEnabled?: boolean;
+	extraBody?: Record<string, unknown>;
 };
 
 export function isChatModelInformation(model: IModelAPIResponse): model is IChatModelInformation {


### PR DESCRIPTION
Adds support for passing custom fields via an `extraBody` property throughout the BYOK (Bring Your Own Key) model configuration and request pipeline. This enables providers to specify additional request parameters (such as special options for certain endpoints) in a flexible way. The changes ensure that these custom fields are available in model metadata, configuration, and are included in outgoing requests.