### PR TITLE
[BYOK/CustomOAI] Payload format incorrectly defaults to ChatCompletions when using explicit /responses endpoint

### DIFF
--- a/src/extension/byok/vscode-node/customOAIProvider.ts
+++ b/src/extension/byok/vscode-node/customOAIProvider.ts
@@ -147,7 +147,6 @@ export abstract class AbstractCustomOAIBYOKModelProvider extends AbstractOpenAIC
 		const modelInfo = resolveModelInfo(model.id, this._name, undefined, modelCapabilities);
 		if (modelCapabilities?.url?.includes('/responses')) {
 			modelInfo.supported_endpoints = [
-				ModelSupportedEndpoint.ChatCompletions,
 				ModelSupportedEndpoint.Responses
 			];
 		}


### PR DESCRIPTION
### Description:
When configuring a Custom OpenAI or Azure BYOK provider in settings.json with a custom deployment URL ending in /responses (e.g., "https://my-custom-gateway.azure/v1/responses"), the Copilot Chat extension incorrectly sends the payload using the standard /chat/completions JSON format instead of the expected Responses API format.

This causes 400 Bad Request errors on custom backend servers that are explicitly designed to parse the Copilot Responses API schema.

### Root Cause Analysis:
I traced the issue to src/extension/byok/vscode-node/customOAIProvider.ts in the AbstractCustomOAIBYOKModelProvider.createOpenAIEndPoint method:
```
// Current implementation
if (modelCapabilities?.url?.includes('/responses')) {
    modelInfo.supported_endpoints = [
        ModelSupportedEndpoint.ChatCompletions, // <-- The culprit
        ModelSupportedEndpoint.Responses
    ];
}
```



### Why this matters (Use Case):
While /responses is not a standard public OpenAI API endpoint, it is the native protocol used by Copilot to support advanced streaming, thinking parts, and tool calling. Enterprise users and developers often build custom middleware/gateways that implement the /responses endpoint to fully support Copilot's advanced features. When the user explicitly sets the URL to /responses, they expect the client to send the Responses payload, not the legacy ChatCompletions payload.

In future (More Flexible): Do not hardcode this in createOpenAIEndPoint. Instead, allow users to specify supportedEndpoints in settings.json under the model capabilities, and let resolveModelInfo() handle it (it already has logic to parse supportedEndpoints from BYOKModelCapabilities).