### PR TITLE
feat: add languageDiagnosticsService for nes/inline completion provider

### DIFF
--- a/src/lib/node/chatLibMain.ts
+++ b/src/lib/node/chatLibMain.ts
@@ -188,6 +188,11 @@ export interface INESProviderOptions {
 	readonly waitForTreatmentVariables?: boolean;
 	readonly undesiredModelsManager?: IUndesiredModelsManager;
 	readonly configOverrides?: Map<ConfigKeyType, unknown>;
+	/**
+	 * Diagnostics provider used to enrich the NES prompt with the active file's
+	 * lint/error context. When omitted, falls back to a no-op {@link TestLanguageDiagnosticsService}.
+	 */
+	readonly languageDiagnosticsService?: ILanguageDiagnosticsService;
 }
 
 export interface INESResult {
@@ -361,7 +366,7 @@ function setupServices(options: INESProviderOptions) {
 	builder.define(ILogService, new SyncDescriptor(LogServiceImpl, [[logTarget || new ConsoleLog(undefined, InternalLogLevel.Trace)]]));
 	builder.define(IGitExtensionService, new SyncDescriptor(NullGitExtensionService));
 	builder.define(ILanguageContextProviderService, new SyncDescriptor(NullLanguageContextProviderService));
-	builder.define(ILanguageDiagnosticsService, new SyncDescriptor(TestLanguageDiagnosticsService));
+	builder.define(ILanguageDiagnosticsService, options.languageDiagnosticsService || new SyncDescriptor(TestLanguageDiagnosticsService));
 	builder.define(IIgnoreService, new SyncDescriptor(NullIgnoreService));
 	builder.define(ISnippyService, new SyncDescriptor(NullSnippyService));
 	builder.define(IDomainService, new SyncDescriptor(DomainService));
@@ -719,6 +724,7 @@ export interface IInlineCompletionsProviderOptions {
 	readonly capiClientService?: ICAPIClientService;
 	readonly citationHandler?: IInlineCompletionsCitationHandler;
 	readonly configOverrides?: Map<ConfigKeyType, unknown>;
+	readonly languageDiagnosticsService?: ILanguageDiagnosticsService;
 }
 
 export type IGetInlineCompletionsOptions = Exclude<Partial<GetGhostTextOptions>, 'promptOnly'> & {
@@ -958,7 +964,7 @@ function setupCompletionServices(options: IInlineCompletionsProviderOptions): II
 		}
 	});
 	builder.define(ILanguageContextProviderService, options.languageContextProvider ?? new NullLanguageContextProviderService());
-	builder.define(ILanguageDiagnosticsService, new SyncDescriptor(TestLanguageDiagnosticsService));
+	builder.define(ILanguageDiagnosticsService, options.languageDiagnosticsService || new SyncDescriptor(TestLanguageDiagnosticsService));
 	builder.define(IRequestLogger, new SyncDescriptor(NullRequestLogger));
 
 	return builder.seal();


### PR DESCRIPTION
Adds an optional languageDiagnosticsService to INESProviderOptions and IInlineCompletionsProviderOptions, allowing external embedders of @vscode/chat-lib to provide their own diagnostics source for NES and inline completion requests.