### PR TITLE
Fix read_cell_output incorrectly reporting all outputs as too large

### DIFF
--- a/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/src/extension/prompts/node/panel/toolCalling.tsx
@@ -345,7 +345,6 @@ const toolsCalledInParallel = new Set<ToolName>([
 	ToolName.GetErrors,
 	ToolName.GetScmChanges,
 	ToolName.GetNotebookSummary,
-	ToolName.ReadCellOutput,
 	ToolName.InstallExtension,
 	ToolName.FetchWebPage,
 ]);

--- a/src/extension/tools/node/runNotebookCellTool.tsx
+++ b/src/extension/tools/node/runNotebookCellTool.tsx
@@ -383,7 +383,7 @@ export class RunNotebookCellOutput extends PromptElement<IRunNotebookCellOutputP
 			|| item.mime === 'application/vnd.code.notebook.stderr'
 			|| item.mime === 'application/json');
 		if (textItem) {
-			if (getCharLimit(textItem.data.byteLength) > sizing.tokenBudget / this.props.sizeLimitRatio) {
+			if (textItem.data.byteLength > getCharLimit(sizing.tokenBudget / this.props.sizeLimitRatio)) {
 				return <Tag name={`cell-output`} attrs={{ mimeType: textItem.mime }}>
 					Output {index + 1}: Output is too large to be used as context in the language model, but the user should be able to see it in the notebook.<br />
 					<br />
@@ -394,7 +394,7 @@ export class RunNotebookCellOutput extends PromptElement<IRunNotebookCellOutputP
 			</Tag>;
 		}
 
-		const largeOutput = output.items.find((item) => getCharLimit(item.data.byteLength) > sizing.tokenBudget / this.props.sizeLimitRatio);
+		const largeOutput = output.items.find((item) => item.data.byteLength > getCharLimit(sizing.tokenBudget / this.props.sizeLimitRatio));
 		if (largeOutput) {
 			return <Tag name={`cell-output`} attrs={{ mimeType: largeOutput.mime }}>
 				Output {index + 1}: Output is too large to be used as context in the language model, but the user should be able to see it in the notebook.<br />


### PR DESCRIPTION
Two related issues caused even tiny notebook cell outputs (e.g. 5 bytes) to be replaced with "Output is too large to be used as context".

1. Inverted size check in `RunNotebookCellOutput`: `getCharLimit` converts tokens to chars (×4), but it was applied to the byteLength side and compared against a token count. Compare byteLength against getCharLimit(tokenBudget / sizeLimitRatio) instead — the threshold was 16× too small.

2. Remove `ReadCellOutput` from `toolsCalledInParallel`. Tools in that set are invoked eagerly with a sentinel `{ tokenBudget: 1 }` sizing on the premise that they don't consume sizing info. `RunNotebookCellOutput` does — it gates output on `sizing.tokenBudget` — so the sentinel made every non-empty output trip the size check. Letting it use the normal lazy path gives it the endpoint's real prompt budget.