### PR TITLE
Disable all memory tools for VS Code until feature parity is reached (#953)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1099,7 +1099,7 @@
 				"displayName": "Memory",
 				"toolReferenceName": "memory",
 				"userDescription": "Manage persistent memory across conversations",
-				"when": "config.github.copilot.chat.tools.memory.enabled",
+				"when": "config.github.copilot.chat.tools.memory.enabled && !github.copilot.chat.memoryDisabled",
 				"modelDescription": "Manage a persistent memory system with three scopes for storing notes and information across conversations.\n\nMemory is organized under /memories/ with three tiers:\n- `/memories/` — User memory: persistent notes that survive across all workspaces and conversations. Store preferences, patterns, and general insights here.\n- `/memories/session/` — Session memory: notes scoped to the current conversation. Store task-specific context and in-progress notes here. Cleared after the conversation ends.\n- `/memories/repo/` — Repository memory: repository-scoped facts stored via Copilot. Only the `create` command is supported for this path.\n\nIMPORTANT: Before creating new memory files, first view the /memories/ directory to understand what already exists. This helps avoid duplicates and maintain organized notes.\n\nCommands:\n- `view`: View contents of a file or list directory contents. Can be used on files or directories (e.g., \"/memories/\" to see all top-level items).\n- `create`: Create a new file at the specified path with the given content. Fails if the file already exists.\n- `str_replace`: Replace an exact string in a file with a new string. The old_str must appear exactly once in the file.\n- `insert`: Insert text at a specific line number in a file. Line 0 inserts at the beginning.\n- `delete`: Delete a file or directory (and all its contents).\n- `rename`: Rename or move a file or directory from path to new_path. Cannot rename across scopes.",
 				"inputSchema": {
 					"type": "object",
@@ -1168,6 +1168,7 @@
 				"displayName": "Resolve Memory File URI",
 				"toolReferenceName": "resolveMemoryFileUri",
 				"userDescription": "Resolve a memory file path to its actual URI",
+				"when": "config.github.copilot.chat.tools.memory.enabled && !github.copilot.chat.memoryDisabled",
 				"modelDescription": "Resolve a memory file path (like /memories/session/plan.md or /memories/repo/notes.md) to its fully qualified URI. Use this when you need the actual URI for a memory file, for example to pass it to setArtifacts. The path must start with /memories/.",
 				"tags": [],
 				"inputSchema": {
@@ -5240,11 +5241,11 @@
 				},
 				{
 					"command": "github.copilot.chat.tools.memory.showMemories",
-					"when": "config.github.copilot.chat.tools.memory.enabled"
+					"when": "config.github.copilot.chat.tools.memory.enabled && !github.copilot.chat.memoryDisabled"
 				},
 				{
 					"command": "github.copilot.chat.tools.memory.clearMemories",
-					"when": "config.github.copilot.chat.tools.memory.enabled"
+					"when": "config.github.copilot.chat.tools.memory.enabled && !github.copilot.chat.memoryDisabled"
 				},
 				{
 					"command": "github.copilot.sessions.commit",

--- a/src/extension/tools/common/agentMemoryService.ts
+++ b/src/extension/tools/common/agentMemoryService.ts
@@ -13,6 +13,7 @@ import { IExperimentationService } from '../../../platform/telemetry/common/null
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
 import { createServiceIdentifier } from '../../../util/common/services';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
+import { isMemoryDisabledByKillSwitch } from './memoryKillSwitch';
 
 /**
  * Repository memory entry format aligned with CAPI service contract.
@@ -160,6 +161,11 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 
 	async checkMemoryEnabled(): Promise<boolean> {
 		try {
+			// Kill switch: disable all memory operations when feature flag is active
+			if (isMemoryDisabledByKillSwitch(this.experimentationService)) {
+				return false;
+			}
+
 			// Check if CAPI sync is enabled via config
 			if (!this.isCAPIMemorySyncConfigEnabled()) {
 				return false;

--- a/src/extension/tools/common/memoryKillSwitch.ts
+++ b/src/extension/tools/common/memoryKillSwitch.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
+
+/**
+ * Feature flag name for the memory kill switch.
+ * When this flag is enabled, all memory operations (tools, prompt injection, retrieval)
+ * are disabled in VS Code until core memory features reach full parity across clients.
+ */
+const MEMORY_DISABLED_VSCODE_FF = 'copilot_swe_agent_memory_disabled_vscode';
+
+/**
+ * Checks whether the memory kill switch feature flag is active.
+ * When active, all memory operations should be disabled.
+ */
+export function isMemoryDisabledByKillSwitch(experimentationService: IExperimentationService): boolean {
+	return experimentationService.getTreatmentVariable<boolean>(MEMORY_DISABLED_VSCODE_FF) === true;
+}

--- a/src/extension/tools/node/memoryContextPrompt.tsx
+++ b/src/extension/tools/node/memoryContextPrompt.tsx
@@ -13,6 +13,7 @@ import { ITelemetryService } from '../../../platform/telemetry/common/telemetry'
 import { URI } from '../../../util/vs/base/common/uri';
 import { Tag } from '../../prompts/node/base/tag';
 import { IAgentMemoryService, normalizeCitations, RepoMemoryEntry } from '../common/agentMemoryService';
+import { isMemoryDisabledByKillSwitch } from '../common/memoryKillSwitch';
 import { ToolName } from '../common/toolNames';
 import { extractSessionId } from './memoryTool';
 
@@ -37,6 +38,10 @@ export class MemoryContextPrompt extends PromptElement<MemoryContextPromptProps>
 	}
 
 	async render() {
+		if (isMemoryDisabledByKillSwitch(this.experimentationService)) {
+			return null;
+		}
+
 		const enableCopilotMemory = this.configurationService.getExperimentBasedConfig(ConfigKey.CopilotMemoryEnabled, this.experimentationService);
 		const enableMemoryTool = this.configurationService.getExperimentBasedConfig(ConfigKey.MemoryToolEnabled, this.experimentationService);
 
@@ -257,6 +262,10 @@ export class MemoryInstructionsPrompt extends PromptElement<BasePromptElementPro
 	}
 
 	async render(state: void, sizing: PromptSizing) {
+		if (isMemoryDisabledByKillSwitch(this.experimentationService)) {
+			return null;
+		}
+
 		const enableCopilotMemory = this.configurationService.getExperimentBasedConfig(ConfigKey.CopilotMemoryEnabled, this.experimentationService);
 		const enableMemoryTool = this.configurationService.getExperimentBasedConfig(ConfigKey.MemoryToolEnabled, this.experimentationService);
 		if (!enableCopilotMemory && !enableMemoryTool) {

--- a/src/extension/tools/node/memoryTool.tsx
+++ b/src/extension/tools/node/memoryTool.tsx
@@ -17,6 +17,7 @@ import { URI } from '../../../util/vs/base/common/uri';
 import { LanguageModelTextPart, LanguageModelToolResult, MarkdownString } from '../../../vscodeTypes';
 import { IAgentMemoryService, RepoMemoryEntry } from '../common/agentMemoryService';
 import { IMemoryCleanupService } from '../common/memoryCleanupService';
+import { isMemoryDisabledByKillSwitch } from '../common/memoryKillSwitch';
 import { ToolName } from '../common/toolNames';
 import { ICopilotTool, ToolRegistry } from '../common/toolsRegistry';
 import { formatUriForFileWidget } from '../common/toolUtils';
@@ -251,6 +252,9 @@ export class MemoryTool implements ICopilotTool<MemoryToolParams> {
 	}
 
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<MemoryToolParams>, _token: CancellationToken): Promise<vscode.LanguageModelToolResult> {
+		if (isMemoryDisabledByKillSwitch(this.experimentationService)) {
+			return new LanguageModelToolResult([new LanguageModelTextPart('Error: Memory operations are currently disabled.')]);
+		}
 		const params = options.input;
 		const sessionResource = options.chatSessionResource?.toString();
 		const resultText = await this._dispatch(params, sessionResource, options.chatRequestId, options.model);

--- a/src/extension/tools/node/resolveMemoryFileUriTool.tsx
+++ b/src/extension/tools/node/resolveMemoryFileUriTool.tsx
@@ -5,8 +5,10 @@
 
 import type * as vscode from 'vscode';
 import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
+import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { URI } from '../../../util/vs/base/common/uri';
 import { LanguageModelTextPart, LanguageModelToolResult } from '../../../vscodeTypes';
+import { isMemoryDisabledByKillSwitch } from '../common/memoryKillSwitch';
 import { ToolName } from '../common/toolNames';
 import { ICopilotTool, ToolRegistry } from '../common/toolsRegistry';
 import { extractSessionId } from './memoryTool';
@@ -22,9 +24,14 @@ export class ResolveMemoryFileUriTool implements ICopilotTool<IResolveMemoryFile
 
 	constructor(
 		@IVSCodeExtensionContext private readonly _extensionContext: vscode.ExtensionContext,
+		@IExperimentationService private readonly _experimentationService: IExperimentationService,
 	) { }
 
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<IResolveMemoryFileUriParams>, _token: vscode.CancellationToken): Promise<vscode.LanguageModelToolResult> {
+		if (isMemoryDisabledByKillSwitch(this._experimentationService)) {
+			throw new Error('Memory operations are currently disabled.');
+		}
+
 		const memoryPath = options.input.path;
 		if (!memoryPath || !memoryPath.startsWith('/memories/')) {
 			throw new Error('Path must start with /memories/');

--- a/src/extension/tools/vscode-node/tools.ts
+++ b/src/extension/tools/vscode-node/tools.ts
@@ -13,6 +13,7 @@ import { IExperimentationService } from '../../../platform/telemetry/common/null
 import { Disposable, DisposableMap } from '../../../util/vs/base/common/lifecycle';
 import { autorun, autorunIterableDelta } from '../../../util/vs/base/common/observableInternal';
 import { URI } from '../../../util/vs/base/common/uri';
+import { isMemoryDisabledByKillSwitch } from '../common/memoryKillSwitch';
 import { getContributedToolName } from '../common/toolNames';
 import { isVscodeLanguageModelTool } from '../common/toolsRegistry';
 import { IToolsService } from '../common/toolsService';
@@ -32,6 +33,14 @@ export class ToolsContribution extends Disposable {
 		@IFileSystemService private readonly fileSystemService: IFileSystemService,
 	) {
 		super();
+
+		// Set context key for memory kill switch so `when` clauses can gate memory tools/commands
+		const memoryDisabled = isMemoryDisabledByKillSwitch(this.experimentationService);
+		vscode.commands.executeCommand('setContext', 'github.copilot.chat.memoryDisabled', memoryDisabled);
+		this._register(this.experimentationService.onDidTreatmentsChange(() => {
+			const disabled = isMemoryDisabledByKillSwitch(this.experimentationService);
+			vscode.commands.executeCommand('setContext', 'github.copilot.chat.memoryDisabled', disabled);
+		}));
 
 		for (const [name, tool] of toolsService.copilotTools) {
 			if (isVscodeLanguageModelTool(tool)) {


### PR DESCRIPTION
## Summary

Disable all memory operations (`store_memory`, `vote_memory`, and retrieval) for the VS Code Copilot Chat client, gated behind the `copilot_swe_agent_memory_disabled_vscode` [feature flag](https://devportal.githubapp.com/feature-flags/copilot_swe_agent_memory_disabled_vscode/overview).
closes: https://github.com/github/agents/issues/953
## Motivation

Per #953 — we want to prevent VS Code from creating memories without vote data while core memory features (user-scoped memories, voting, package/prompt API integration) are being built out.

## What's disabled when the FF is active

| Layer | What's gated |
|-------|-------------|
| **Tool availability** | `copilot_memory` and `copilot_resolveMemoryFileUri` tools hidden via `when` clause |
| **Prompt injection** | `MemoryContextPrompt` and `MemoryInstructionsPrompt` return `null` |
| **CAPI service** | `AgentMemoryService.checkMemoryEnabled()` returns `false` |
| **Tool safety net** | `MemoryTool.invoke()` and `ResolveMemoryFileUriTool.invoke()` return errors |
| **Menu commands** | Show Memories / Clear Memories commands hidden |

## Implementation

- New shared helper `isMemoryDisabledByKillSwitch()` in `src/extension/tools/common/memoryKillSwitch.ts` checks the FF via `IExperimentationService.getTreatmentVariable()`
- Context key `github.copilot.chat.memoryDisabled` is set on startup and updated reactively on treatment changes

## Re-enablement

Flip the `copilot_swe_agent_memory_disabled_vscode` FF to `false` once:
- User-scoped memories have landed
- Memory voting is fully integrated
- Package/prompt API integration is complete

cc @tiferet @adityasharad @VincentDondain @bhavyaus @digitarald