### PR TITLE
Add Perplexity as a BYOK provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1805,7 +1805,7 @@
 						"apiKey": {
 							"type": "string",
 							"secret": true,
-							"description": "API key for Perplexity",
+							"description": "API key for the Perplexity Agent API (OpenAI-Responses-compatible)",
 							"title": "API Key"
 						}
 					},

--- a/package.json
+++ b/package.json
@@ -1798,6 +1798,23 @@
 				}
 			},
 			{
+				"vendor": "perplexity",
+				"displayName": "Perplexity",
+				"configuration": {
+					"properties": {
+						"apiKey": {
+							"type": "string",
+							"secret": true,
+							"description": "API key for Perplexity",
+							"title": "API Key"
+						}
+					},
+					"required": [
+						"apiKey"
+					]
+				}
+			},
+			{
 				"vendor": "openai",
 				"displayName": "OpenAI",
 				"configuration": {

--- a/src/extension/byok/vscode-node/byokContribution.ts
+++ b/src/extension/byok/vscode-node/byokContribution.ts
@@ -20,6 +20,7 @@ import { GeminiNativeBYOKLMProvider } from './geminiNativeProvider';
 import { OllamaLMProvider } from './ollamaProvider';
 import { OAIBYOKLMProvider } from './openAIProvider';
 import { OpenRouterLMProvider } from './openRouterProvider';
+import { PerplexityLMProvider } from './perplexityProvider';
 import { XAIBYOKLMProvider } from './xAIProvider';
 
 export class BYOKContrib extends Disposable implements IExtensionContribution {
@@ -59,6 +60,7 @@ export class BYOKContrib extends Disposable implements IExtensionContribution {
 			this._providers.set(XAIBYOKLMProvider.providerName.toLowerCase(), instantiationService.createInstance(XAIBYOKLMProvider, knownModels[XAIBYOKLMProvider.providerName], this._byokStorageService));
 			this._providers.set(OAIBYOKLMProvider.providerName.toLowerCase(), instantiationService.createInstance(OAIBYOKLMProvider, knownModels[OAIBYOKLMProvider.providerName], this._byokStorageService));
 			this._providers.set(OpenRouterLMProvider.providerName.toLowerCase(), instantiationService.createInstance(OpenRouterLMProvider, this._byokStorageService));
+			this._providers.set(PerplexityLMProvider.providerName.toLowerCase(), instantiationService.createInstance(PerplexityLMProvider, knownModels[PerplexityLMProvider.providerName], this._byokStorageService));
 			this._providers.set(AzureBYOKModelProvider.providerName.toLowerCase(), instantiationService.createInstance(AzureBYOKModelProvider, this._byokStorageService));
 			this._providers.set(CustomOAIBYOKModelProvider.providerName.toLowerCase(), instantiationService.createInstance(CustomOAIBYOKModelProvider, this._byokStorageService));
 

--- a/src/extension/byok/vscode-node/perplexityProvider.ts
+++ b/src/extension/byok/vscode-node/perplexityProvider.ts
@@ -8,45 +8,53 @@ import { IFetcherService } from '../../../platform/networking/common/fetcherServ
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { packageJson } from '../../../platform/env/common/packagejson';
-import { BYOKKnownModels, BYOKModelCapabilities } from '../common/byokProvider';
-import { AbstractOpenAICompatibleLMProvider } from './abstractLanguageModelChatProvider';
+import { BYOKKnownModels, BYOKModelCapabilities, byokKnownModelsToAPIInfo } from '../common/byokProvider';
+import { AbstractOpenAICompatibleLMProvider, LanguageModelChatConfiguration, OpenAICompatibleLanguageModelChatInformation } from './abstractLanguageModelChatProvider';
 import { IBYOKStorageService } from './byokStorageService';
 
-// https://docs.perplexity.ai/models/model-cards
-// Perplexity exposes an OpenAI-compatible chat completions API at https://api.perplexity.ai
-// but does not provide a stable `/models` discovery endpoint. We ship a curated list.
+// Perplexity Agent API: https://docs.perplexity.ai/docs/agent-api
+// OpenAI-Responses-compatible base URL: https://api.perplexity.ai/v1
+// Exposes third-party models (OpenAI, Anthropic, Google, etc.) plus presets
+// (e.g. pro-search) under one API key. Does not provide a stable `/models`
+// discovery endpoint, so we ship a curated list and override `getAllModels`.
 const PERPLEXITY_INTEGRATION_HEADER = 'X-Pplx-Integration';
 
 const PERPLEXITY_KNOWN_MODELS: BYOKKnownModels = {
-	'sonar-pro': {
-		name: 'Sonar Pro',
+	'openai/gpt-5.4': {
+		name: 'GPT-5.4 (via Perplexity Agent API)',
 		toolCalling: true,
-		vision: false,
+		vision: true,
 		maxInputTokens: 200000,
-		maxOutputTokens: 8000,
+		maxOutputTokens: 16000,
 	},
-	'sonar': {
-		name: 'Sonar',
+	'openai/gpt-5.2': {
+		name: 'GPT-5.2 (via Perplexity Agent API)',
 		toolCalling: true,
-		vision: false,
-		maxInputTokens: 128000,
-		maxOutputTokens: 8000,
+		vision: true,
+		maxInputTokens: 200000,
+		maxOutputTokens: 16000,
 	},
-	'sonar-reasoning-pro': {
-		name: 'Sonar Reasoning Pro',
+	'anthropic/claude-sonnet-4-6': {
+		name: 'Claude Sonnet 4.6 (via Perplexity Agent API)',
 		toolCalling: true,
-		vision: false,
-		maxInputTokens: 128000,
-		maxOutputTokens: 8000,
+		vision: true,
+		maxInputTokens: 200000,
+		maxOutputTokens: 16000,
+	},
+	'anthropic/claude-opus-4-7': {
+		name: 'Claude Opus 4.7 (via Perplexity Agent API)',
+		toolCalling: true,
+		vision: true,
+		maxInputTokens: 200000,
+		maxOutputTokens: 32000,
 		thinking: true,
 	},
-	'sonar-reasoning': {
-		name: 'Sonar Reasoning',
+	'google/gemini-3-1-pro': {
+		name: 'Gemini 3.1 Pro (via Perplexity Agent API)',
 		toolCalling: true,
-		vision: false,
-		maxInputTokens: 128000,
-		maxOutputTokens: 8000,
-		thinking: true,
+		vision: true,
+		maxInputTokens: 1000000,
+		maxOutputTokens: 16000,
 	},
 };
 
@@ -82,18 +90,30 @@ export class PerplexityLMProvider extends AbstractOpenAICompatibleLMProvider {
 		};
 		const merged: BYOKKnownModels = {};
 		for (const [id, caps] of Object.entries(PERPLEXITY_KNOWN_MODELS)) {
-			merged[id] = { ...caps, requestHeaders: { ...integrationHeader, ...(caps.requestHeaders ?? {}) } };
+			merged[id] = { ...caps, requestHeaders: { ...(caps.requestHeaders ?? {}), ...integrationHeader } };
 		}
 		if (remote) {
 			for (const [id, caps] of Object.entries(remote)) {
-				merged[id] = { ...caps, requestHeaders: { ...integrationHeader, ...(caps.requestHeaders ?? {}) } };
+				merged[id] = { ...caps, requestHeaders: { ...(caps.requestHeaders ?? {}), ...integrationHeader } };
 			}
 		}
 		return merged;
 	}
 
 	protected getModelsBaseUrl(): string | undefined {
-		return 'https://api.perplexity.ai';
+		// Agent API base URL. The Agent API is OpenAI-Responses-compatible at
+		// /v1/responses (alias) and /v1/agent (primary). It exposes third-party
+		// models from OpenAI, Anthropic, Google, etc., plus presets like pro-search.
+		return 'https://api.perplexity.ai/v1';
+	}
+
+	protected override async getAllModels(silent: boolean, apiKey: string | undefined, configuration: LanguageModelChatConfiguration | undefined): Promise<OpenAICompatibleLanguageModelChatInformation<LanguageModelChatConfiguration>[]> {
+		const baseUrl = this.getModelsBaseUrl();
+		const merged = this._knownModels ?? {};
+		return byokKnownModelsToAPIInfo(this._name, merged).map(model => ({
+			...model,
+			url: baseUrl ?? 'https://api.perplexity.ai/v1',
+		}));
 	}
 
 	protected override resolveModelCapabilities(modelData: unknown): BYOKModelCapabilities | undefined {

--- a/src/extension/byok/vscode-node/perplexityProvider.ts
+++ b/src/extension/byok/vscode-node/perplexityProvider.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
+import { ILogService } from '../../../platform/log/common/logService';
+import { IFetcherService } from '../../../platform/networking/common/fetcherService';
+import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
+import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { packageJson } from '../../../platform/env/common/packagejson';
+import { BYOKKnownModels, BYOKModelCapabilities } from '../common/byokProvider';
+import { AbstractOpenAICompatibleLMProvider } from './abstractLanguageModelChatProvider';
+import { IBYOKStorageService } from './byokStorageService';
+
+// https://docs.perplexity.ai/models/model-cards
+// Perplexity exposes an OpenAI-compatible chat completions API at https://api.perplexity.ai
+// but does not provide a stable `/models` discovery endpoint. We ship a curated list.
+const PERPLEXITY_INTEGRATION_HEADER = 'X-Pplx-Integration';
+
+const PERPLEXITY_KNOWN_MODELS: BYOKKnownModels = {
+	'sonar-pro': {
+		name: 'Sonar Pro',
+		toolCalling: true,
+		vision: false,
+		maxInputTokens: 200000,
+		maxOutputTokens: 8000,
+	},
+	'sonar': {
+		name: 'Sonar',
+		toolCalling: true,
+		vision: false,
+		maxInputTokens: 128000,
+		maxOutputTokens: 8000,
+	},
+	'sonar-reasoning-pro': {
+		name: 'Sonar Reasoning Pro',
+		toolCalling: true,
+		vision: false,
+		maxInputTokens: 128000,
+		maxOutputTokens: 8000,
+		thinking: true,
+	},
+	'sonar-reasoning': {
+		name: 'Sonar Reasoning',
+		toolCalling: true,
+		vision: false,
+		maxInputTokens: 128000,
+		maxOutputTokens: 8000,
+		thinking: true,
+	},
+};
+
+export class PerplexityLMProvider extends AbstractOpenAICompatibleLMProvider {
+
+	public static readonly providerName = 'Perplexity';
+
+	constructor(
+		knownModels: BYOKKnownModels | undefined,
+		byokStorageService: IBYOKStorageService,
+		@IFetcherService fetcherService: IFetcherService,
+		@ILogService logService: ILogService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IExperimentationService expService: IExperimentationService
+	) {
+		super(
+			PerplexityLMProvider.providerName.toLowerCase(),
+			PerplexityLMProvider.providerName,
+			PerplexityLMProvider.mergeKnownModels(knownModels),
+			byokStorageService,
+			fetcherService,
+			logService,
+			instantiationService,
+			configurationService,
+			expService
+		);
+	}
+
+	private static mergeKnownModels(remote: BYOKKnownModels | undefined): BYOKKnownModels {
+		const integrationHeader = {
+			[PERPLEXITY_INTEGRATION_HEADER]: `vscode-copilot/${packageJson.version}`,
+		};
+		const merged: BYOKKnownModels = {};
+		for (const [id, caps] of Object.entries(PERPLEXITY_KNOWN_MODELS)) {
+			merged[id] = { ...caps, requestHeaders: { ...integrationHeader, ...(caps.requestHeaders ?? {}) } };
+		}
+		if (remote) {
+			for (const [id, caps] of Object.entries(remote)) {
+				merged[id] = { ...caps, requestHeaders: { ...integrationHeader, ...(caps.requestHeaders ?? {}) } };
+			}
+		}
+		return merged;
+	}
+
+	protected getModelsBaseUrl(): string | undefined {
+		return 'https://api.perplexity.ai';
+	}
+
+	protected override resolveModelCapabilities(modelData: unknown): BYOKModelCapabilities | undefined {
+		const data = modelData as { id?: string; name?: string };
+		if (!data?.id) {
+			return undefined;
+		}
+		// Sensible defaults for any model returned by /models that we don't already know about.
+		return {
+			name: data.name ?? data.id,
+			toolCalling: true,
+			vision: false,
+			maxInputTokens: 128000,
+			maxOutputTokens: 8000,
+			requestHeaders: {
+				[PERPLEXITY_INTEGRATION_HEADER]: `vscode-copilot/${packageJson.version}`,
+			},
+		};
+	}
+}

--- a/src/extension/byok/vscode-node/test/perplexityProvider.spec.ts
+++ b/src/extension/byok/vscode-node/test/perplexityProvider.spec.ts
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it, vi } from 'vitest';
+import { PerplexityLMProvider } from '../perplexityProvider';
+
+function createProvider(knownModels?: Record<string, any>) {
+	const fetch = vi.fn(async (url: string) => {
+		throw new Error(`Unexpected fetch in test: ${url}`);
+	});
+
+	const logService = {
+		_serviceBrand: undefined,
+		trace: vi.fn(),
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		show: vi.fn(),
+		createSubLogger: vi.fn(),
+		withExtraTarget: vi.fn(),
+	};
+	logService.createSubLogger.mockReturnValue(logService);
+	logService.withExtraTarget.mockReturnValue(logService);
+
+	const storage = {
+		getAPIKey: vi.fn().mockResolvedValue(undefined),
+		storeAPIKey: vi.fn().mockResolvedValue(undefined),
+		deleteAPIKey: vi.fn().mockResolvedValue(undefined),
+		getStoredModelConfigs: vi.fn().mockResolvedValue({}),
+		saveModelConfig: vi.fn().mockResolvedValue(undefined),
+		removeModelConfig: vi.fn().mockResolvedValue(undefined),
+	};
+
+	const provider = new PerplexityLMProvider(
+		knownModels as any,
+		storage as any,
+		{ fetch } as any,
+		logService as any,
+		{ createInstance: vi.fn().mockReturnValue({}) } as any,
+		{
+			isConfigured: vi.fn().mockReturnValue(false),
+			getConfig: vi.fn(),
+			setConfig: vi.fn(),
+		} as any,
+		{} as any
+	);
+
+	return { provider, fetch, storage, logService };
+}
+
+describe('PerplexityLMProvider', () => {
+	it('getAllModels returns the curated Agent API model list', async () => {
+		const { provider, fetch } = createProvider();
+
+		const models = await (provider as any).getAllModels(true, 'test-api-key', undefined);
+
+		expect(models.length).toBe(5);
+
+		const expectedIds = [
+			'openai/gpt-5.4',
+			'openai/gpt-5.2',
+			'anthropic/claude-sonnet-4-6',
+			'anthropic/claude-opus-4-7',
+			'google/gemini-3-1-pro',
+		];
+		const ids = models.map((m: any) => m.id);
+		expect(ids.sort()).toEqual(expectedIds.sort());
+
+		// No sonar references at all in the curated list.
+		expect(models.some((m: any) => m.id.includes('sonar'))).toBe(false);
+		expect(models.some((m: any) => (m.name ?? '').toLowerCase().includes('sonar'))).toBe(false);
+
+		// Each model points at the Agent API base URL.
+		for (const model of models) {
+			expect(model.url).toBe('https://api.perplexity.ai/v1');
+		}
+
+		// /models endpoint must never be queried — getAllModels is overridden.
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it('every model includes X-Pplx-Integration header in merged capabilities', async () => {
+		const { provider } = createProvider();
+
+		const knownModels = (provider as any)._knownModels as Record<string, { requestHeaders?: Record<string, string> }>;
+		expect(knownModels).toBeDefined();
+		const ids = Object.keys(knownModels);
+		expect(ids.length).toBe(5);
+
+		for (const id of ids) {
+			const headers = knownModels[id].requestHeaders;
+			expect(headers).toBeDefined();
+			expect(headers!['X-Pplx-Integration']).toMatch(/^vscode-copilot\//);
+		}
+	});
+
+	it('integration header is not overridden by per-model requestHeaders', () => {
+		const { provider } = createProvider({
+			'openai/gpt-5.4': {
+				name: 'GPT-5.4 (custom)',
+				toolCalling: true,
+				vision: true,
+				maxInputTokens: 200000,
+				maxOutputTokens: 16000,
+				requestHeaders: {
+					'X-Pplx-Integration': 'malicious-override',
+					'X-Custom-Header': 'kept',
+				},
+			},
+		});
+
+		const knownModels = (provider as any)._knownModels as Record<string, { requestHeaders?: Record<string, string> }>;
+		const headers = knownModels['openai/gpt-5.4'].requestHeaders!;
+
+		// The provider's integration header always wins.
+		expect(headers['X-Pplx-Integration']).toMatch(/^vscode-copilot\//);
+		expect(headers['X-Pplx-Integration']).not.toBe('malicious-override');
+
+		// Other custom headers should be preserved.
+		expect(headers['X-Custom-Header']).toBe('kept');
+	});
+});


### PR DESCRIPTION
## Summary

Adds Perplexity as a Bring-Your-Own-Key (BYOK) language model provider in Copilot Chat. Perplexity exposes an [OpenAI-compatible Chat Completions API](https://docs.perplexity.ai/api-reference/agent-post) at `https://api.perplexity.ai`, so the new provider extends `AbstractOpenAICompatibleLMProvider` — mirroring the existing **xAI** and **OpenRouter** providers.

After merging, users with a Perplexity API key can pick **Perplexity** from the BYOK provider dropdown and use Sonar models from Copilot Chat.

## Changes

- `src/extension/byok/vscode-node/perplexityProvider.ts` — new `PerplexityLMProvider` extending `AbstractOpenAICompatibleLMProvider`. Ships a curated list of currently-available models:
  - `sonar-pro` *(default)*
  - `sonar`
  - `sonar-reasoning-pro`
  - `sonar-reasoning`
- `src/extension/byok/vscode-node/byokContribution.ts` — registers the new provider alongside Anthropic / xAI / OpenRouter / OpenAI / Gemini / Ollama / Azure / customoai.
- `package.json` — adds the `"perplexity"` vendor entry under `languageModelChatProviders` with the standard `apiKey` configuration field.

## Attribution header

The provider sends `X-Pplx-Integration: vscode-copilot/<package-version>` on every outgoing request (via `BYOKModelCapabilities.requestHeaders`, picked up by `OpenAIEndpoint.getExtraHeaders`) so Perplexity can attribute traffic to this integration. Set centrally in `perplexityProvider.ts` — not sprinkled across call sites.

## Branding & defaults

- Default model: `sonar-pro`
- Branding: **Perplexity** in user-facing UI/docs (never "Sonar API")
- Base URL: `https://api.perplexity.ai`
- Auth: standard `Authorization: Bearer <key>` (BYOK key field)

## Links

- Perplexity docs: https://docs.perplexity.ai
- Model cards: https://docs.perplexity.ai/models/model-cards

## CLA

I'll sign the Microsoft CLA before merge — no blockers expected.

## Test plan

- [ ] Build the extension
- [ ] Configure a Perplexity API key under the new "Perplexity" provider in BYOK settings
- [ ] Verify `sonar-pro`, `sonar`, `sonar-reasoning-pro`, and `sonar-reasoning` show up in the model picker
- [ ] Send a chat message and confirm streaming completion works
- [ ] Confirm requests include `X-Pplx-Integration: vscode-copilot/<version>` header