### PR TITLE
Add base and compare branch names to Copilot PR title and description generation

### DIFF
--- a/src/extension/githubPullRequest.d.ts
+++ b/src/extension/githubPullRequest.d.ts
@@ -6,7 +6,7 @@
 import type { CancellationToken, Disposable, Uri } from 'vscode';
 
 export interface TitleAndDescriptionProvider {
-	provideTitleAndDescription(context: { commitMessages: string[]; patches: string[] | { patch: string; fileUri: string; previousFileUri?: string }[]; issues?: { reference: string; content: string }[] }, token: CancellationToken): Promise<{ title: string; description?: string } | undefined>;
+	provideTitleAndDescription(context: { commitMessages: string[]; patches: string[] | { patch: string; fileUri: string; previousFileUri?: string }[]; issues?: { reference: string; content: string }[]; template?: string; baseBranch?: string; compareBranch?: string }, token: CancellationToken): Promise<{ title: string; description?: string } | undefined>;
 }
 
 export interface ReviewerComments {

--- a/src/extension/githubPullRequest.d.ts
+++ b/src/extension/githubPullRequest.d.ts
@@ -6,7 +6,7 @@
 import type { CancellationToken, Disposable, Uri } from 'vscode';
 
 export interface TitleAndDescriptionProvider {
-	provideTitleAndDescription(context: { commitMessages: string[]; patches: string[] | { patch: string; fileUri: string; previousFileUri?: string }[]; issues?: { reference: string; content: string }[]; template?: string; baseBranch?: string; compareBranch?: string }, token: CancellationToken): Promise<{ title: string; description?: string } | undefined>;
+	provideTitleAndDescription(context: { commitMessages: string[]; patches: string[] | { patch: string; fileUri: string; previousFileUri?: string }[]; issues?: { reference: string; content: string }[]; template?: string; compareBranch?: string }, token: CancellationToken): Promise<{ title: string; description?: string } | undefined>;
 }
 
 export interface ReviewerComments {

--- a/src/extension/prompt/node/githubPullRequestTitleAndDescriptionGenerator.ts
+++ b/src/extension/prompt/node/githubPullRequestTitleAndDescriptionGenerator.ts
@@ -73,17 +73,19 @@ export class GitHubPullRequestTitleAndDescriptionGenerator implements TitleAndDe
 		return patches;
 	}
 
-	async provideTitleAndDescription(context: { commitMessages: string[]; patches: string[] | { patch: string; fileUri: string; previousFileUri?: string }[]; issues?: { reference: string; content: string }[]; template?: string }, token: CancellationToken): Promise<{ title: string; description?: string } | undefined> {
+	async provideTitleAndDescription(context: { commitMessages: string[]; patches: string[] | { patch: string; fileUri: string; previousFileUri?: string }[]; issues?: { reference: string; content: string }[]; template?: string; baseBranch?: string; compareBranch?: string }, token: CancellationToken): Promise<{ title: string; description?: string } | undefined> {
 		const commitMessages: string[] = context.commitMessages;
 		const allPatches: { patch: string; fileUri?: string; previousFileUri?: string }[] = isStringArray(context.patches) ? context.patches.map(patch => ({ patch })) : context.patches;
 		const patches = await this.excludePatches(allPatches);
 		const issues: { reference: string; content: string }[] | undefined = context.issues;
 		const template: string | undefined = context.template;
+		const baseBranch: string | undefined = context.baseBranch;
+		const compareBranch: string | undefined = context.compareBranch;
 
 		const endpoint = await this.endpointProvider.getChatEndpoint('copilot-fast');
 		const charLimit = Math.floor((endpoint.modelMaxPromptTokens * 4) / 3);
 
-		const prompt = await this.createPRTitleAndDescriptionPrompt(commitMessages, patches, issues, template, charLimit);
+		const prompt = await this.createPRTitleAndDescriptionPrompt(commitMessages, patches, issues, template, baseBranch, compareBranch, charLimit);
 		const fetchResult = await endpoint
 			.makeChatRequest(
 				'githubPullRequestTitleAndDescriptionGenerator',
@@ -172,7 +174,7 @@ export class GitHubPullRequestTitleAndDescriptionGenerator implements TitleAndDe
 		}
 	}
 
-	private async createPRTitleAndDescriptionPrompt(commitMessages: string[], patches: string[], issues: { reference: string; content: string }[] | undefined, template: string | undefined, charLimit: number): Promise<RenderPromptResult> {
+	private async createPRTitleAndDescriptionPrompt(commitMessages: string[], patches: string[], issues: { reference: string; content: string }[] | undefined, template: string | undefined, baseBranch: string | undefined, compareBranch: string | undefined, charLimit: number): Promise<RenderPromptResult> {
 		// Reserve 20% of the character limit for the safety rules and instructions
 		const availableChars = charLimit - Math.floor(charLimit * 0.2);
 
@@ -190,7 +192,7 @@ export class GitHubPullRequestTitleAndDescriptionGenerator implements TitleAndDe
 		}
 
 		const endpoint = await this.endpointProvider.getChatEndpoint('copilot-fast');
-		const promptRenderer = PromptRenderer.create(this.instantiationService, endpoint, GitHubPullRequestPrompt, { commitMessages, issues, patches, template });
+		const promptRenderer = PromptRenderer.create(this.instantiationService, endpoint, GitHubPullRequestPrompt, { commitMessages, issues, patches, template, baseBranch, compareBranch });
 		return promptRenderer.render(undefined, undefined);
 	}
 }

--- a/src/extension/prompt/node/githubPullRequestTitleAndDescriptionGenerator.ts
+++ b/src/extension/prompt/node/githubPullRequestTitleAndDescriptionGenerator.ts
@@ -73,19 +73,18 @@ export class GitHubPullRequestTitleAndDescriptionGenerator implements TitleAndDe
 		return patches;
 	}
 
-	async provideTitleAndDescription(context: { commitMessages: string[]; patches: string[] | { patch: string; fileUri: string; previousFileUri?: string }[]; issues?: { reference: string; content: string }[]; template?: string; baseBranch?: string; compareBranch?: string }, token: CancellationToken): Promise<{ title: string; description?: string } | undefined> {
+	async provideTitleAndDescription(context: { commitMessages: string[]; patches: string[] | { patch: string; fileUri: string; previousFileUri?: string }[]; issues?: { reference: string; content: string }[]; template?: string; compareBranch?: string }, token: CancellationToken): Promise<{ title: string; description?: string } | undefined> {
 		const commitMessages: string[] = context.commitMessages;
 		const allPatches: { patch: string; fileUri?: string; previousFileUri?: string }[] = isStringArray(context.patches) ? context.patches.map(patch => ({ patch })) : context.patches;
 		const patches = await this.excludePatches(allPatches);
 		const issues: { reference: string; content: string }[] | undefined = context.issues;
 		const template: string | undefined = context.template;
-		const baseBranch: string | undefined = context.baseBranch;
 		const compareBranch: string | undefined = context.compareBranch;
 
 		const endpoint = await this.endpointProvider.getChatEndpoint('copilot-fast');
 		const charLimit = Math.floor((endpoint.modelMaxPromptTokens * 4) / 3);
 
-		const prompt = await this.createPRTitleAndDescriptionPrompt(commitMessages, patches, issues, template, baseBranch, compareBranch, charLimit);
+		const prompt = await this.createPRTitleAndDescriptionPrompt(commitMessages, patches, issues, template, compareBranch, charLimit);
 		const fetchResult = await endpoint
 			.makeChatRequest(
 				'githubPullRequestTitleAndDescriptionGenerator',
@@ -174,7 +173,7 @@ export class GitHubPullRequestTitleAndDescriptionGenerator implements TitleAndDe
 		}
 	}
 
-	private async createPRTitleAndDescriptionPrompt(commitMessages: string[], patches: string[], issues: { reference: string; content: string }[] | undefined, template: string | undefined, baseBranch: string | undefined, compareBranch: string | undefined, charLimit: number): Promise<RenderPromptResult> {
+	private async createPRTitleAndDescriptionPrompt(commitMessages: string[], patches: string[], issues: { reference: string; content: string }[] | undefined, template: string | undefined, compareBranch: string | undefined, charLimit: number): Promise<RenderPromptResult> {
 		// Reserve 20% of the character limit for the safety rules and instructions
 		const availableChars = charLimit - Math.floor(charLimit * 0.2);
 
@@ -192,7 +191,7 @@ export class GitHubPullRequestTitleAndDescriptionGenerator implements TitleAndDe
 		}
 
 		const endpoint = await this.endpointProvider.getChatEndpoint('copilot-fast');
-		const promptRenderer = PromptRenderer.create(this.instantiationService, endpoint, GitHubPullRequestPrompt, { commitMessages, issues, patches, template, baseBranch, compareBranch });
+		const promptRenderer = PromptRenderer.create(this.instantiationService, endpoint, GitHubPullRequestPrompt, { commitMessages, issues, patches, template, compareBranch });
 		return promptRenderer.render(undefined, undefined);
 	}
 }

--- a/src/extension/prompts/node/github/pullRequestDescriptionPrompt.tsx
+++ b/src/extension/prompts/node/github/pullRequestDescriptionPrompt.tsx
@@ -12,6 +12,8 @@ interface GitHubPullRequestPromptProps extends BasePromptElementProps {
 	patches: string[];
 	issues: { reference: string; content: string }[] | undefined;
 	template: string | undefined;
+	baseBranch: string | undefined;
+	compareBranch: string | undefined;
 }
 
 interface GitHubPullRequestIdentityProps extends BasePromptElementProps {
@@ -89,6 +91,8 @@ interface GitHubPullRequestUserMessageProps extends BasePromptElementProps {
 	commitMessages: string[];
 	patches: string[];
 	template: string | undefined;
+	baseBranch: string | undefined;
+	compareBranch: string | undefined;
 }
 
 class GitHubPullRequestUserMessage extends PromptElement<GitHubPullRequestUserMessageProps> {
@@ -97,6 +101,11 @@ class GitHubPullRequestUserMessage extends PromptElement<GitHubPullRequestUserMe
 		const formattedPatches = this.props.patches.map(patch => <>```diff<br />{patch}<br />```<br /></>);
 		return (
 			<>
+				{(this.props.baseBranch || this.props.compareBranch) && (
+					<>
+						This pull request will merge {this.props.compareBranch ? `branch "${this.props.compareBranch}"` : 'the current branch'} into {this.props.baseBranch ? `branch "${this.props.baseBranch}"` : 'the base branch'}.<br />
+					</>
+				)}
 				These are the commits that will be included in the pull request you are about to make:<br />
 				{formattedCommitMessages}<br />
 				Below is a list of git patches that contain the file changes for all the files that will be included in the pull request:<br />
@@ -124,7 +133,7 @@ export class GitHubPullRequestPrompt extends PromptElement<GitHubPullRequestProm
 					<SafetyRules />
 				</SystemMessage>
 				<UserMessage>
-					<GitHubPullRequestUserMessage commitMessages={this.props.commitMessages} patches={this.props.patches} template={this.props.template} />
+					<GitHubPullRequestUserMessage commitMessages={this.props.commitMessages} patches={this.props.patches} template={this.props.template} baseBranch={this.props.baseBranch} compareBranch={this.props.compareBranch} />
 					<Tag priority={750} name='custom-instructions'>
 						<CustomInstructions
 							chatVariables={undefined}

--- a/src/extension/prompts/node/github/pullRequestDescriptionPrompt.tsx
+++ b/src/extension/prompts/node/github/pullRequestDescriptionPrompt.tsx
@@ -12,7 +12,6 @@ interface GitHubPullRequestPromptProps extends BasePromptElementProps {
 	patches: string[];
 	issues: { reference: string; content: string }[] | undefined;
 	template: string | undefined;
-	baseBranch: string | undefined;
 	compareBranch: string | undefined;
 }
 
@@ -91,7 +90,6 @@ interface GitHubPullRequestUserMessageProps extends BasePromptElementProps {
 	commitMessages: string[];
 	patches: string[];
 	template: string | undefined;
-	baseBranch: string | undefined;
 	compareBranch: string | undefined;
 }
 
@@ -101,9 +99,9 @@ class GitHubPullRequestUserMessage extends PromptElement<GitHubPullRequestUserMe
 		const formattedPatches = this.props.patches.map(patch => <>```diff<br />{patch}<br />```<br /></>);
 		return (
 			<>
-				{(this.props.baseBranch || this.props.compareBranch) && (
+				{this.props.compareBranch && (
 					<>
-						This pull request will merge {this.props.compareBranch ? `branch "${this.props.compareBranch}"` : 'the current branch'} into {this.props.baseBranch ? `branch "${this.props.baseBranch}"` : 'the base branch'}.<br />
+						The merged/compare/source branch is "{this.props.compareBranch}".<br />
 					</>
 				)}
 				These are the commits that will be included in the pull request you are about to make:<br />
@@ -133,7 +131,7 @@ export class GitHubPullRequestPrompt extends PromptElement<GitHubPullRequestProm
 					<SafetyRules />
 				</SystemMessage>
 				<UserMessage>
-					<GitHubPullRequestUserMessage commitMessages={this.props.commitMessages} patches={this.props.patches} template={this.props.template} baseBranch={this.props.baseBranch} compareBranch={this.props.compareBranch} />
+					<GitHubPullRequestUserMessage commitMessages={this.props.commitMessages} patches={this.props.patches} template={this.props.template} compareBranch={this.props.compareBranch} />
 					<Tag priority={750} name='custom-instructions'>
 						<CustomInstructions
 							chatVariables={undefined}


### PR DESCRIPTION
Adds `compareBranch` to the context passed to `TitleAndDescriptionProvider.provideTitleAndDescription`, and include it in the prompt sent to the model when generating a PR title and description.

Previously the model had no knowledge of which branch is merged, causing it to hallucinate branch names in the generated description. With this change, the user message sent to the model now includes: `If merged brand contain X then Y.`

### Changes
- `githubPullRequest.d.ts`: Added `compareBranch?` to the `TitleAndDescriptionProvider` context interface.
- `githubPullRequestTitleAndDescriptionGenerator.ts`: Passes `compareBranch` through to the prompt renderer.
- `pullRequestDescriptionPrompt.tsx`: Renders the branch name as a sentence at the start of the user message when either value is present.

Part of microsoft/vscode-pull-request-github#8662




> Originally, the base branch was also exposed, but this feature was declined by the maintainers of the pull request extension repository.