### PR TITLE
Rename skillContentRead telemetry properties to use 'skill' prefix

### DIFF
--- a/src/extension/tools/node/readFileTool.tsx
+++ b/src/extension/tools/node/readFileTool.tsx
@@ -386,19 +386,19 @@ export class ReadFileTool implements ICopilotTool<ReadFileParams> {
 			const plaintextProps = {
 				skillName: skillInfo.skillName,
 				skillPath: uri.toString(),
-				extensionId,
-				extensionVersion,
+				skillExtensionId: extensionId,
+				skillExtensionVersion: extensionVersion,
 				skillStorage: skillInfo.storage,
-				contentHash,
+				skillContentHash: contentHash,
 			};
 
 			this.telemetryService.sendGHTelemetryEvent('skillContentRead',
 				{
 					skillNameHash: String(hash(skillInfo.skillName)),
-					extensionIdHash: extensionId ? String(hash(extensionId)) : '',
-					extensionVersion: plaintextProps.extensionVersion,
+					skillExtensionIdHash: extensionId ? String(hash(extensionId)) : '',
+					skillExtensionVersion: plaintextProps.skillExtensionVersion,
 					skillStorage: plaintextProps.skillStorage,
-					contentHash,
+					skillContentHash: contentHash,
 				}
 			);
 

--- a/src/extension/tools/node/test/readFile.spec.tsx
+++ b/src/extension/tools/node/test/readFile.spec.tsx
@@ -765,26 +765,26 @@ suite('ReadFile', () => {
 			expect(event).toBeDefined();
 			expect(event!.properties!.skillStorage).toBe(SkillStorage.Workspace);
 			expect(event!.properties!.skillNameHash).not.toBe('');
-			expect(event!.properties!.extensionIdHash).toBe('');
-			expect(event!.properties!.extensionVersion).toBe('');
-			expect(event!.properties!.contentHash).not.toBe('');
+			expect(event!.properties!.skillExtensionIdHash).toBe('');
+			expect(event!.properties!.skillExtensionVersion).toBe('');
+			expect(event!.properties!.skillContentHash).not.toBe('');
 
 			const enhanced = telemetry.enhancedEvents.find(e => e.eventName === 'skillContentRead');
 			expect(enhanced).toBeDefined();
 			expect(enhanced!.properties!.skillName).toBe('my-skill');
 			expect(enhanced!.properties!.skillPath).toBe(skillUri.toString());
-			expect(enhanced!.properties!.extensionId).toBe('');
-			expect(enhanced!.properties!.extensionVersion).toBe('');
+			expect(enhanced!.properties!.skillExtensionId).toBe('');
+			expect(enhanced!.properties!.skillExtensionVersion).toBe('');
 			expect(enhanced!.properties!.skillStorage).toBe(SkillStorage.Workspace);
-			expect(enhanced!.properties!.contentHash).not.toBe('');
+			expect(enhanced!.properties!.skillContentHash).not.toBe('');
 
 			const internal = telemetry.internalEvents.find(e => e.eventName === 'skillContentRead');
 			expect(internal).toBeDefined();
 			expect(internal!.properties!.skillName).toBe('my-skill');
 			expect(internal!.properties!.skillPath).toBe(skillUri.toString());
-			expect(internal!.properties!.extensionId).toBe('');
+			expect(internal!.properties!.skillExtensionId).toBe('');
 			expect(internal!.properties!.skillStorage).toBe(SkillStorage.Workspace);
-			expect(internal!.properties!.contentHash).not.toBe('');
+			expect(internal!.properties!.skillContentHash).not.toBe('');
 
 			testAccessor.dispose();
 		});
@@ -821,7 +821,7 @@ suite('ReadFile', () => {
 			testAccessor.dispose();
 		});
 
-		test('should send skillStorage=extension with extensionIdHash and extensionVersion', async () => {
+		test('should send skillStorage=extension with skillExtensionIdHash and skillExtensionVersion', async () => {
 			const skillContent = '# Extension Skill';
 			const skillUri = URI.file('/extensions/publisher.my-ext/skills/ext-skill/SKILL.md');
 			const testDoc = createTextDocumentData(skillUri, skillContent, 'markdown').document;
@@ -861,26 +861,26 @@ suite('ReadFile', () => {
 			const event = telemetry.events.find(e => e.eventName === 'skillContentRead');
 			expect(event).toBeDefined();
 			expect(event!.properties!.skillStorage).toBe(SkillStorage.Extension);
-			expect(event!.properties!.extensionIdHash).not.toBe('');
-			expect(event!.properties!.extensionVersion).toBe('1.2.3');
-			expect(event!.properties!.contentHash).not.toBe('');
+			expect(event!.properties!.skillExtensionIdHash).not.toBe('');
+			expect(event!.properties!.skillExtensionVersion).toBe('1.2.3');
+			expect(event!.properties!.skillContentHash).not.toBe('');
 
 			const enhanced = telemetry.enhancedEvents.find(e => e.eventName === 'skillContentRead');
 			expect(enhanced).toBeDefined();
 			expect(enhanced!.properties!.skillName).toBe('ext-skill');
 			expect(enhanced!.properties!.skillPath).toBe(skillUri.toString());
-			expect(enhanced!.properties!.extensionId).toBe('publisher.my-ext');
-			expect(enhanced!.properties!.extensionVersion).toBe('1.2.3');
+			expect(enhanced!.properties!.skillExtensionId).toBe('publisher.my-ext');
+			expect(enhanced!.properties!.skillExtensionVersion).toBe('1.2.3');
 			expect(enhanced!.properties!.skillStorage).toBe(SkillStorage.Extension);
-			expect(enhanced!.properties!.contentHash).not.toBe('');
+			expect(enhanced!.properties!.skillContentHash).not.toBe('');
 
 			const internal = telemetry.internalEvents.find(e => e.eventName === 'skillContentRead');
 			expect(internal).toBeDefined();
 			expect(internal!.properties!.skillName).toBe('ext-skill');
-			expect(internal!.properties!.extensionId).toBe('publisher.my-ext');
-			expect(internal!.properties!.extensionVersion).toBe('1.2.3');
+			expect(internal!.properties!.skillExtensionId).toBe('publisher.my-ext');
+			expect(internal!.properties!.skillExtensionVersion).toBe('1.2.3');
 			expect(internal!.properties!.skillStorage).toBe(SkillStorage.Extension);
-			expect(internal!.properties!.contentHash).not.toBe('');
+			expect(internal!.properties!.skillContentHash).not.toBe('');
 
 			testAccessor.dispose();
 		});


### PR DESCRIPTION
## Summary

Renames telemetry properties in the `skillContentRead` event to add a `skill` prefix, aligning property names with the event name to reduce ambiguity in the collected data. This was suggested by folks on the data team.

## Property Renames

### GH telemetry event (`sendGHTelemetryEvent`)
| Old | New |
|-----|-----|
| `extensionIdHash` | `skillExtensionIdHash` |
| `extensionVersion` | `skillExtensionVersion` |
| `contentHash` | `skillContentHash` |

### Enhanced GH + Internal MSFT events (plaintext props)
| Old | New |
|-----|-----|
| `extensionId` | `skillExtensionId` |
| `extensionVersion` | `skillExtensionVersion` |
| `contentHash` | `skillContentHash` |

Properties that already had the `skill` prefix (`skillName`, `skillPath`, `skillStorage`, `skillNameHash`) are unchanged.

## Testing

- Updated all unit test assertions in `readFile.spec.tsx` to match the new property names
- All 34 tests pass